### PR TITLE
fix NodeAttr to support bool

### DIFF
--- a/cinn/frontend/syntax.h
+++ b/cinn/frontend/syntax.h
@@ -12,6 +12,7 @@
 #include "cinn/common/context.h"
 #include "cinn/common/object.h"
 #include "cinn/common/type.h"
+#include "cinn/hlir/framework/node.h"
 
 namespace cinn {
 namespace frontend {
@@ -76,14 +77,7 @@ struct Variable : public common::Shared<_Variable_> {
  * Data of a Instruction.
  */
 struct _Instruction_ : public common::Object {
-  using attr_t = std::variant<int,
-                              float,
-                              bool,
-                              std::string,
-                              std::vector<int>,
-                              std::vector<float>,
-                              std::vector<bool>,
-                              std::vector<std::string>>;
+  using attr_t = hlir::framework::AttrType;
 
   std::string op_type;
   std::unordered_map<std::string, attr_t> attrs;

--- a/cinn/hlir/framework/node.cc
+++ b/cinn/hlir/framework/node.cc
@@ -12,6 +12,43 @@ std::tuple<common::GraphEdge *, common::GraphEdge *> NodeData::LinkTo(Node *othe
   return this->common::GraphNode::LinkTo(other->as<common::GraphNode>());
 }
 
+namespace {
+
+struct PyBindNodeAttrVisitor {
+  std::stringstream &out;
+  PyBindNodeAttrVisitor(std::stringstream &out) : out(out) {}
+
+  void operator()(int v) { out << "int: " << v; }
+  void operator()(float v) { out << "float: " << v; }
+  void operator()(bool v) { out << "bool: " << v; }
+  void operator()(const std::string &v) { out << "string: " << v; }
+#define VISIT_ELEMENTS(T__)                                      \
+  void operator()(const std::vector<T__> &vs) {                  \
+    if (vs.empty()) return;                                      \
+    for (int i = 0; i < vs.size() - 1; i++) out << vs[i] << ","; \
+    out << vs.back();                                            \
+  }
+  VISIT_ELEMENTS(int)
+  VISIT_ELEMENTS(float)
+  VISIT_ELEMENTS(bool)
+  VISIT_ELEMENTS(std::string)
+};
+
+}  // namespace
+
+std::ostream &operator<<(std::ostream &os, const NodeAttr &node_attr) {
+  std::stringstream ss;
+  ss << "NodeAttr:\n";
+  for (auto &item : node_attr.attr_store) {
+    std::stringstream os;
+    PyBindNodeAttrVisitor visitor(os);
+    std::visit(visitor, item.second);
+    ss << "- " << os.str() << "\n";
+  }
+  os << ss.str();
+  return os;
+}
+
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/framework/node.h
+++ b/cinn/hlir/framework/node.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+
 #include "cinn/common/graph_utils.h"
 #include "cinn/hlir/framework/op.h"
 
@@ -15,7 +16,15 @@ namespace framework {
 class Node;
 class NodeData;
 
-using NodePtr = std::shared_ptr<Node>;
+using NodePtr  = std::shared_ptr<Node>;
+using AttrType = std::variant<bool,
+                              float,
+                              int,
+                              std::string,
+                              std::vector<bool>,
+                              std::vector<int>,
+                              std::vector<float>,
+                              std::vector<std::string>>;
 
 /**
  * \brief Attributes of each node in graph.
@@ -23,14 +32,7 @@ using NodePtr = std::shared_ptr<Node>;
  *  and other parameters like axis.
  */
 struct NodeAttr {
-  using attr_t = std::variant<int,
-                              float,
-                              bool,
-                              std::string,
-                              std::vector<int>,
-                              std::vector<float>,
-                              std::vector<bool>,
-                              std::vector<std::string>>;
+  using attr_t = AttrType;
 
   /**
    * \brief The operator this node uses.
@@ -47,6 +49,8 @@ struct NodeAttr {
    */
   std::unordered_map<std::string, attr_t> attr_store;
 };
+
+std::ostream &operator<<(std::ostream &os, const NodeAttr &node_attr);
 
 /**
  * \brief Node represents an operation in a computation graph.
@@ -97,14 +101,7 @@ class Node : public common::GraphNode {
  * \brief NodeData represents the output data from an operator.
  */
 class NodeData : public common::GraphNode {
-  using attr_t = std::variant<int,
-                              float,
-                              bool,
-                              std::string,
-                              std::vector<int>,
-                              std::vector<float>,
-                              std::vector<bool>,
-                              std::vector<std::string>>;
+  using attr_t = AttrType;
 
  public:
   NodeData(NodePtr node, uint32_t index, uint32_t version, std::string id)

--- a/cinn/pybind/framework.cc
+++ b/cinn/pybind/framework.cc
@@ -2,6 +2,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+
 #include "cinn/common/cinn_value.h"
 #include "cinn/hlir/framework/node.h"
 #include "cinn/hlir/framework/op.h"
@@ -44,11 +45,13 @@ void BindFramework(pybind11::module *m) {
              }
              return res;
            });
+
   py::class_<NodeAttr>(*m, "NodeAttr")
       .def(py::init<>())
       .def_readwrite("attr_store", &NodeAttr::attr_store)
       .def("set_attr",
-           [](NodeAttr &self, const std::string &key, NodeAttr::attr_t value) { self.attr_store[key] = value; });
+           [](NodeAttr &self, const std::string &key, NodeAttr::attr_t value) { self.attr_store[key] = value; })
+      .def("__str__", [](NodeAttr &self) { return utils::GetStreamCnt(self); });
 
 }  // namespace frontend
 }  // namespace cinn::pybind

--- a/cinn/pybind/ir.cc
+++ b/cinn/pybind/ir.cc
@@ -475,7 +475,6 @@ void BindIrTensor(py::module *m) {
   tensor.def(py::init<>())
       .def(py::init<ir::IrNode *>())
       .def("ndims", &ir::Tensor::ndims)
-      // TODO(fuchang01): c++ not implemented .def("slice", &ir::Tensor::Slice)
       .def("expand_inlined", &ir::Tensor::ExpandInlined);
 
   DefineExprNode<ir::_Tensor_>(m, "_Tensor_");
@@ -485,9 +484,6 @@ void BindIrTensor(py::module *m) {
       .def_readwrite("operation", &ir::_Tensor_::operation)
       .def_readwrite("name", &ir::_Tensor_::name)
       .def_readwrite("buffer", &ir::_Tensor_::buffer)
-      // TODO(fuchang01): c++ not implemented .def_readwrite("read_cache_relation", &ir::_Tensor_::read_cache_relation)
-      // TODO(fuchang01): c++ not implemented .def_readwrite("write_cache_relation",
-      // &ir::_Tensor_::write_cache_relation)
       .def("domain_with_reduce_axis", &ir::_Tensor_::domain_without_reduce_axis)
       .def("domain_without_reduce_axis", &ir::_Tensor_::domain_without_reduce_axis)
       .def_static("make", &ir::_Tensor_::Make)
@@ -528,7 +524,8 @@ void BindIrTensor(py::module *m) {
            py::arg("memory_type"),
            py::arg("type") = Type::type_t::Void)
       .def("bind", py::overload_cast<lang::Buffer &>(&ir::_Tensor_::Bind))
-      .def("bind", py::overload_cast<const ir::Buffer &>(&ir::_Tensor_::Bind));
+      .def("bind", py::overload_cast<const ir::Buffer &>(&ir::_Tensor_::Bind))
+      .def("__str__", [](const ir::Tensor &self) { return "<Tensor " + self->name + ">"; });
 
   py::class_<ir::Operation /*, ir::FunctionDef*/> operation(*m, "Operation");
   operation.def(py::init<>()).def(py::init<ir::IrNode *>()).def_readwrite("name", &ir::Operation::name);


### PR DESCRIPTION
- the BUG: pybind passes bool as integer in `std::variant` value passing.

This PR fix this by moving bool before int in `std::varient` type.