### PR TITLE
fix resnet bug

### DIFF
--- a/cinn/backends/llvm/codegen_llvm.cc
+++ b/cinn/backends/llvm/codegen_llvm.cc
@@ -876,15 +876,10 @@ llvm::Value *CodeGenLLVM::Visit(const ir::_LoweredFunc_ *op) {
       /*Parent=*/function,
       /*InsertBefore=*/nullptr);
 
-  llvm::Value *old_args = GetVar("_args");  // store _args
   SetVar("_args", args[0]);
   b_->SetInsertPoint(entry);
   Visit(&function_body);
-  if (old_args) {
-    SetVar("_args", old_args);  // restore _args
-  } else {
-    symbol_table_->Erase("_args");
-  }
+  symbol_table_->Erase("_args");
   RetVoid();
   return function;
 }

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -113,9 +113,7 @@ ir::Tensor BatchNorm_NCHW(const ir::Tensor &input,
   auto res = Compute(
       input->shape,
       [=](Expr n, Expr c, Expr h, Expr w) {
-        //! TODO(haozech) Add Sqrt will cause bug
-        //! return (input(n, c, h, w) - mean(c))* scale(c) / Sqrt(variance(c) + Expr(epsilon)) + bias(c);
-        return (input(n, c, h, w) - mean(c)) * scale(c) / (variance(c) + Expr(epsilon)) + bias(c);
+        return (input(n, c, h, w) - mean(c)) * scale(c) / Sqrt(variance(c) + Expr(epsilon)) + bias(c);
       },
       output_name);
   return res;

--- a/python/tests/test_matmul.py
+++ b/python/tests/test_matmul.py
@@ -12,6 +12,7 @@ from cinn.poly import create_stages
 
 class TestMamul(unittest.TestCase):
     def setUp(self):
+        np.random.seed(0)
         self.target = Target()
         self.target.arch = Target.Arch.X86
         self.target.bits = Target.Bit.k32

--- a/python/tests/test_op_nn.py
+++ b/python/tests/test_op_nn.py
@@ -437,10 +437,7 @@ class OpTest_batchnorm(SingleOpTester):
         [X, Scale, Bias, Mean, Variance] = inputs_data
         c = X.shape[1]
         for i in range(0, c):
-            """ TODO(haozech) This should be the correct compute function(with sqrt)
             X[:, i, :, :] = (X[:, i, :, :] - Mean[i]) / math.sqrt(
-                Variance[i] + 0.00001) * Scale[i] + Bias[i] """
-            X[:, i, :, :] = (X[:, i, :, :] - Mean[i]) / (
                 Variance[i] + 0.00001) * Scale[i] + Bias[i]
         return X
 


### PR DESCRIPTION
Sqrt in batchnorm PE results in jit compile error in CodegenLLVM, this PR is a fix.