### PR TITLE
Add CUDA backends support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ function prepare_llvm {
     clang++ -mavx2 -masm=intel -S -emit-llvm cinn/runtime/cinn_runtime.cc -I$PWD
     cd -
 
-    export runtime_include_dir=$workspace/cinn/runtime
+    export runtime_include_dir=$workspace/cinn/runtime/cuda
 }
 
 function cmake_ {
@@ -39,7 +39,7 @@ function cmake_ {
     mkdir -p $build_dir
     cp $workspace/cmake/config.cmake $build_dir
     echo "set(ISL_HOME /usr/local)" >> $build_dir/config.cmake
-    echo "set(WITH_CUDA OFF)" >> $build_dir/config.cmake
+    echo "set(WITH_CUDA ON)" >> $build_dir/config.cmake
     echo "set(WITH_MKL_CBLAS ON)" >> $build_dir/config.cmake
     cd $build_dir
     cmake ..
@@ -47,12 +47,18 @@ function cmake_ {
 
 function prepare_model {
     cd $build_dir/thirds
-    wget http://paddle-inference-dist.bj.bcebos.com/CINN/ResNet18.tar
-    tar -xvf ResNet18.tar
-    wget http://paddle-inference-dist.bj.bcebos.com/CINN/MobileNetV2.tar
-    tar -xvf MobileNetV2.tar
-    wget http://paddle-inference-dist.bj.bcebos.com/CINN/EfficientNet.tar
-    tar -xvf EfficientNet.tar
+    if [[ ! -f "ResNet18.tar" ]]; then
+        wget http://paddle-inference-dist.bj.bcebos.com/CINN/ResNet18.tar
+        tar -xvf ResNet18.tar
+    fi
+    if [[ ! -f "MobileNetV2.tar" ]]; then
+        wget http://paddle-inference-dist.bj.bcebos.com/CINN/MobileNetV2.tar
+        tar -xvf MobileNetV2.tar
+    fi
+    if [[ ! -f "EfficientNet.tar" ]]; then
+        wget http://paddle-inference-dist.bj.bcebos.com/CINN/EfficientNet.tar
+        tar -xvf EfficientNet.tar
+    fi
     python $workspace/python/tests/fake_model/naive_mul.py
     python $workspace/python/tests/fake_model/naive_multi_fc.py
     python $workspace/python/tests/fake_model/resnet_model.py

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,8 @@ function cmake_ {
     mkdir -p $build_dir
     cp $workspace/cmake/config.cmake $build_dir
     echo "set(ISL_HOME /usr/local)" >> $build_dir/config.cmake
-    echo "set(WITH_CUDA ON)" >> $build_dir/config.cmake
+    # To enable Cuda backend, set(WITH_CUDA ON)
+    echo "set(WITH_CUDA OFF)" >> $build_dir/config.cmake
     echo "set(WITH_MKL_CBLAS ON)" >> $build_dir/config.cmake
     cd $build_dir
     cmake ..

--- a/cinn/backends/codegen_cuda_dev.h
+++ b/cinn/backends/codegen_cuda_dev.h
@@ -59,6 +59,7 @@ class CodeGenCUDA_Dev : public CodeGenC {
  protected:
   void Visit(const ir::_LoweredFunc_* op) override;
   void Visit(const ir::Min* op) override;
+  void Visit(const ir::Max* op) override;
   void Visit(const ir::Alloc* op) override;
   void Visit(const ir::Call* op) override;
 

--- a/cinn/backends/generated1.cu
+++ b/cinn/backends/generated1.cu
@@ -1,1 +1,1 @@
-#include "cinn/backends/_generated1.cu"
+// #include "cinn/backends/_generated1.cu"

--- a/cinn/backends/generated1.cu
+++ b/cinn/backends/generated1.cu
@@ -1,1 +1,1 @@
-// #include "cinn/backends/_generated1.cu"
+#include "cinn/backends/_generated1.cu"

--- a/cinn/hlir/framework/CMakeLists.txt
+++ b/cinn/hlir/framework/CMakeLists.txt
@@ -15,6 +15,7 @@ set(srcs
 if(WITH_CUDA)
   nv_test(test_hlir_framework_buffer SRCS buffer_test.cc DEPS core)
   nv_test(test_hlir_framework_infershape_pass SRCS infershape_pass_test.cc DEPS core)
+  nv_test(test_cuda_graph_compiler SRCS cuda_graph_compiler_test.cc DEPS core)
 else()
   cc_test(test_hlir_framework_buffer SRCS buffer_test.cc DEPS core)
   cc_test(test_hlir_framework_infershape_pass SRCS infershape_pass_test.cc DEPS core)

--- a/cinn/hlir/framework/cuda_graph_compiler_test.cc
+++ b/cinn/hlir/framework/cuda_graph_compiler_test.cc
@@ -1,13 +1,12 @@
 #include <gtest/gtest.h>
 #include <stdlib.h>
-#include "cinn/backends/codegen_cuda_dev.h"
 
 #include <any>
 #include <string>
-
 #include <tuple>
 #include <vector>
 
+#include "cinn/backends/codegen_cuda_dev.h"
 #include "cinn/backends/codegen_cuda_host.h"
 #include "cinn/backends/codegen_cuda_util.h"
 #include "cinn/backends/cuda_util.h"
@@ -19,11 +18,6 @@
 #include "cinn/common/cuda_test_helper.h"
 #include "cinn/common/ir_util.h"
 #include "cinn/common/test_helper.h"
-#include "cinn/ir/ir_printer.h"
-#include "cinn/runtime/cpu/use_extern_funcs.h"
-#include "cinn/runtime/cuda/cuda_module.h"
-#include "cinn/runtime/cuda/cuda_util.h"
-#include "cinn/runtime/use_extern_funcs.h"
 #include "cinn/hlir/framework/graph.h"
 #include "cinn/hlir/framework/graph_compiler.h"
 #include "cinn/hlir/framework/node.h"
@@ -33,7 +27,12 @@
 #include "cinn/hlir/op/use_ops.h"
 #include "cinn/hlir/pass/use_pass.h"
 #include "cinn/hlir/pe/broadcast.h"
+#include "cinn/ir/ir_printer.h"
 #include "cinn/lang/packed_func.h"
+#include "cinn/runtime/cpu/use_extern_funcs.h"
+#include "cinn/runtime/cuda/cuda_module.h"
+#include "cinn/runtime/cuda/cuda_util.h"
+#include "cinn/runtime/use_extern_funcs.h"
 
 namespace cinn {
 namespace hlir {
@@ -51,8 +50,10 @@ void CudaSetRandData(const Tensor& tensor, const Target& target) {
   for (float& v : host_memory) {
     v = (rand() * 1.f) / RAND_MAX;  // All random data
   }
-  CUDA_CALL(
-      cudaMemcpy(reinterpret_cast<void*>(data), host_memory.data(), tensor->shape().numel() * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CALL(cudaMemcpy(reinterpret_cast<void*>(data),
+                       host_memory.data(),
+                       tensor->shape().numel() * sizeof(float),
+                       cudaMemcpyHostToDevice));
 }
 
 std::vector<float> CudaGetData(const Tensor& tensor, const Target& target) {
@@ -84,8 +85,8 @@ TEST(GraphCompiler, RunModel) {
   auto e   = prog.add(c, d);
   std::unordered_map<std::string, attr_t> attr_store;
   attr_store["scale"] = 1.0f;
-  attr_store["bias"] = 0.0f;
-  auto o   = prog.scale(e, attr_store);
+  attr_store["bias"]  = 0.0f;
+  auto o              = prog.scale(e, attr_store);
   ASSERT_EQ(prog.size(), 4UL);
   auto g = std::make_shared<Graph>(prog);
   ApplyPass(g.get(), "InferShape");
@@ -100,16 +101,18 @@ TEST(GraphCompiler, RunModel) {
   auto B = GetTensor(scope, "B");
   CudaSetRandData(A, target);
   CudaSetRandData(B, target);
-  
+
   program->Execute();
   auto host_data1 = CudaGetData(A, target);
   auto host_data2 = CudaGetData(B, target);
-  auto Out = GetTensor(scope, o->id);
+  auto Out        = GetTensor(scope, o->id);
   auto host_data3 = CudaGetData(Out, target);
 
   for (int i = 0; i < Out->shape().numel(); i++) {
-      LOG_FIRST_N(INFO, 10) << "data[" << i << "]: " << "2 * "<< host_data1[i] << " + " << "3 * " << host_data2[i] << " = " << host_data3[i];
-      EXPECT_NEAR(host_data3[i], 2 * host_data1[i] + 3 * host_data2[i], 1e-5);
+    LOG_FIRST_N(INFO, 10) << "data[" << i << "]: "
+                          << "2 * " << host_data1[i] << " + "
+                          << "3 * " << host_data2[i] << " = " << host_data3[i];
+    EXPECT_NEAR(host_data3[i], 2 * host_data1[i] + 3 * host_data2[i], 1e-5);
   }
 }
 }  // namespace framework

--- a/cinn/hlir/framework/cuda_graph_compiler_test.cc
+++ b/cinn/hlir/framework/cuda_graph_compiler_test.cc
@@ -122,9 +122,8 @@ TEST(GraphCompiler, RunModel) {
 
   auto target_mul = test_mul(host_data1, host_data2, M.as_int32(), K.as_int32(), N.as_int32());
   for (int i = 0; i < Out->shape().numel(); i++) {
-    /*      LOG_FIRST_N(INFO, 10) << "data[" << i << "]: "
-                              << "2 * " << host_data1[i] << " + "
-                              << "3 * " << host_data2[i] << " = " << host_data3[i]; */
+    LOG_FIRST_N(INFO, 10) << "cinn_data[" << i << "]: " << 2 * (host_data1[i] + target_mul[i]) + 0.5
+                          << " v.s. target_data[" << i << "]: " << host_data3[i];
     EXPECT_NEAR(host_data3[i], 2 * (host_data1[i] + target_mul[i]) + 0.5, 1e-5);
   }
 }

--- a/cinn/hlir/framework/cuda_graph_compiler_test.cc
+++ b/cinn/hlir/framework/cuda_graph_compiler_test.cc
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include "cinn/backends/codegen_cuda_dev.h"
+
+#include <any>
+#include <string>
+
+#include <tuple>
+#include <vector>
+
+#include "cinn/backends/codegen_cuda_host.h"
+#include "cinn/backends/codegen_cuda_util.h"
+#include "cinn/backends/cuda_util.h"
+#include "cinn/backends/extern_func_jit_register.h"
+#include "cinn/backends/llvm/execution_engine.h"
+#include "cinn/backends/llvm/simple_jit.h"
+#include "cinn/backends/nvrtc_util.h"
+#include "cinn/cinn.h"
+#include "cinn/common/cuda_test_helper.h"
+#include "cinn/common/ir_util.h"
+#include "cinn/common/test_helper.h"
+#include "cinn/ir/ir_printer.h"
+#include "cinn/runtime/cpu/use_extern_funcs.h"
+#include "cinn/runtime/cuda/cuda_module.h"
+#include "cinn/runtime/cuda/cuda_util.h"
+#include "cinn/runtime/use_extern_funcs.h"
+#include "cinn/hlir/framework/graph.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+#include "cinn/hlir/framework/node.h"
+#include "cinn/hlir/framework/op.h"
+#include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/framework/scope.h"
+#include "cinn/hlir/op/use_ops.h"
+#include "cinn/hlir/pass/use_pass.h"
+#include "cinn/hlir/pe/broadcast.h"
+#include "cinn/lang/packed_func.h"
+
+namespace cinn {
+namespace hlir {
+namespace framework {
+
+Tensor GetTensor(const std::shared_ptr<Scope>& scope, const std::string& name) {
+  auto* var    = scope->Var<Tensor>(name);
+  auto& tensor = std::get<Tensor>(*var);
+  return tensor;
+}
+
+void CudaSetRandData(const Tensor& tensor, const Target& target) {
+  auto* data = tensor->mutable_data<float>(target);
+  std::vector<float> host_memory(tensor->shape().numel(), 0);
+  for (float& v : host_memory) {
+    v = (rand() * 1.f) / RAND_MAX;  // All random data
+  }
+  CUDA_CALL(
+      cudaMemcpy(reinterpret_cast<void*>(data), host_memory.data(), tensor->shape().numel() * sizeof(float), cudaMemcpyHostToDevice));
+}
+
+std::vector<float> CudaGetData(const Tensor& tensor, const Target& target) {
+  auto* A_data = tensor->mutable_data<float>(target);
+  std::vector<float> host_data(tensor->shape().numel(), 0);
+
+  CUDA_CALL(cudaMemcpy(host_data.data(),
+                       reinterpret_cast<void*>(A_data),
+                       tensor->shape().numel() * sizeof(float),
+                       cudaMemcpyDeviceToHost));
+  return host_data;
+}
+
+TEST(GraphCompiler, RunModel) {
+  using attr_t = hlir::framework::AttrType;
+  frontend::Program prog;
+  // TODO(Superjomn) Replace with Placeholder here.
+  Expr M(100);
+  Expr N(32);
+  frontend::Variable a("A");
+  frontend::Variable b("B");
+  Type t   = Float(32);
+  a->shape = {M.as_int32(), N.as_int32()};
+  b->shape = {M.as_int32(), N.as_int32()};
+  a->type  = t;
+  b->type  = t;
+  auto c   = prog.add(a, b);
+  auto d   = prog.add(c, b);
+  auto e   = prog.add(c, d);
+  std::unordered_map<std::string, attr_t> attr_store;
+  attr_store["scale"] = 1.0f;
+  attr_store["bias"] = 0.0f;
+  auto o   = prog.scale(e, attr_store);
+  ASSERT_EQ(prog.size(), 4UL);
+  auto g = std::make_shared<Graph>(prog);
+  ApplyPass(g.get(), "InferShape");
+
+  Target target(Target::OS::Linux, Target::Arch::NVGPU, Target::Bit::k64, {});
+  auto scope = BuildScope(target, g);
+
+  GraphCompiler gc(target, scope, g);
+  std::unique_ptr<Program> program = gc.Build();
+
+  auto A = GetTensor(scope, "A");
+  auto B = GetTensor(scope, "B");
+  CudaSetRandData(A, target);
+  CudaSetRandData(B, target);
+  
+  program->Execute();
+  auto host_data1 = CudaGetData(A, target);
+  auto host_data2 = CudaGetData(B, target);
+  auto Out = GetTensor(scope, o->id);
+  auto host_data3 = CudaGetData(Out, target);
+
+  for (int i = 0; i < Out->shape().numel(); i++) {
+      LOG_FIRST_N(INFO, 10) << "data[" << i << "]: " << "2 * "<< host_data1[i] << " + " << "3 * " << host_data2[i] << " = " << host_data3[i];
+      EXPECT_NEAR(host_data3[i], 2 * host_data1[i] + 3 * host_data2[i], 1e-5);
+  }
+}
+}  // namespace framework
+
+}  // namespace hlir
+}  // namespace cinn

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -37,15 +37,19 @@ std::unique_ptr<Program> GraphCompiler::Build() {
   if (this->target_.arch == Target::Arch::X86) {
     CodeGenCX86 codegen(this->target_, CodeGenCX86::Feature::AVX512);
     codegen.SetInlineBuiltinCodes(false);
-    auto out = codegen.Compile(m_builder_.Build(), CodeGenC::OutputKind::CImpl);
+    auto build_module = m_builder_.Build();
+    auto out = codegen.Compile(build_module, CodeGenC::OutputKind::CImpl);
     LOG(INFO) << "[Debug] C Code is:\n" << out;
+    compiler_->Build(build_module);
   } else if (this->target_.arch == Target::Arch::NVGPU) {
     backends::CodeGenCUDA_Dev codegen(this->target_);
-    auto out = codegen.Compile(m_builder_.Build());
+    codegen.SetInlineBuiltinCodes(false);
+    auto build_module = m_builder_.Build();
+    auto out = codegen.Compile(build_module);
     LOG(INFO) << "[Debug] CUDA Code is:\n" << out;
+    compiler_->Build(build_module);
   }
-  compiler_->Build(m_builder_.Build());
-
+  
   return std::unique_ptr<Program>(new Program(scope_, BuildInstructions()));
 }
 

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -38,18 +38,20 @@ std::unique_ptr<Program> GraphCompiler::Build() {
     CodeGenCX86 codegen(this->target_, CodeGenCX86::Feature::AVX512);
     codegen.SetInlineBuiltinCodes(false);
     auto build_module = m_builder_.Build();
-    auto out = codegen.Compile(build_module, CodeGenC::OutputKind::CImpl);
+    auto out          = codegen.Compile(build_module, CodeGenC::OutputKind::CImpl);
     LOG(INFO) << "[Debug] C Code is:\n" << out;
     compiler_->Build(build_module);
   } else if (this->target_.arch == Target::Arch::NVGPU) {
     backends::CodeGenCUDA_Dev codegen(this->target_);
     codegen.SetInlineBuiltinCodes(false);
     auto build_module = m_builder_.Build();
-    auto out = codegen.Compile(build_module);
+    auto out          = codegen.Compile(build_module);
     LOG(INFO) << "[Debug] CUDA Code is:\n" << out;
     compiler_->Build(build_module);
+  } else {
+    CINN_NOT_IMPLEMENTED
   }
-  
+
   return std::unique_ptr<Program>(new Program(scope_, BuildInstructions()));
 }
 

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -115,7 +115,7 @@ ir::LoweredFunc GraphCompiler::GetOpFunc(const Node* node) {
     inputs.push_back(temp.as_tensor_ref());
   }
 
-  auto func = Lower(GenOpFuncName(node), stages, inputs);
+  auto func = Lower(GenOpFuncName(node), stages, inputs, {}, {}, nullptr, this->target_);
   VLOG(2) << "The function of node [" << node->attrs.node_name << "] is:\n" << func;
   return func;
 }

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -39,7 +39,7 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     CINNValuePack arg_pack = args[0];
     CHECK_EQ(arg_pack.size(), 2UL);
     if (target.arch == Target::Arch::NVGPU) {
-      Expr Out = arg_pack[0];
+      Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
       stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
@@ -188,6 +188,7 @@ std::shared_ptr<OpStrategy> StrategyForConv2d(const framework::NodeAttr &attrs,
     Expr weights_dilation = arg_pack[1];
     CHECK(weights_dilation.as_tensor());
     stages[weights_dilation.as_tensor_ref()]->ComputeInline();
+
     if (target.arch == Target::Arch::NVGPU) {
       Expr Out = arg_pack[2];
       CHECK(Out.as_tensor());
@@ -336,10 +337,9 @@ std::shared_ptr<OpStrategy> StrategyForDepthwiseConv2d(const framework::NodeAttr
         stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
       }
       *ret = CINNValuePack{{arg_pack[1], CINNValue(stages)}};
-    }
-    else {
+    } else {
       if (target.arch == Target::Arch::NVGPU) {
-        Expr Out = arg_pack[0];
+        Expr Out              = arg_pack[0];
         poly::StageMap stages = arg_pack[1];
         CHECK(Out.as_tensor());
         stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -34,12 +34,18 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     *ret        = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}};
   });
 
-  framework::CINNSchedule relu_schedule([](lang::Args args, lang::RetValue *ret) {
+  framework::CINNSchedule relu_schedule([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input argument of relu schedule is empty! Please check.\n";
     CINNValuePack arg_pack = args[0];
     CHECK_EQ(arg_pack.size(), 2UL);
-    Expr A [[maybe_unused]] = arg_pack[0];
-    *ret                    = arg_pack;
+    if (target.arch == Target::Arch::NVGPU) {
+      Expr Out = arg_pack[0];
+      poly::StageMap stages = arg_pack[1];
+      CHECK(Out.as_tensor());
+      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
+      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+    }
+    *ret = arg_pack;
   });
 
   auto strategy = std::make_shared<framework::OpStrategy>();
@@ -171,7 +177,7 @@ std::shared_ptr<OpStrategy> StrategyForConv2d(const framework::NodeAttr &attrs,
     *ret = CINNValuePack{res};
   });
 
-  framework::CINNSchedule conv2d_schedule([](lang::Args args, lang::RetValue *ret) {
+  framework::CINNSchedule conv2d_schedule([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input argument of conv2d schedule is empty! Please check.\n";
     CINNValuePack arg_pack = args[0];
     CHECK_EQ(arg_pack.size(), 4UL);
@@ -182,6 +188,12 @@ std::shared_ptr<OpStrategy> StrategyForConv2d(const framework::NodeAttr &attrs,
     Expr weights_dilation = arg_pack[1];
     CHECK(weights_dilation.as_tensor());
     stages[weights_dilation.as_tensor_ref()]->ComputeInline();
+    if (target.arch == Target::Arch::NVGPU) {
+      Expr Out = arg_pack[2];
+      CHECK(Out.as_tensor());
+      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
+      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+    }
     *ret = CINNValuePack{{arg_pack[2], CINNValue(stages)}};
   });
 
@@ -306,7 +318,7 @@ std::shared_ptr<OpStrategy> StrategyForDepthwiseConv2d(const framework::NodeAttr
     *ret = CINNValuePack{res};
   });
 
-  framework::CINNSchedule depthwise_conv2d_schedule([](lang::Args args, lang::RetValue *ret) {
+  framework::CINNSchedule depthwise_conv2d_schedule([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input argument of depthwise_conv schedule is empty! Please check.\n";
     CINNValuePack arg_pack = args[0];
     CHECK(arg_pack.size() == 2UL || arg_pack.size() == 3UL);
@@ -315,8 +327,24 @@ std::shared_ptr<OpStrategy> StrategyForDepthwiseConv2d(const framework::NodeAttr
       Expr input_pad        = arg_pack[0];
       CHECK(input_pad.as_tensor());
       stages[input_pad.as_tensor_ref()]->ComputeInline();
+      if (target.arch == Target::Arch::NVGPU) {
+        Expr Out = arg_pack[1];
+        CHECK(Out.as_tensor());
+        stages[input_pad.as_tensor_ref()]->Bind(0, "blockIdx.x");
+        stages[input_pad.as_tensor_ref()]->Bind(1, "threadIdx.x");
+        stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
+        stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      }
       *ret = CINNValuePack{{arg_pack[1], CINNValue(stages)}};
-    } else {
+    }
+    else {
+      if (target.arch == Target::Arch::NVGPU) {
+        Expr Out = arg_pack[0];
+        poly::StageMap stages = arg_pack[1];
+        CHECK(Out.as_tensor());
+        stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
+        stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      }
       *ret = arg_pack;
     }
   });

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -174,18 +174,8 @@ std::shared_ptr<OpStrategy> StrategyForMul(const framework::NodeAttr &attrs,
     Var axis_k(check_dim, UniqName("axis_k"));
     auto new_A = A_tensor->Reshape(new_xshape, stages);
     auto new_B = B_tensor->Reshape(new_yshape, stages);
-    auto out   = Compute(
-        output_shape,
-        [=](const std::vector<Expr> &indice) {
-          std::vector<Expr> A_indice;
-          std::vector<Expr> B_indice;
-          B_indice.push_back(axis_k);
-          A_indice.insert(A_indice.begin(), indice.begin(), indice.begin() + x_num_col_dims);
-          B_indice.insert(B_indice.begin() + 1, indice.begin() + x_num_col_dims, indice.end());
-          A_indice.push_back(axis_k);
-          return lang::ReduceSum(new_A(A_indice) * new_B(B_indice), {axis_k});
-        },
-        UniqName("Mul_out"));
+
+    auto out = pe::Mul(new_A, new_B, x_num_col_dims, output_shape, axis_k, UniqName("Mul_output"));
     VLOG(3) << "mul out: " << out;
     stages->InsertLazily(out);
     CHECK(!out_type.empty()) << "Output type of Mul is empty! Please check.\n";

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -150,32 +150,41 @@ std::shared_ptr<OpStrategy> StrategyForMul(const framework::NodeAttr &attrs,
     }
     auto A_tensor = A.as_tensor_ref();
     auto B_tensor = B.as_tensor_ref();
-    std::vector<Expr> new_xshape{Expr(1), Expr(1)};
-    std::vector<Expr> new_yshape{Expr(1), Expr(1)};
-    auto stages = CreateStages({A_tensor, B_tensor});
+    auto stages   = CreateStages({A_tensor, B_tensor});
+    std::vector<Expr> output_shape;
+    std::vector<Expr> new_xshape;
+    std::vector<Expr> new_yshape;
+    Expr check_dim(1);
     for (int i = 0; i < A_tensor->shape.size(); i++) {
       if (i < x_num_col_dims) {
-        new_xshape[0] = new_xshape[0] * A_tensor->shape[i];
+        output_shape.push_back(A_tensor->shape[i]);
+        new_xshape.push_back(A_tensor->shape[i]);
       } else {
-        new_xshape[1] = new_xshape[1] * A_tensor->shape[i];
+        check_dim = check_dim * A_tensor->shape[i];
       }
     }
-
+    new_xshape.push_back(check_dim);
+    new_yshape.push_back(check_dim);
     for (int i = 0; i < B_tensor->shape.size(); i++) {
-      if (i < y_num_col_dims) {
-        new_yshape[0] = new_yshape[0] * B_tensor->shape[i];
-      } else {
-        new_yshape[1] = new_yshape[1] * B_tensor->shape[i];
+      if (i >= y_num_col_dims) {
+        output_shape.push_back(B_tensor->shape[i]);
+        new_yshape.push_back(B_tensor->shape[i]);
       }
     }
-
+    Var axis_k(check_dim, UniqName("axis_k"));
     auto new_A = A_tensor->Reshape(new_xshape, stages);
     auto new_B = B_tensor->Reshape(new_yshape, stages);
-    std::vector<Expr> output_shape{new_xshape[0], new_yshape[1]};
-    Var axis_k(new_xshape[1], UniqName("axis_k"));
-    auto out = Compute(
+    auto out   = Compute(
         output_shape,
-        [=](Expr m, Expr n) { return lang::ReduceSum(new_A(m, axis_k) * new_B(axis_k, n), {axis_k}); },
+        [=](const std::vector<Expr> &indice) {
+          std::vector<Expr> A_indice;
+          std::vector<Expr> B_indice;
+          B_indice.push_back(axis_k);
+          A_indice.insert(A_indice.begin(), indice.begin(), indice.begin() + x_num_col_dims);
+          B_indice.insert(B_indice.begin() + 1, indice.begin() + x_num_col_dims, indice.end());
+          A_indice.push_back(axis_k);
+          return lang::ReduceSum(new_A(A_indice) * new_B(B_indice), {axis_k});
+        },
         UniqName("Mul_out"));
     VLOG(3) << "mul out: " << out;
     stages->InsertLazily(out);
@@ -209,9 +218,7 @@ std::vector<std::vector<int>> InferShapeForMul(const std::vector<std::vector<int
   CHECK_GE(inputs_shape[0].size(), 2U) << "Input matrix X's dim should be >= 2! Please check.";
   CHECK_GE(inputs_shape[1].size(), 2U) << "Input matrix Y's dim should be >= 2! Please check.";
 
-  std::vector<int> output_shape(2);
-  std::vector<int> shape1_new{1, 1};
-  std::vector<int> shape2_new{1, 1};
+  std::vector<int> output_shape;
   int x_num_col_dims = 1;
   int y_num_col_dims = 1;
   for (auto &iter : attrs.attr_store) {
@@ -219,27 +226,43 @@ std::vector<std::vector<int>> InferShapeForMul(const std::vector<std::vector<int
       x_num_col_dims = std::get<int>(iter.second);
     } else if (iter.first == "y_num_col_dims") {
       y_num_col_dims = std::get<int>(iter.second);
+    } else {
+      LOG(ERROR) << "Unsupported attr: " << iter.first << std::endl;
     }
   }
+  int check_dim_x = 1;
+  int check_dim_y = 1;
   for (int i = 0; i < inputs_shape[0].size(); i++) {
     if (i < x_num_col_dims) {
-      shape1_new[0] = shape1_new[0] * inputs_shape[0][i];
+      output_shape.push_back(inputs_shape[0][i]);
     } else {
-      shape1_new[1] = shape1_new[1] * inputs_shape[0][i];
+      check_dim_x = check_dim_x * inputs_shape[0][i];
     }
   }
 
   for (int i = 0; i < inputs_shape[1].size(); i++) {
     if (i < y_num_col_dims) {
-      shape2_new[0] = shape2_new[0] * inputs_shape[1][i];
+      check_dim_y = check_dim_y * inputs_shape[1][i];
     } else {
-      shape2_new[1] = shape2_new[1] * inputs_shape[1][i];
+      output_shape.push_back(inputs_shape[1][i]);
     }
   }
-  CHECK_EQ(shape1_new[1], shape2_new[0])
-      << "For matrix multiply: X * Y, second dim of X's shape should be equal to first dim of Y's shape! Please Check!";
-  output_shape[0] = shape1_new[0];
-  output_shape[1] = shape2_new[1];
+  CHECK_EQ(check_dim_x, check_dim_y) << "For matrix multiply: X * Y, second dim of X's shape :[" << check_dim_x
+                                     << "] should be equal to first dim of Y's shape :[" << check_dim_y
+                                     << "]! Please Check!";
+
+  LOG(INFO) << "infer shape of mul's output is:\n";
+  for (auto v : output_shape) {
+    LOG(INFO) << v << ", ";
+  }
+  LOG(INFO) << "first input shape of mul is:\n";
+  for (auto v : inputs_shape[0]) {
+    LOG(INFO) << v << ", ";
+  }
+  LOG(INFO) << "second input shape of mul is:\n";
+  for (auto v : inputs_shape[1]) {
+    LOG(INFO) << v << ", ";
+  }
   std::vector<std::vector<int>> res{output_shape};
   return res;
 }

--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -121,6 +121,26 @@ Tensor Matmul(const Tensor& A,
   return Compute(output_shape, fn, name);
 }
 
+Tensor Mul(const Tensor& A,
+           const Tensor& B,
+           int x_num_col_dims,
+           const std::vector<Expr>& output_shape,
+           const Var& axis_k,
+           const std::string& name) {
+  return Compute(
+      output_shape,
+      [=](const std::vector<Expr>& indice) {
+        std::vector<Expr> A_indice;
+        std::vector<Expr> B_indice;
+        B_indice.push_back(axis_k);
+        A_indice.insert(A_indice.begin(), indice.begin(), indice.begin() + x_num_col_dims);
+        B_indice.insert(B_indice.begin() + 1, indice.begin() + x_num_col_dims, indice.end());
+        A_indice.push_back(axis_k);
+        return lang::ReduceSum(A(A_indice) * B(B_indice), {axis_k});
+      },
+      name);
+}
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/transform.h
+++ b/cinn/hlir/pe/transform.h
@@ -39,6 +39,13 @@ ir::Tensor Matmul(const ir::Tensor& A,
                   int y_num_col_dims      = 1,
                   const std::string& name = UniqName("T_Transform_Matmul_out"));
 
+ir::Tensor Mul(const ir::Tensor& A,
+               const ir::Tensor& B,
+               int x_num_col_dims,
+               const std::vector<ir::Expr>& output_shape,
+               const ir::Var& axis_k,
+               const std::string& name);
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/ir/lowered_func.cc
+++ b/cinn/ir/lowered_func.cc
@@ -73,6 +73,10 @@ void _LoweredFunc_::PrepareAllocOutputBufferExprs() {
 
 std::vector<Expr> _LoweredFunc_::PrepareAllocTempBufferExprs() const {
   std::vector<Expr> alloc_output_buffer_exprs;
+  if (temp_bufs.empty())
+    LOG(INFO) << "The temp_bufs of " << this->name << " is empty!!";
+  else
+    LOG(INFO) << "The " << this->name << " 's temp_bufs's size is " << temp_bufs.size();
   for (auto& temp_buf : temp_bufs) {
     if (!temp_buf->shape.empty() && temp_buf->type() != Void()) {
       alloc_output_buffer_exprs.push_back(Alloc::Make(temp_buf, temp_buf->type(), temp_buf->shape, Expr(), Expr()));
@@ -123,6 +127,47 @@ void _LoweredFunc_::PrepareBufferCastExprs() {
 
     buffer_data_cast_exprs.push_back(let);
   }
+}
+
+std::vector<Expr> _LoweredFunc_::CudaPrepareBufferCastExprs() const {
+  // collect write.
+  std::vector<Expr> res;
+  optim::TensorWriteTeller write_teller;
+  write_teller.Collect(&body);
+
+  // ir::BufferGetTensorName(arg.buffer_arg().As<ir::_Buffer_>());
+
+  auto tensors = CollectAllTensorReference();
+  std::sort(tensors.begin(), tensors.end(), [](const Tensor& a, const Tensor& b) { return a->name < b->name; });
+  VLOG(3) << "Function used " << tensors.size() << " buffers";
+  LOG(INFO) << "[Cuda] The function's args are:\n";
+  for (auto& a : args) {
+    if (a.is_buffer()) {
+      LOG(INFO) << a.name() << " is buffer\n";
+    } else if (a.is_var()) {
+      LOG(INFO) << a.name() << " is var\n";
+    }
+  }
+  for (auto& tensor : tensors) {
+    LOG(INFO) << "[Cuda]The tensor's name is: " << tensor->name;
+    LOG(INFO) << "[Cuda]The tensor's buffer name is: " << tensor->buffer->name;
+    auto* node = tensor.As<ir::_Tensor_>();
+    CHECK(node);
+    if (!tensor->buffer.defined()) continue;
+    if (tensor->name == tensor->buffer->name.substr(1)) continue;
+    Type value_type = tensor->type().ElementOf();
+    bool is_const   = !write_teller.IsWrite(tensor->name);
+    value_type.set_cpp_handle();
+    value_type.set_cpp_const(is_const);
+    Var variable = _Var_::Make(tensor->name, value_type);
+    Var body     = Var(tensor->buffer->name.substr(1), value_type);
+    // Expr body = runtime::BufferGetDataHandle(tensor->buffer, is_const);
+
+    auto let = Let::Make(variable, body);
+
+    res.push_back(let);
+  }
+  return res;
 }
 
 void _LoweredFunc_::PrepareArgumentExprs() {

--- a/cinn/ir/lowered_func.cc
+++ b/cinn/ir/lowered_func.cc
@@ -73,10 +73,11 @@ void _LoweredFunc_::PrepareAllocOutputBufferExprs() {
 
 std::vector<Expr> _LoweredFunc_::PrepareAllocTempBufferExprs() const {
   std::vector<Expr> alloc_output_buffer_exprs;
-  if (temp_bufs.empty())
+  if (temp_bufs.empty()) {
     LOG(INFO) << "The temp_bufs of " << this->name << " is empty!!";
-  else
+  } else {
     LOG(INFO) << "The " << this->name << " 's temp_bufs's size is " << temp_bufs.size();
+  }
   for (auto& temp_buf : temp_bufs) {
     if (!temp_buf->shape.empty() && temp_buf->type() != Void()) {
       alloc_output_buffer_exprs.push_back(Alloc::Make(temp_buf, temp_buf->type(), temp_buf->shape, Expr(), Expr()));
@@ -141,8 +142,12 @@ std::vector<Expr> _LoweredFunc_::CudaAliasVarExprs() const {
   for (auto& tensor : tensors) {
     auto* node = tensor.As<ir::_Tensor_>();
     CHECK(node);
-    if (!tensor->buffer.defined()) continue;
-    if (tensor->name == tensor->buffer->name.substr(1)) continue;
+    if (!tensor->buffer.defined()) {
+      continue;
+    }
+    if (tensor->name == tensor->buffer->name.substr(1)) {
+      continue;
+    }
     Type value_type = tensor->type().ElementOf();
     bool is_const   = !write_teller.IsWrite(tensor->name);
     value_type.set_cpp_handle();

--- a/cinn/ir/lowered_func.h
+++ b/cinn/ir/lowered_func.h
@@ -156,7 +156,7 @@ struct _LoweredFunc_ : ExprNode<_LoweredFunc_> {
 
   //! Prepare the expressions for `alloc_tmp_buffer_exprs`.
   std::vector<Expr> PrepareAllocTempBufferExprs() const;
-  std::vector<Expr> CudaPrepareBufferCastExprs() const;
+  std::vector<Expr> CudaAliasVarExprs() const;
 
  private:
   void CheckValid() const;

--- a/cinn/ir/lowered_func.h
+++ b/cinn/ir/lowered_func.h
@@ -156,6 +156,7 @@ struct _LoweredFunc_ : ExprNode<_LoweredFunc_> {
 
   //! Prepare the expressions for `alloc_tmp_buffer_exprs`.
   std::vector<Expr> PrepareAllocTempBufferExprs() const;
+  std::vector<Expr> CudaPrepareBufferCastExprs() const;
 
  private:
   void CheckValid() const;
@@ -166,6 +167,7 @@ struct _LoweredFunc_ : ExprNode<_LoweredFunc_> {
   //! Insert the allocation expr for temporary variables.
   void AllocTempBuffer();
   void PrepareBufferCastExprs();
+
   void PrepareArgumentExprs();
   //! Get all the Buffers the function body references.
   //! NOTE it will return the buffers with duplicates removed(by comparing their name).

--- a/cinn/ir/tensor.h
+++ b/cinn/ir/tensor.h
@@ -26,7 +26,9 @@ namespace lang {
 template <typename T>
 struct Placeholder;
 
-void InitReduceTensor(poly::StageMap stages, const ir::Tensor& tensor);
+void InitReduceTensor(poly::StageMap stages,
+                      const ir::Tensor& tensor,
+                      const Target& target = common::DefaultHostTarget());
 }  // namespace lang
 
 namespace ir {
@@ -259,7 +261,7 @@ class _Tensor_ : public ExprNode<_Tensor_> {
    * @param init_val The initial value.
    * @return The initializing tensor.
    */
-  ir::Tensor InitReduction(poly::StageMap stages) const;
+  ir::Tensor InitReduction(poly::StageMap stages, const Target& target = common::DefaultHostTarget()) const;
 
   //! The names of the tensors depend the same buffer and should schedule before this.
   std::set<std::string> buffer_depended_tensor_names_;
@@ -269,7 +271,7 @@ class _Tensor_ : public ExprNode<_Tensor_> {
 
   friend Shared<poly::Stage> CreateStage(Tensor tensor);
 
-  friend void lang::InitReduceTensor(poly::StageMap stages, const ir::Tensor& tensor);
+  friend void lang::InitReduceTensor(poly::StageMap stages, const ir::Tensor& tensor, const Target& target);
 };
 
 Shared<poly::Stage> CreateStage(Tensor tensor);

--- a/cinn/lang/lower.h
+++ b/cinn/lang/lower.h
@@ -32,7 +32,8 @@ ir::LoweredFunc Lower(const std::string &name,
                       const std::vector<Tensor> &tensor_args,
                       const std::vector<Var> &scalar_args     = {},
                       const std::vector<Tensor> &temp_tensors = {},
-                      Module::Builder *b                      = nullptr);
+                      Module::Builder *b                      = nullptr,
+                      const Target &target                    = common::DefaultHostTarget());
 
 }  // namespace lang
 }  // namespace cinn

--- a/cinn/poly/stage.cc
+++ b/cinn/poly/stage.cc
@@ -550,6 +550,7 @@ void Stage::ShareBufferWith(Stage *other) {
 
   meta.tensors_to_share_buffer_with.insert(other->id());
   other->meta.tensors_to_share_buffer_with.insert(tensor_->name);
+  LOG(INFO) << "In ShareBufferWith: 2 tensors are: " << other->id() << "  " << tensor_->name;
 }
 
 isl_map *__isl_give GatherAccesses(Stage *stage, const std::string &tensor_name) {

--- a/cinn/pybind/framework.cc
+++ b/cinn/pybind/framework.cc
@@ -97,13 +97,13 @@ void BindFramework(pybind11::module *m) {
              std::memcpy(array_data, self->data<float>(), self->shape().numel() * sizeof(float));
              return array;
            })
-      .def("from_numpy", [](hlir::framework::Tensor &self, py::array array) {
+      .def("from_numpy", [](hlir::framework::Tensor &self, py::array array, const common::Target &target) {
         CHECK(array.dtype().is(py::dtype::of<float>())) << "currently only support float32 data type as input";
         hlir::framework::shape_t shape;
         std::copy_n(array.shape(), array.ndim(), std::back_inserter(shape));
         self->Resize(Shape(shape));
         // TODO(Superjomn) Support other target.
-        auto *data = self->mutable_data<float>(common::DefaultHostTarget());
+        auto *data = self->mutable_data<float>(target);
         for (int i = 0; i < self->shape().numel(); i++) {
           data[i] = reinterpret_cast<const float *>(array.data())[i];
         }

--- a/cinn/pybind/framework.cc
+++ b/cinn/pybind/framework.cc
@@ -79,10 +79,14 @@ void BindFramework(pybind11::module *m) {
              if (target.arch == Target::Arch::X86) {
                std::memcpy(mutable_data, t->data<float>(), t->shape().numel() * sizeof(float));
              } else if (target.arch == Target::Arch::NVGPU) {
+#ifdef CINN_WITH_CUDA
                CUDA_CALL(cudaMemcpy(mutable_data,
                                     reinterpret_cast<void *>(t->mutable_data<float>(target)),
                                     t->shape().numel() * sizeof(float),
                                     cudaMemcpyDeviceToHost));
+#else
+               LOG(FATAL) <<"To use CUDA backends, you need to set WITH_CUDA ON!";
+#endif
              } else {
                CINN_NOT_IMPLEMENTED
              }
@@ -106,10 +110,14 @@ void BindFramework(pybind11::module *m) {
              if (target.arch == Target::Arch::X86) {
                std::memcpy(array_data, self->data<float>(), self->shape().numel() * sizeof(float));
              } else if (target.arch == Target::Arch::NVGPU) {
+#ifdef CINN_WITH_CUDA
                CUDA_CALL(cudaMemcpy(array_data,
                                     reinterpret_cast<void *>(self->mutable_data<float>(target)),
                                     self->shape().numel() * sizeof(float),
                                     cudaMemcpyDeviceToHost));
+#else
+               LOG(FATAL) <<"To use CUDA backends, you need to set WITH_CUDA ON!";
+#endif
              } else {
                CINN_NOT_IMPLEMENTED
              }
@@ -126,10 +134,14 @@ void BindFramework(pybind11::module *m) {
             data[i] = reinterpret_cast<const float *>(array.data())[i];
           }
         } else if (target.arch == Target::Arch::NVGPU) {
+#ifdef CINN_WITH_CUDA
           CUDA_CALL(cudaMemcpy(reinterpret_cast<void *>(data),
                                reinterpret_cast<const float *>(array.data()),
                                self->shape().numel() * sizeof(float),
                                cudaMemcpyHostToDevice));
+#else
+               LOG(FATAL) <<"To use CUDA backends, you need to set WITH_CUDA ON!";
+#endif
         } else {
           CINN_NOT_IMPLEMENTED
         }

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -93,10 +93,14 @@ void BindFrontend(pybind11::module *m) {
                    << "The size of tensor [" << tensor_inputs[i]->id
                    << "] is different with the input data's size! Please check.";
                if (target.arch == Target::Arch::NVGPU) {
+#ifdef CINN_WITH_CUDA
                  CUDA_CALL(cudaMemcpy(reinterpret_cast<void *>(data),
                                       input_data[i].data(),
                                       in_tensor->shape().numel() * sizeof(float),
                                       cudaMemcpyHostToDevice));
+#else
+                 LOG(FATAL) <<"To use CUDA backends, you need to set WITH_CUDA ON!";
+#endif
                } else if (target.arch == Target::Arch::X86) {
                  for (size_t j = 0; j < in_tensor->shape().numel(); j++) {
                    data[j] = reinterpret_cast<const float *>(input_data[i].data())[j];  // All random data

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -92,8 +92,17 @@ void BindFrontend(pybind11::module *m) {
                CHECK_EQ(input_data[i].size(), in_tensor->shape().numel())
                    << "The size of tensor [" << tensor_inputs[i]->id
                    << "] is different with the input data's size! Please check.";
-               for (size_t j = 0; j < in_tensor->shape().numel(); j++) {
-                 data[j] = reinterpret_cast<const float *>(input_data[i].data())[j];  // All random data
+               if (target.arch == Target::Arch::NVGPU) {
+                 CUDA_CALL(cudaMemcpy(reinterpret_cast<void *>(data),
+                                      input_data[i].data(),
+                                      in_tensor->shape().numel() * sizeof(float),
+                                      cudaMemcpyHostToDevice));
+               } else if (target.arch == Target::Arch::X86) {
+                 for (size_t j = 0; j < in_tensor->shape().numel(); j++) {
+                   data[j] = reinterpret_cast<const float *>(input_data[i].data())[j];  // All random data
+                 }
+               } else {
+                 CINN_NOT_IMPLEMENTED
                }
              }
              program->Execute();

--- a/cinn/pybind/lang.cc
+++ b/cinn/pybind/lang.cc
@@ -48,7 +48,8 @@ void BindLower(py::module *m) {
          arg("tensor_args"),
          arg("scalar_args")  = std::vector<ir::Var>(),
          arg("temp_tensors") = std::vector<ir::Tensor>(),
-         arg("b")            = nullptr);
+         arg("b")            = nullptr,
+         arg("target")       = common::DefaultHostTarget());
 }
 
 void BindCompute(py::module *m) {

--- a/python/tests/test_efficientnet.py
+++ b/python/tests/test_efficientnet.py
@@ -47,10 +47,10 @@ class TestLoadEfficientNetModel(unittest.TestCase):
         # True means load combined model
         self.executor.load_paddle_model(self.model_dir, self.target, True)
         a_t = self.executor.get_tensor(self.input_tensor)
-        a_t.from_numpy(x_data)
+        a_t.from_numpy(x_data, self.target)
 
         out = self.executor.get_tensor(self.target_tensor)
-        out.from_numpy(np.zeros(out.shape(), dtype='float32'))
+        out.from_numpy(np.zeros(out.shape(), dtype='float32'), self.target)
 
         self.executor.run()
 

--- a/python/tests/test_efficientnet.py
+++ b/python/tests/test_efficientnet.py
@@ -54,7 +54,7 @@ class TestLoadEfficientNetModel(unittest.TestCase):
 
         self.executor.run()
 
-        out = out.numpy()
+        out = out.numpy(self.target)
         target_result = self.get_paddle_inference_result(
             self.model_dir, x_data)
 

--- a/python/tests/test_frontend.py
+++ b/python/tests/test_frontend.py
@@ -88,7 +88,7 @@ class TestFrontend(unittest.TestCase):
         ]
         result = prog.build_and_get_output(self.target, [a, b, e], tensor_data,
                                            h)
-        result = result.numpy().reshape(-1)
+        result = result.numpy(self.target).reshape(-1)
         tensor_data.append(result)
         self.paddle_verify(tensor_data)
 
@@ -131,7 +131,7 @@ class TestLoadPaddleModel_FC(unittest.TestCase):
         out = self.executor.get_tensor("fc_0.tmp_2")
         target = self.get_paddle_inference_result(self.model_dir, x_data)
 
-        self.assertTrue(np.allclose(out.numpy(), target, atol=1e-4))
+        self.assertTrue(np.allclose(out.numpy(self.target), target, atol=1e-4))
 
 
 class TestLoadPaddleModel_MultiFC(unittest.TestCase):
@@ -168,7 +168,7 @@ class TestLoadPaddleModel_MultiFC(unittest.TestCase):
         out = self.executor.get_tensor("fc_5.tmp_2")
         target = self.get_paddle_inference_result(self.model_dir, x_data)
 
-        self.assertTrue(np.allclose(out.numpy(), target, atol=1e-4))
+        self.assertTrue(np.allclose(out.numpy(self.target), target, atol=1e-4))
 
 
 if __name__ == "__main__":

--- a/python/tests/test_frontend.py
+++ b/python/tests/test_frontend.py
@@ -124,7 +124,7 @@ class TestLoadPaddleModel_FC(unittest.TestCase):
         self.executor = Interpreter(["A"], [self.x_shape])
         self.executor.load_paddle_model(self.model_dir, self.target, False)
         a_t = self.executor.get_tensor("A")
-        a_t.from_numpy(x_data)
+        a_t.from_numpy(x_data, self.target)
 
         self.executor.run()
 
@@ -161,7 +161,7 @@ class TestLoadPaddleModel_MultiFC(unittest.TestCase):
         self.executor = Interpreter(["A"], [self.x_shape])
         self.executor.load_paddle_model(self.model_dir, self.target, False)
         a_t = self.executor.get_tensor("A")
-        a_t.from_numpy(x_data)
+        a_t.from_numpy(x_data, self.target)
 
         self.executor.run()
 

--- a/python/tests/test_hlir_framework.py
+++ b/python/tests/test_hlir_framework.py
@@ -5,9 +5,13 @@ import numpy as np
 
 class TensorTest(unittest.TestCase):
     def test_basic(self):
+        target = Target()
+        target.arch = Target.Arch.X86
+        target.bits = Target.Bit.k64
+        target.os = Target.OS.Linux
         tensor = Tensor()
         data = np.random.random([10, 5])
-        tensor.from_numpy(data)
+        tensor.from_numpy(data, target)
 
         self.assertTrue(np.allclose(tensor.numpy(), data))
 

--- a/python/tests/test_mobilenetv2.py
+++ b/python/tests/test_mobilenetv2.py
@@ -55,7 +55,7 @@ class TestLoadResnetModel(unittest.TestCase):
 
         self.executor.run()
 
-        out = out.numpy()
+        out = out.numpy(self.target)
         target_result = self.get_paddle_inference_result(
             self.model_dir, x_data)
 

--- a/python/tests/test_mobilenetv2.py
+++ b/python/tests/test_mobilenetv2.py
@@ -48,10 +48,10 @@ class TestLoadResnetModel(unittest.TestCase):
         # True means load combined model
         self.executor.load_paddle_model(self.model_dir, self.target, True)
         a_t = self.executor.get_tensor(self.input_tensor)
-        a_t.from_numpy(x_data)
+        a_t.from_numpy(x_data, self.target)
 
         out = self.executor.get_tensor(self.target_tensor)
-        out.from_numpy(np.zeros(out.shape(), dtype='float32'))
+        out.from_numpy(np.zeros(out.shape(), dtype='float32'), self.target)
 
         self.executor.run()
 

--- a/python/tests/test_resnet.py
+++ b/python/tests/test_resnet.py
@@ -56,7 +56,7 @@ class TestLoadResnetModel(unittest.TestCase):
 
         self.executor.run()
 
-        out = out.numpy()
+        out = out.numpy(self.target)
         target_result = self.get_paddle_inference_result(x_data)
 
         print("result in test_model: \n")

--- a/python/tests/test_resnet.py
+++ b/python/tests/test_resnet.py
@@ -49,10 +49,10 @@ class TestLoadResnetModel(unittest.TestCase):
         self.executor = Interpreter(["resnet_input"], [self.x_shape])
         self.executor.load_paddle_model(self.model_dir, self.target, False)
         a_t = self.executor.get_tensor("resnet_input")
-        a_t.from_numpy(x_data)
+        a_t.from_numpy(x_data, self.target)
 
         out = self.executor.get_tensor("relu_0.tmp_0")
-        out.from_numpy(np.zeros(out.shape(), dtype='float32'))
+        out.from_numpy(np.zeros(out.shape(), dtype='float32'), self.target)
 
         self.executor.run()
 
@@ -68,7 +68,6 @@ class TestLoadResnetModel(unittest.TestCase):
                 print("Error! ", i, "-th data has diff with target data:\n",
                       out[i], " vs: ", target_result[i], ". Diff is: ",
                       out[i] - target_result[i])
-        # TODO(haozech) fix this.
         self.assertTrue(np.allclose(out, target_result, atol=1e-3))
 
 

--- a/python/tests/test_resnet18.py
+++ b/python/tests/test_resnet18.py
@@ -55,7 +55,7 @@ class TestLoadResnetModel(unittest.TestCase):
 
         self.executor.run()
 
-        out = out.numpy()
+        out = out.numpy(self.target)
         target_result = self.get_paddle_inference_result(
             self.model_dir, x_data)
 

--- a/python/tests/test_resnet18.py
+++ b/python/tests/test_resnet18.py
@@ -48,10 +48,10 @@ class TestLoadResnetModel(unittest.TestCase):
         # True means load combined model
         self.executor.load_paddle_model(self.model_dir, self.target, True)
         a_t = self.executor.get_tensor(self.input_tensor)
-        a_t.from_numpy(x_data)
+        a_t.from_numpy(x_data, self.target)
 
         out = self.executor.get_tensor(self.target_tensor)
-        out.from_numpy(np.zeros(out.shape(), dtype='float32'))
+        out.from_numpy(np.zeros(out.shape(), dtype='float32'), self.target)
 
         self.executor.run()
 


### PR DESCRIPTION
添加cuda端支持以及相关单测
主要修改为：在build.sh中`echo "set(WITH_CUDA ON)"` 时，框架会启用对cuda端的支持；
通过Target的设置控制后端的选择，`target_.arch == Target::Arch::NVGPU`时会在cuda后端上运行。
对于已有的测试，只需开启WITH_CUDA并将相关测试中的target.arch改为Target::Arch::NVGPU即可在cuda上运行。
目前仅支持C++端，python端还有bug未解决。
测试可以参考新增的cuda_graph_compiler_test.cc