### PR TITLE
enhance schedule

### DIFF
--- a/cinn/backends/codegen_c_x86.h
+++ b/cinn/backends/codegen_c_x86.h
@@ -62,6 +62,7 @@ class CodeGenCX86 : public CodeGenC {
   //! The output argument, such as the destination for Load.
   void PrintVecOutputArgument(const Expr *op);
   void PrintAbsAddr(const ir::Load *op);
+  void PrintAbsAddr(const ir::Store *op);
   template <typename Op>
   void VisitBinaryOp(const Op *op, Expr a, Expr b, const std::string &op_repr);
 };

--- a/cinn/optim/vectorize_loops.h
+++ b/cinn/optim/vectorize_loops.h
@@ -17,6 +17,9 @@ namespace detail {
 //! Vecorize the \p expr by making the \p var has \p lanes lanes.
 void Vectorize(Var var, int lanes, Expr* expr);
 
+//! Fit the vector's lanes in IR with the device SIMD size.
+void FitVectorLanesWithDevice(int bits, Expr *expr);
+
 }  // namespace detail
 
 }  // namespace optim


### PR DESCRIPTION
- Refactor the PolySchedule::PartitionGroup
  - use a naive but more intuitive way
- Add data dependency link between the tensors binded to the same buffer