### PR TITLE
isl ast gen support set iterator names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(cmake/external/glog.cmake)
 include(cmake/external/gtest.cmake)
 # include(cmake/external/protobuf.cmake)
 # include(cmake/external/mklml.cmake)
-#include(cmake/external/boost.cmake)
+#include(cmake/external/boost.cmakeg)
 find_package(Threads REQUIRED)
 
 include_directories(${ISL_HOME}/include)
@@ -29,6 +29,6 @@ link_directories(${ISL_HOME}/lib)
 
 set(core_src CACHE INTERNAL "" FORCE)
 add_subdirectory(cinn)
-add_subdirectory(unittest)
+#add_subdirectory(unittest)
 
 cc_library(core SRCS ${core_src} DEPS glog)

--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -7,6 +7,7 @@
 
 namespace cinn {
 namespace backends {
+using namespace utils;
 
 CodeGenC::CodeGenC(std::ostream &os, Target target) : ir::IrPrinter(os), target_(target) {}
 
@@ -227,12 +228,12 @@ void CodeGenC::PrintIncludes() {
 }
 
 void CodeGenC::PrintFileGuardOpen(const std::string &name) {
-  os() << utils::StringFormat("#ifndef _%s_H_\n", name.c_str());
-  os() << utils::StringFormat("#define _%s_H_\n", name.c_str());
+  os() << utils::StringFormat("#ifndef _%s_CINN_H_\n", Uppercase(name).c_str());
+  os() << utils::StringFormat("#define _%s_CINN_H_\n", Uppercase(name).c_str());
   os() << "\n";
 }
 void CodeGenC::PrintFileGuardClose(const std::string &module_name) {
-  os() << utils::StringFormat("#endif  // %s\n", module_name.c_str());
+  os() << utils::StringFormat("#endif  // _%s_CINN_H_\n", Uppercase(module_name).c_str());
 }
 
 void CodeGenC::PrintBufferCreation(const std::vector<ir::Buffer> &buffers) {

--- a/cinn/backends/codegen_c_test.cc
+++ b/cinn/backends/codegen_c_test.cc
@@ -48,9 +48,9 @@ TEST(CodeGenC, basic) {
 void func_C(const struct cinn_buffer_t *A, const struct cinn_buffer_t *B, struct cinn_buffer_t *C)
 {
   cinn_buffer_t::alloc(C);
-  for (int32_t c1 = 0; (c1 <= 99); c1 += 1){
-    for (int32_t c3 = 0; (c3 <= 19); c3 += 1){
-      C[((c1 * 20) + c3)] = (A[((c1 * 20) + c3)] + B[((c1 * 20) + c3)]);
+  for (int32_t i = 0; (i <= 99); i += 1){
+    for (int32_t j = 0; (j <= 19); j += 1){
+      C[((i * 20) + j)] = (A[((i * 20) + j)] + B[((i * 20) + j)]);
     };
   };
 }
@@ -79,8 +79,8 @@ TEST(CodeGenC, module) {
   std::cout << "codegen C:" << std::endl << out << std::endl;
 
   std::string target_str = R"ROC(
-#ifndef _module1_H_
-#define _module1_H_
+#ifndef _MODULE1_CINN_H_
+#define _MODULE1_CINN_H_
 
 #include <cinn_runtime.h>
 #include <stdio.h>
@@ -89,14 +89,14 @@ cinn_buffer_t* C = cinn_buffer_t::new_();
 void add1(const struct cinn_buffer_t *A, const struct cinn_buffer_t *B, struct cinn_buffer_t *C)
 {
   cinn_buffer_t::alloc(C);
-  for (int32_t c1 = 0; (c1 <= 99); c1 += 1){
-    for (int32_t c3 = 0; (c3 <= 19); c3 += 1){
-      C[((c1 * 20) + c3)] = (A[((c1 * 20) + c3)] + B[((c1 * 20) + c3)]);
+  for (int32_t i = 0; (i <= 99); i += 1){
+    for (int32_t j = 0; (j <= 19); j += 1){
+      C[((i * 20) + j)] = (A[((i * 20) + j)] + B[((i * 20) + j)]);
     };
   };
 }
 
-#endif  // module1
+#endif  // _MODULE1_CINN_H_
 )ROC";
 
   EXPECT_EQ(utils::Trim(out), utils::Trim(target_str));

--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -1,4 +1,6 @@
 #include "cinn/common/target.h"
+#include <glog/logging.h>
+#include "cinn/runtime/cinn_runtime.h"
 
 namespace cinn {
 namespace common {
@@ -8,6 +10,20 @@ bool Target::operator==(const Target &other) const {
          arch == other.arch &&  //
          bits == other.bits &&  //
          features == other.features;
+}
+
+int Target::runtime_arch() const {
+  switch (arch) {
+    case Arch::Unk:
+      return cinn_unk_device;
+    case Arch::X86:
+      return cinn_x86_device;
+    case Arch::ARM:
+      return cinn_arm_device;
+    default:
+      LOG(FATAL) << "Not supported arch";
+  }
+  return -1;
 }
 
 }  // namespace common

--- a/cinn/common/target.h
+++ b/cinn/common/target.h
@@ -14,7 +14,6 @@ struct Target {
     Linux,
     Windows,
   };
-  OS os{OS::Unk};
 
   /**
    * The architecture used by the target. Determines the instruction set to use.
@@ -24,13 +23,15 @@ struct Target {
     X86,
     ARM,
   };
-  Arch arch{Arch::Unk};
 
   enum Bit : int {
     Unk = -1,
     k32,
     k64,
   };
+
+  OS os{OS::Unk};
+  Arch arch{Arch::Unk};
   Bit bits{Unk};
 
   enum class Feature : int {
@@ -42,6 +43,9 @@ struct Target {
   Target() = default;
 
   Target(OS o, Arch a, Bit b, const std::vector<Feature>& features) : os(o), arch(a), bits(b) {}
+
+  //! Get the Runtime architecture, it is casted to integer to avoid header file depending.
+  int runtime_arch() const;
 
   bool operator==(const Target& other) const;
   bool operator!=(const Target& other) const { return !(*this == other); }

--- a/cinn/lang/compute_test.cc
+++ b/cinn/lang/compute_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "cinn/ir/ir_operators.h"
+#include "cinn/lang/buffer.h"
 #include "cinn/lang/placeholder.h"
 #include "cinn/lang/tensor.h"
 
@@ -16,20 +17,16 @@ TEST(Compute, basic) {
   Placeholder<float> x("x", {M, N});
 
   ir::Tensor y = Compute(
-      {100, 100},
-      [&](Var i, Var j) -> Expr {
-        LOG(INFO) << "type: " << x(i, j).type();
-        return x(i, j) + 1.f;
-      },
-      "y");
+      {100, 100}, [=](Var i, Var j) -> Expr { return x(i, j) + 1.f; }, "y");
   LOG(INFO) << "compute: " << y->operaion->As<ir::ComputeOp>()->body[0];
-  LOG(INFO) << "y.element: " << y->stage->domain();
 
   ir::Tensor z = Compute(
-      {100, 100}, [&](Var i, Var j) -> Expr { return y(i, j) * 2.f; }, "z");
+      {100, 100}, [=](Var i, Var j) -> Expr { return y(i, j) * 2.f; }, "z");
+
+  lang::Buffer z_buffer;
+  z->Bind(z_buffer);
 
   LOG(INFO) << "z: " << z->operaion->As<ir::ComputeOp>()->body[0];
-  LOG(INFO) << "z.element: " << z->stage->domain();
 
   auto schedule = poly::CreateSchedule(z);
   LOG(INFO) << "group: " << schedule->gened_groups().size();
@@ -42,9 +39,7 @@ TEST(Compute, basic) {
   }
 
   ASSERT_EQ(schedule->gened_groups().size(), 1UL);
-  EXPECT_EQ(schedule->gened_groups().front().nodes[0]->id(), "x");
-  EXPECT_EQ(schedule->gened_groups().front().nodes[1]->id(), "y");
-  EXPECT_EQ(schedule->gened_groups().front().nodes[2]->id(), "z");
+  EXPECT_EQ(schedule->gened_groups().front().nodes[0]->id(), "z");
   LOG(INFO) << "Finished";
 }
 

--- a/cinn/lang/lower.cc
+++ b/cinn/lang/lower.cc
@@ -30,6 +30,8 @@ Expr LowerGroup(const poly::detail::Group& group, const std::map<std::string, Ex
   poly::AstGen gen(context, stages, scheduler);
   isl::ast_node ast = gen.Build();
 
+  // set iterator names.
+
   ir::Expr e;
   poly::IslAstNodeToCinnExpr(ast, &e);
 

--- a/cinn/lang/lower_test.cc
+++ b/cinn/lang/lower_test.cc
@@ -27,17 +27,17 @@ TEST(lower, basic) {
 
   LOG(INFO) << "lower_size " << lower_funcs.size();
 
-#define TEST_SOUTPUT(x, out) \
-  LOG(INFO) << "\n" << x;    \
+#define TEST_SOUTPUT(x, out)           \
+  std::cout << "\n" << x << std::endl; \
   EXPECT_EQ(utils::GetStreamCnt(x), utils::Trim(out));
 
   auto out = R"ROC(
 {
-  poly_for (0, (c1 <= 99), 1)
+  poly_for (0, (i <= 99), 1)
   {
-    poly_for (0, (c3 <= 14), 1)
+    poly_for (0, (j <= 14), 1)
     {
-      B[((c1 * 15) + c3)] = (A[((c1 * 15) + c3)] + 1)
+      B[((i * 15) + j)] = (A[((i * 15) + j)] + 1)
     }
   }
 }
@@ -61,7 +61,7 @@ TEST(lower, more_complex) {
   auto lower_funcs = Lower("cal_C", {A, B, C});
 
   LOG(INFO) << "lower_size " << lower_funcs.size();
-  LOG(INFO) << "func:\n" << Expr(lower_funcs.front()->self());
+  std::cout << "func:\n" << Expr(lower_funcs.front()->self()) << std::endl;
 }
 
 }  // namespace lang

--- a/cinn/lang/tensor.h
+++ b/cinn/lang/tensor.h
@@ -100,6 +100,9 @@ class PlaceholderOp;
  * _Tensor_ holds the content of a Tensor.
  */
 class _Tensor_ : public ExprNode<_Tensor_> {
+  //! a pointer to Shared<Stage>, use void* to avoid cyclic definition dependency.
+  void* stage_shared{};
+
  public:
   //! Shape of this tensor.
   std::vector<Expr> shape;
@@ -109,10 +112,11 @@ class _Tensor_ : public ExprNode<_Tensor_> {
   FunctionRef operaion;
   //! Name of this tensor.
   std::string name;
-  //! Polyhedral element for analysis and schedule.
-  poly::Stage* stage{};
   //! The bound buffer, for each tensor if it is not inline.
   Buffer buffer;
+
+  //! Polyhedral element for analysis and schedule.
+  poly::Stage* stage();
 
   //! Generate a tensor from a computation.
   static Tensor Make(const std::string& name,
@@ -153,7 +157,7 @@ class _Tensor_ : public ExprNode<_Tensor_> {
 
   static const IrNodeTy _node_type_ = IrNodeTy::_Tensor_;
 
-  _Tensor_() : ExprNode<_Tensor_>(Float(32)), stage(nullptr) {}
+  _Tensor_() : ExprNode<_Tensor_>(Float(32)) {}
 
   ~_Tensor_();
 
@@ -161,6 +165,9 @@ class _Tensor_ : public ExprNode<_Tensor_> {
   //! Create the polyhedral element for analysis.
   //! It is based on the shape.
   void InitStage();
+
+  //! Free the memory for stage.
+  void DropStage();
 
   //! Initialize the axis field after the shape field is assigned.
   void InitAxis();

--- a/cinn/lang/tensor_test.cc
+++ b/cinn/lang/tensor_test.cc
@@ -28,16 +28,16 @@ TEST(Tensor, inlined) {
 
   auto funcs = lang::Lower("func_C", {A, B, D});
   ASSERT_EQ(funcs.size(), 1UL);
-  LOG(INFO) << "output: \n" << funcs.front();
+  std::cout << "output: \n" << funcs.front() << std::endl;
   auto out = GetStreamCnt(funcs.front());
   EXPECT_EQ(Trim(out), Trim(R"ROC(
 function func_C (A, B, D)
 {
-  poly_for (0, (c1 <= 99), 1)
+  poly_for (0, (i <= 99), 1)
   {
-    poly_for (0, (c3 <= 19), 1)
+    poly_for (0, (j <= 19), 1)
     {
-      D[((c1 * 20) + c3)] = (((A[((c1 * 20) + c3)] + B[((c1 * 20) + c3)]) * 2) + 1)
+      D[((i * 20) + j)] = (((A[((i * 20) + j)] + B[((i * 20) + j)]) * 2) + 1)
     }
   }
 }

--- a/cinn/poly/ast_gen.cc
+++ b/cinn/poly/ast_gen.cc
@@ -31,15 +31,17 @@ isl::ast_node AstGen::Build() {
 
   // Build it.
   auto ast_build = isl::ast_build::from_context(context_);
-  // Set iterators.
-  if (!iterator_names_.empty()) {
-    auto iterator_names = scheduler_.WrapIteratorNames(iterator_names_);
-    isl::id_list ids    = isl::manage(isl_id_list_alloc(ctx().get(), iterator_names.size()));
-    for (int i = 0; i < iterator_names.size(); i++) {
-      ids = isl::manage(isl_id_list_add(ids.release(), isl_id_alloc(ctx().get(), iterator_names[i].c_str(), nullptr)));
-    }
-    ast_build = isl::manage(isl_ast_build_set_iterators(ast_build.release(), ids.release()));
+
+  // Set iterators names for readable code.
+  CHECK(!scheduler_.detailed_dimension_names().empty());
+  auto iterator_names = iterator_names_.empty() ? scheduler_.detailed_dimension_names() : iterator_names_;
+  iterator_names      = scheduler_.WrapIteratorNames(iterator_names);
+  LOG(INFO) << "iterator_names after wrap: " << utils::Join(iterator_names, ", ");
+  isl::id_list ids = isl::manage(isl_id_list_alloc(ctx().get(), iterator_names.size()));
+  for (int i = 0; i < iterator_names.size(); i++) {
+    ids = isl::manage(isl_id_list_add(ids.release(), isl_id_alloc(ctx().get(), iterator_names[i].c_str(), nullptr)));
   }
+  ast_build = isl::manage(isl_ast_build_set_iterators(ast_build.release(), ids.release()));
 
   // collect iterator map
   auto get_domain_by_name = [this](const std::string& name) -> isl::set {

--- a/cinn/poly/isl_utils.cc
+++ b/cinn/poly/isl_utils.cc
@@ -71,5 +71,14 @@ std::string isl_map_get_statement_repr(__isl_keep isl_map *map, isl_dim_type typ
   return utils::StringFormat("%s[%s]", tuple_name, utils::Join(dims, ", ").c_str());
 }
 
+std::vector<std::string> GetDimNames(isl_map *map, isl_dim_type dim_type) {
+  std::vector<std::string> res;
+  int n = isl_map_dim(map, dim_type);
+  for (int i = 0; i < n; i++) {
+    res.push_back(isl_map_get_dim_name(map, dim_type, i));
+  }
+  return res;
+}
+
 }  // namespace poly
 }  // namespace cinn

--- a/cinn/poly/isl_utils.h
+++ b/cinn/poly/isl_utils.h
@@ -17,6 +17,8 @@ std::vector<std::string> GetDimNames(const isl::map& x, isl_dim_type dim_type);
 void SetDimNames(isl::set* set, const std::vector<std::string>& names);
 void SetDimNames(isl::map* map, isl_dim_type dim_type, const std::vector<std::string>& names);
 
+std::vector<std::string> GetDimNames(isl_map* map, isl_dim_type dim_type);
+
 //! Convert a list of isl::map to isl::union_map
 isl::union_map MapsToUnionMap(const std::vector<isl::map>& maps);
 isl::union_set SetsToUnionSet(const std::vector<isl::set>& sets);

--- a/cinn/poly/schedule.h
+++ b/cinn/poly/schedule.h
@@ -57,6 +57,9 @@ struct TimeSchedule {
   //! ISL range format, such as '[dup, t0, t1]: dup=0 and t0=0 and t1=i]'
   std::string __str__() const;
 
+  //! Get the axis names with the original dimension names and faked time dimensions.
+  std::vector<std::string> final_axis_names() const;
+
   std::vector<std::string> domain_dims;
   int duplicate_id{};
   std::vector<TimeDim> time_dims;
@@ -187,13 +190,15 @@ class PolyScheduler {
   std::map<std::string, isl::map> BuildSchedule() const;
 
   /**
-   * Wrap the iterator names with time space.
+   * Wrap the iterator names with time space fake names, it is used for isl AST to set iterator names.
    * @param names the original iterator names.
    * @return the iterator names with time space included.
    */
   std::vector<std::string> WrapIteratorNames(const std::vector<std::string> &names) const;
 
   int space_size() const { return space_size_; }
+
+  const std::vector<std::string> &detailed_dimension_names() const { return detailed_dimension_names_; }
 
  private:
   /**
@@ -209,6 +214,10 @@ class PolyScheduler {
   mutable isl::ctx ctx_{Context::Global().isl_ctx()};
 
   mutable ScheduleGraph schedule_graph_;
+
+  // Record the longest dimensions(of some stage) to be the final detailed dimension names. It might be used for ISL AST
+  // to set iterator names and generate readable code.
+  mutable std::vector<std::string> detailed_dimension_names_;
 };
 
 }  // namespace poly

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -72,7 +72,8 @@ typedef int cinn_dimension_t;
 typedef enum cinn_device_kind_t {
   cinn_unk_device    = -1,  // Undefined device.
   cinn_x86_device    = 0,   // X86 device
-  cinn_opencl_device = 1    // OpenCL device
+  cinn_opencl_device = 1,   // OpenCL device
+  cinn_arm_device    = 2    // ARM device
 } cinn_device_kind_t;
 
 //! Help to tell where the buffer locates.
@@ -241,10 +242,10 @@ extern cinn_device_interface_t cinn_x86_device_interface;
     fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, __LINE__, __func__, __VA_ARGS__); \
   } while (0)
 
-#define CINN_CHECK(cond)               \
-  if (!(cond)) {                       \
+#define CINN_CHECK(cond)                \
+  if (!(cond)) {                        \
     CINN_LOG("check %s failed", #cond); \
-    abort();                           \
+    abort();                            \
   }
 #define CINN_CHECKP(cond, ...) \
   if (!(cond)) {               \

--- a/cinn/runtime/cinn_runtime_test.cc
+++ b/cinn/runtime/cinn_runtime_test.cc
@@ -10,4 +10,9 @@ TEST(buffer, basic) {
   std::vector<cinn_dimension_t> shape({3, 10});
   buffer->resize(shape.data(), shape.size());
   buffer->device_interface->impl->malloc(NULL, buffer);
+  auto* data = reinterpret_cast<float*>(buffer->host_memory);
+  data[0]    = 0.f;
+  data[1]    = 1.f;
+  EXPECT_EQ(data[0], 0.f);
+  EXPECT_EQ(data[1], 1.f);
 }

--- a/cinn/utils/string.cc
+++ b/cinn/utils/string.cc
@@ -49,5 +49,13 @@ std::string Trim(const std::string &s, const char *empty) {
   return s.substr(start, end - start + 1);
 }
 
+std::string Uppercase(const std::string &x) {
+  auto res = x;
+  for (auto &c : res) {
+    c = toupper(c);
+  }
+  return res;
+}
+
 }  // namespace utils
 }  // namespace cinn

--- a/cinn/utils/string.h
+++ b/cinn/utils/string.h
@@ -33,5 +33,8 @@ std::string Join(const std::vector<std::string>& fields, const std::string& spli
 
 std::string Trim(const std::string& s, const char* empty = " \n\r\t");
 
+//! Convert a string to its uppercase.
+std::string Uppercase(const std::string& x);
+
 }  // namespace utils
 }  // namespace cinn

--- a/tools/codestyle/.gitignore
+++ b/tools/codestyle/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+*.html
+*.json


### PR DESCRIPTION
- support set iterator names
- fix test_compute segmentfault
  - make the member "stage" from `Stage*` type to `void*`(`Shared<Stage>*`)


```c++
14: void add1(const struct cinn_buffer_t *A, const struct cinn_buffer_t *B, struct cinn_buffer_t *C)
14: {
14:   cinn_buffer_t::alloc(C);
14:   for (int32_t i = 0; (i <= 99); i += 1){
14:     for (int32_t j = 0; (j <= 19); j += 1){
14:       C[((i * 20) + j)] = (A[((i * 20) + j)] + B[((i * 20) + j)]);
14:     };
14:   };
14: }
```