### PR TITLE
refine executor.get_tensor

### DIFF
--- a/cinn/frontend/executor.h
+++ b/cinn/frontend/executor.h
@@ -52,7 +52,8 @@ class Executor final {
   std::unique_ptr<hlir::framework::GraphCompiler> graph_compiler_;
 
   std::unordered_map<std::string, Variable> var_map_;
-  std::unordered_map<std::string, std::string> var_map_paddle_to_program_;
+  std::unordered_map<std::string, std::string> var_map_paddle_to_cinn_;
+  std::unordered_map<std::string, std::string> var_map_cinn_to_paddle_;
 
   std::unique_ptr<hlir::framework::Program> runtime_program_;
 };

--- a/cinn/frontend/executor_test.cc
+++ b/cinn/frontend/executor_test.cc
@@ -12,6 +12,7 @@ TEST(Executor, basic) {
   Executor executor({"A"}, {{1, 30}});
   executor.LoadPaddleModel(FLAGS_model_dir);
   executor.Run();
+  executor.GetTensor("fc_0.tmp_2");
 }
 
 }  // namespace cinn::frontend

--- a/cinn/hlir/framework/scope.cc
+++ b/cinn/hlir/framework/scope.cc
@@ -7,7 +7,6 @@ namespace hlir {
 namespace framework {
 
 Variable* Scope::FindVar(const std::string& name) const {
-  CheckVarNameValid(name);
   auto it = data_.find(name);
   if (it != data_.end()) return it->second.get();
   return nullptr;

--- a/python/tests/test_frontend.py
+++ b/python/tests/test_frontend.py
@@ -81,7 +81,6 @@ class TestFrontend(unittest.TestCase):
         # print program
         for i in range(prog.size()):
             print(prog[i])
-        # prog.build_program(self.target, [a, b, e], h)
         tensor_data = [
             np.random.random([1, 24, 56, 56]).astype("float32"),
             np.random.random([1, 24, 56, 56]).astype("float32"),


### PR DESCRIPTION
Executor::GetTensor can retrieve a tensor using the corresponding var name in Paddle model or the name in CINN framework.