### PR TITLE
fix gcc82 ambiguous operator overload syntax and update paddle2.0 enable_static()

### DIFF
--- a/cinn/pybind/bind_utils.h
+++ b/cinn/pybind/bind_utils.h
@@ -72,7 +72,7 @@ inline ValueVar ConvertToVar(const CINNValue &value) {
   } else if (type_code == CINNValue::TypeCode<ir::Var>()) {
     var = ir::Var(value);
   } else if (type_code == CINNValue::TypeCode<ir::Expr>()) {
-    var = ir::Expr(value);
+    var = ir::Expr(value.operator ir::Expr());
   } else {
     var = nullptr;
   }

--- a/cinn/pybind/common.cc
+++ b/cinn/pybind/common.cc
@@ -221,7 +221,7 @@ void BindCinnValue(py::module *m) {
       .def("to_cinn_buffer_p", [](CINNValue &self) { return static_cast<cinn_buffer_t *>(self); })
       .def("to_str", [](CINNValue &self) { return static_cast<char *>(self); })
       .def("to_var", [](CINNValue &self) { return ir::Var(self); })
-      .def("to_expr", [](CINNValue &self) { return ir::Expr(self); })
+      .def("to_expr", [](CINNValue &self) { return ir::Expr(self.operator ir::Expr()); })
       .def("set", &CINNValue::Set<int32_t>)
       .def("set", &CINNValue::Set<int64_t>)
       .def("set", &CINNValue::Set<float>)

--- a/python/tests/fake_model/naive_mul.py
+++ b/python/tests/fake_model/naive_mul.py
@@ -1,10 +1,12 @@
 import numpy
 import sys, os
 import numpy as np
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 
 size = 30
+paddle.enable_static()
 
 a = fluid.layers.data(name="A", shape=[-1, size], dtype='float32')
 label = fluid.layers.data(name="label", shape=[size], dtype='float32')

--- a/python/tests/fake_model/naive_multi_fc.py
+++ b/python/tests/fake_model/naive_multi_fc.py
@@ -4,11 +4,13 @@ A fake model with multiple FC layers to test CINN on a more complex model.
 import numpy
 import sys, os
 import numpy as np
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 
 size = 64
 num_layers = 6
+paddle.enable_static()
 
 a = fluid.layers.data(name="A", shape=[-1, size], dtype='float32')
 label = fluid.layers.data(name="label", shape=[size], dtype='float32')

--- a/python/tests/fake_model/resnet_model.py
+++ b/python/tests/fake_model/resnet_model.py
@@ -1,8 +1,11 @@
 import numpy
 import sys, os
 import numpy as np
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
+
+paddle.enable_static()
 
 resnet_input = fluid.layers.data(
     name="resnet_input",


### PR DESCRIPTION
In order to adopt GCC82 and paddle 2.0 in new docker image, made several changes:

1. return ir::Expr(self.operator ir::Expr()); 
2. enable_static();

```
/cinn_paddle_v2/CINN/cinn/pybind/bind_utils.h: In function ‘cinn::pybind::ValueVar cinn::pybind::ConvertToVar(const cinn::common::CINNValue&)’:
/cinn_paddle_v2/CINN/cinn/pybind/bind_utils.h:75:25: error: call of overloaded ‘Expr(const cinn::common::CINNValue&)’ is ambiguous
     var = ir::Expr(value);
                         ^
In file included from /cinn_paddle_v2/CINN/cinn/ir/function_base.h:3,
                 from /cinn_paddle_v2/CINN/cinn/ir/ir.h:15,
                 from /cinn_paddle_v2/CINN/cinn/hlir/pe/elementwise.h:3,
                 from /cinn_paddle_v2/CINN/cinn/pybind/pe.cc:2:
/cinn_paddle_v2/CINN/cinn/ir/node.h:269:12: note: candidate: ‘cinn::ir::Expr::Expr(double)’
   explicit Expr(double x) : IrNodeRef(new FloatImm(Float(64), x)) {}
            ^~~~
```