### PR TITLE
Update pybind11.cmake

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -26,7 +26,7 @@ ExternalProject_Add(
         extern_pybind
         ${EXTERNAL_PROJECT_LOG_ARGS}
         GIT_REPOSITORY  "https://github.com/pybind/pybind11.git"
-        GIT_TAG         "v2.4.0"
+        GIT_TAG         "v2.4.3"
         PREFIX          ${PYBIND_SOURCE_DIR}
         UPDATE_COMMAND  ""
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
We should choose the last sub-version within a big version.
2.4.0 had some bugs when we update PaddlePaddle,
so updating both CINN and PaddlePaddle to 2.4.3