### PR TITLE
refine runtime buffer creation

### DIFF
--- a/cinn/backends/codegen_c.h
+++ b/cinn/backends/codegen_c.h
@@ -45,6 +45,8 @@ class CodeGenC : public ir::IrPrinter {
   void PrintCastExpr(const std::string& type, Expr e);
   // @}
 
+  void PrintShape(const std::vector<Expr>& shape);
+
   void PrintIncludes();
   void PrintFileGuardOpen(const std::string& module_name);
   void PrintFileGuardClose(const std::string& module_name);

--- a/cinn/backends/codegen_c_test.cc
+++ b/cinn/backends/codegen_c_test.cc
@@ -60,7 +60,7 @@ TEST(CodeGenC, module) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
+cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 20 });
 void add1(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, struct cinn_buffer_t *_C)
 {
   cinn_buffer_malloc((void*)(0), _C);
@@ -148,7 +148,7 @@ TEST(CodeGenC, module_with_transform) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
+cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 20 });
 void add1(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, struct cinn_buffer_t *_C, struct cinn_buffer_t *_D)
 {
   cinn_buffer_malloc((void*)(0), _C);
@@ -219,7 +219,7 @@ TEST(CodeGenC, matmul) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
+cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 50 });
 void matmul(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, struct cinn_buffer_t *_C)
 {
   cinn_buffer_malloc((void*)(0), _C);
@@ -300,7 +300,7 @@ TEST(CodeGenC, matmul_tile) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
+cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 500 });
 void matmul(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, struct cinn_buffer_t *_C)
 {
   cinn_buffer_malloc((void*)(0), _C);
@@ -377,8 +377,8 @@ TEST(CodeGenC, matmul_packed) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
-cinn_buffer_t* _PackedB = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
+cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 500 });
+cinn_buffer_t* _PackedB = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 15, 200, 32 });
 void matmul_with_packing(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, struct cinn_buffer_t *_PackedB, struct cinn_buffer_t *_C)
 {
   cinn_buffer_malloc((void*)(0), _PackedB);

--- a/cinn/runtime/cinn_runtime.cc
+++ b/cinn/runtime/cinn_runtime.cc
@@ -89,3 +89,28 @@ struct cinn_buffer_t* cinn_buffer_t::new_(cinn_device_kind_t device, cinn_type_t
 
   return x;
 }
+
+struct cinn_buffer_t* cinn_buffer_t::new_(cinn_device_kind_t device, cinn_type_t type, const std::vector<int>& shape) {
+  int32_t dimensions      = shape.size();
+  cinn_dimension_t* dims  = new cinn_dimension_t[dimensions];
+  struct cinn_buffer_t* x = new (struct cinn_buffer_t);
+  x->type                 = type;
+  x->device               = device;
+  // NOTE set device_interface for each buffer.
+  switch (x->device) {
+    case cinn_x86_device:
+      x->device_interface = &cinn_x86_device_interface;
+      break;
+    case cinn_unk_device:
+      fprintf(stderr, "Device type of buffer should be set, found Unk");
+      abort();
+      break;
+    default:
+      fprintf(stderr, "Not supported device type");
+      abort();
+  }
+
+  x->dims       = dims;
+  x->dimensions = dimensions;
+  return x;
+}

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -8,6 +8,10 @@
 #include <string.h>
 
 #ifdef __cplusplus
+#include <vector>
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -167,7 +171,13 @@ typedef struct cinn_buffer_t {
         memory_size(0) {}
 
   static struct cinn_buffer_t* new_(cinn_device_kind_t device, cinn_type_t type);
+  static struct cinn_buffer_t* new_(cinn_device_kind_t device, cinn_type_t type, const std::vector<int>& shape);
   static void delete_(struct cinn_buffer_t* x) { delete x; }
+
+  ~cinn_buffer_t() {
+    delete host_memory;
+    delete dims;
+  }
 
   // NOTE the buffer should be resized first.
   static void alloc(struct cinn_buffer_t*);

--- a/cinn/runtime/intrinsic.cc
+++ b/cinn/runtime/intrinsic.cc
@@ -9,7 +9,7 @@ namespace runtime {
 
 ir::Expr BufferCreate(ir::Buffer buffer) {
   std::vector<Expr> args;
-  args.push_back(ir::_Var_::Make(buffer->name, buffer->type()));
+  args.push_back(Expr(buffer));
   args.push_back(Expr(buffer->target.runtime_arch()));
   CHECK(buffer->target.defined()) << "Buffer's target should be set before compile";
   return ir::Call::Make(Void(), runtime::buffer_create, args, ir::Call::CallType::Intrinsic);


### PR DESCRIPTION
```c++
cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t());
```
to 
```c++
cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 200, 300 });
```