### PR TITLE
add op C++ benchmark test framework(matmul, elementwise_add op benchmark test）

### DIFF
--- a/cinn/backends/codegen_cuda_dev.cc
+++ b/cinn/backends/codegen_cuda_dev.cc
@@ -1,10 +1,10 @@
 #include "cinn/backends/codegen_cuda_dev.h"
-#include "cinn/ir/ir_verify.h"
 
 #include <fstream>
 #include <set>
 #include <unordered_set>
 
+#include "cinn/ir/ir_verify.h"
 #include "cinn/optim/remove_nested_block.h"
 
 namespace cinn {

--- a/cinn/backends/llvm/codegen_llvm.cc
+++ b/cinn/backends/llvm/codegen_llvm.cc
@@ -1,5 +1,4 @@
 #include "cinn/backends/llvm/codegen_llvm.h"
-#include "cinn/ir/ir_verify.h"
 
 #include <glog/logging.h>
 #include <glog/stl_logging.h>
@@ -22,6 +21,7 @@
 #include "cinn/common/type.h"
 #include "cinn/ir/ir_operators.h"
 #include "cinn/ir/ir_printer.h"
+#include "cinn/ir/ir_verify.h"
 #include "cinn/runtime/cinn_runtime.h"
 #include "cinn/runtime/intrinsic.h"
 #include "cinn/utils/string.h"

--- a/cinn/backends/llvm/llvm_optimizer.cc
+++ b/cinn/backends/llvm/llvm_optimizer.cc
@@ -142,7 +142,6 @@ void LLVMModuleOptimizer::operator()(llvm::Module *m) {
   std::for_each(m->begin(), m->end(), [&fpm](auto &fn) { fpm->run(fn); });
   fpm->doFinalization();
 
-  // TODO(Superjomn) Enable this. This is quite slow when turned on.
   mpm->run(*m);
 }
 

--- a/cinn/backends/llvm/simple_jit.cc
+++ b/cinn/backends/llvm/simple_jit.cc
@@ -14,6 +14,7 @@
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/Scalar/Reassociate.h>
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
+
 #include <string>
 #include <utility>
 

--- a/cinn/common/test_helper.h
+++ b/cinn/common/test_helper.h
@@ -50,9 +50,9 @@ struct BufferBuilder {
 
  private:
   template <typename T>
-  void RandomFloat(void* arr, int len) {
+  void RandomFloat(void* arr, uint64_t len) {
     auto* data = static_cast<T*>(arr);
-    for (int i = 0; i < len; i++) {
+    for (uint64_t i = 0; i < len; i++) {
       data[i] = static_cast<T>(rand()) / RAND_MAX;  // NOLINT
     }
   }

--- a/cinn/common/type.h
+++ b/cinn/common/type.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <glog/logging.h>
 
+#include <memory>
 #include <string>
 
-#include <memory>
 #include "cinn/common/macros.h"
 #include "cinn/runtime/cinn_runtime.h"
 

--- a/cinn/common/type_test.cc
+++ b/cinn/common/type_test.cc
@@ -1,4 +1,5 @@
 #include "cinn/common/type.h"
+
 #include <gtest/gtest.h>
 
 namespace cinn::common {

--- a/cinn/frontend/interpreter_test.cc
+++ b/cinn/frontend/interpreter_test.cc
@@ -1,6 +1,7 @@
+#include "cinn/frontend/interpreter.h"
+
 #include <gtest/gtest.h>
 
-#include "cinn/frontend/interpreter.h"
 #include "cinn/runtime/use_extern_funcs.h"
 
 DEFINE_string(model_dir, "", "");

--- a/cinn/ir/intrinsic_ops.h
+++ b/cinn/ir/intrinsic_ops.h
@@ -3,6 +3,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Casting.h>
+
 #include "cinn/common/type.h"
 #include "cinn/ir/ir.h"
 

--- a/cinn/ir/intrinsic_ops_test.cc
+++ b/cinn/ir/intrinsic_ops_test.cc
@@ -1,4 +1,5 @@
 #include "cinn/ir/intrinsic_ops.h"
+
 #include <gtest/gtest.h>
 
 namespace cinn::ir {

--- a/cinn/ir/ir.h
+++ b/cinn/ir/ir.h
@@ -4,13 +4,13 @@
 #pragma once
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <variant>
 #include <vector>
 
-#include <map>
 #include "cinn/common/shared.h"
 #include "cinn/common/type.h"
 #include "cinn/ir/function_base.h"

--- a/cinn/ir/ir_verify.cc
+++ b/cinn/ir/ir_verify.cc
@@ -1,4 +1,5 @@
 #include "cinn/ir/ir_verify.h"
+
 #include "cinn/ir/ir_mutator.h"
 #include "cinn/ir/ir_printer.h"
 

--- a/cinn/ir/ir_verify_test.cc
+++ b/cinn/ir/ir_verify_test.cc
@@ -1,5 +1,7 @@
 #include "cinn/ir/ir_verify.h"
+
 #include <gtest/gtest.h>
+
 #include "cinn/ir/ir_operators.h"
 
 namespace cinn::ir {

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -203,8 +203,8 @@ typedef struct cinn_buffer_t {
     memcpy(this->dims, dims, dimensions * sizeof(cinn_dimension_t));
   }
 
-  CINN_ALWAYS_INLINE int num_elements() const {
-    int res = 1;
+  CINN_ALWAYS_INLINE uint64_t num_elements() const {
+    uint64_t res = 1;
     for (int i = 0; i < dimensions; i++) {
       res *= dims[i];
     }

--- a/cinn/runtime/cinn_x86_device_impl.cc
+++ b/cinn/runtime/cinn_x86_device_impl.cc
@@ -11,11 +11,10 @@ int cinn_x86_malloc(void* context, cinn_buffer_t* buf) {
     if (buf->memory) {
       free(buf->memory);
     }
-    int bytes = buf->type.bytes() * buf->num_elements();
     if (buf->align == 0) {
-      buf->memory = (unsigned char*)malloc(bytes);
+      buf->memory = (unsigned char*)malloc(memory_size);
     } else {
-      buf->memory = (unsigned char*)aligned_alloc(buf->align, bytes);
+      buf->memory = (unsigned char*)aligned_alloc(buf->align, memory_size);
     }
     buf->memory_size = memory_size;
     CINN_LOG("buf.memory size is %ld\n", buf->memory_size);

--- a/cinn/utils/timer.cc
+++ b/cinn/utils/timer.cc
@@ -4,14 +4,14 @@ namespace cinn {
 namespace utils {
 
 float Timer::Stop() {
-  end_     = std::chrono::system_clock::now();
-  auto ts  = std::chrono::duration_cast<std::chrono::milliseconds>(end_ - start_);
-  float ms = 1000.f * static_cast<float>(ts.count()) * std::chrono::milliseconds::period::num /
-             std::chrono::milliseconds::period::den;
+  end_     = std::chrono::high_resolution_clock::now();
+  auto ts  = std::chrono::duration_cast<std::chrono::nanoseconds>(end_ - start_);
+  float ms = 1000. * static_cast<double>(ts.count()) * std::chrono::nanoseconds::period::num /
+             std::chrono::nanoseconds::period::den;
   return ms;
 }
 
-void Timer::Start() { start_ = std::chrono::system_clock::now(); }
+void Timer::Start() { start_ = std::chrono::high_resolution_clock::now(); }
 
 }  // namespace utils
 }  // namespace cinn

--- a/cinn/utils/timer.h
+++ b/cinn/utils/timer.h
@@ -14,7 +14,7 @@ class Timer {
   float Stop();
 
  private:
-  std::chrono::time_point<std::chrono::system_clock> start_, end_;
+  std::chrono::time_point<std::chrono::high_resolution_clock, std::chrono::nanoseconds> start_, end_;
 };
 
 }  // namespace utils

--- a/cinnrt/dialect/diagnostic_utils.h
+++ b/cinnrt/dialect/diagnostic_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <llvm/Support/SourceMgr.h>
 #include <mlir/IR/Diagnostics.h>
+
 #include <memory>
 
 namespace cinnrt::dialect {

--- a/cinnrt/dialect/mlir_loader.h
+++ b/cinnrt/dialect/mlir_loader.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <mlir/IR/Module.h>
+
 #include <memory>
 #include <string_view>
+
 #include "cinn/frontend/syntax.h"
 
 namespace cinnrt::dialect {

--- a/cinnrt/host_context/core_runtime.h
+++ b/cinnrt/host_context/core_runtime.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <llvm/ADT/ArrayRef.h>
+
 #include <memory>
 #include <string>
 

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -70,7 +70,7 @@ function(cc_test TARGET_NAME)
       set_property(TEST ${TARGET_NAME} PROPERTY RUN_SERIAL 1)
     endif()
     # No unit test should exceed 10 minutes.
-    set_tests_properties(${TARGET_NAME} PROPERTIES TIMEOUT 600)
+    set_tests_properties(${TARGET_NAME} PROPERTIES TIMEOUT 6000)
   endif()
 endfunction()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(${CMAKE_SOURCE_DIR}/cinn/runtime)
+add_subdirectory(benchmark)
 
 cc_test(test01_elementwise_add_main SRCS test01_elementwise_add_main.cc DEPS core
   ARGS ${global_test_args}

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -1,0 +1,8 @@
+include_directories(${CMAKE_SOURCE_DIR}/cinn/runtime)
+set(srcs test_utils.cc test_matmul.cc test_elementwise.cc)
+
+cc_test(test_matmul SRCS test_matmul.cc test_utils.cc DEPS core ARGS ${global_test_args})
+target_compile_options(test_matmul PRIVATE "-O3")
+
+cc_test(test_elementwise SRCS test_elementwise.cc test_utils.cc DEPS core ARGS ${global_test_args})
+target_compile_options(test_elementwise PRIVATE "-O3")

--- a/tests/benchmark/test_elementwise.cc
+++ b/tests/benchmark/test_elementwise.cc
@@ -1,0 +1,32 @@
+#include "tests/benchmark/test_elementwise.h"
+
+#include <gtest/gtest.h>
+
+#include "cinn/cinn.h"
+#include "cinn/hlir/framework/node.h"
+
+namespace cinn {
+namespace tests {
+
+void ElementwiseAddTester::Compare() {
+  std::vector<float *> all_datas = GetAllDatas();
+  int out_dims                   = GetOutDims();
+  CHECK_EQ(all_datas.size(), 3U) << "elementwise_add should have 3 args.\n";
+  for (int i = 0; i < out_dims; ++i) {
+    EXPECT_EQ((all_datas[0][i] + all_datas[1][i]), all_datas[2][i]);
+  }
+}
+
+TEST(test_elementwise_add, default) {
+  int M = 100;
+  int N = 32;
+  std::vector<std::vector<int>> input_shapes{{M, N}, {M, N}};
+  std::string op_name = "elementwise_add";
+  hlir::framework::NodeAttr attrs;
+  ElementwiseAddTester add_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  add_tester.TestOp("elementwise_add_default", attrs, type);
+}
+
+}  // namespace tests
+}  // namespace cinn

--- a/tests/benchmark/test_elementwise.h
+++ b/tests/benchmark/test_elementwise.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "tests/benchmark/test_utils.h"
+
+namespace cinn {
+namespace tests {
+
+class ElementwiseAddTester : public OpBenchmarkTester {
+ public:
+  ElementwiseAddTester(const std::string &op_name,
+                       const std::vector<std::vector<int>> &input_shapes,
+                       const common::Target &target = common::DefaultHostTarget(),
+                       int repeat                   = 10,
+                       float diff                   = 1e-5)
+      : OpBenchmarkTester(op_name, input_shapes, target, repeat, diff) {}
+
+  void Compare() override;
+};
+
+}  // namespace tests
+}  // namespace cinn

--- a/tests/benchmark/test_matmul.cc
+++ b/tests/benchmark/test_matmul.cc
@@ -1,0 +1,255 @@
+#include "tests/benchmark/test_matmul.h"
+
+#include <gtest/gtest.h>
+
+namespace cinn {
+namespace tests {
+
+// default
+std::vector<ir::Tensor> MatmulTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                             poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  auto out = hlir::pe::Matmul(inputs[0], inputs[1]);
+  outs.push_back(out);
+  (*stages)->InsertLazily(out);
+  return outs;
+}
+
+// tile
+std::vector<ir::Tensor> MatmulTileTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                                 poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  auto out = hlir::pe::Matmul(inputs[0], inputs[1]);
+  outs.push_back(out);
+  (*stages)->InsertLazily(out);
+  (*stages)[out]->Tile(0, 1, 4, 4);
+  return outs;
+}
+
+// split
+std::vector<ir::Tensor> MatmulSplitTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                                  poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  auto out = hlir::pe::Matmul(inputs[0], inputs[1]);
+  outs.push_back(out);
+  (*stages)->InsertLazily(out);
+
+  auto c_poly_iterators = [&](auto &&... args) {
+    std::vector<poly::Iterator> iters;
+    (iters.push_back((*stages)[out]->ith_iterator(args)), ...);
+    return iters;
+  };
+  (*stages)[out]->Split(2, 16);
+  (*stages)[out]->Reorder(c_poly_iterators(1, 0, 2, 3));
+
+  return outs;
+}
+
+// block
+std::vector<ir::Tensor> MatmulBlockTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                                  poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  auto k1 = Var(input_shapes_[0][1], "k1");
+  CHECK_EQ(input_shapes_.size(), 2U) << "matmul's input shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[1].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0][1], input_shapes_[1][0]) << "matmul's reduce axis shape should be same\n";
+  auto C = Compute(
+      {Expr(input_shapes_[0][0]), Expr(input_shapes_[1][1])},
+      [&](Var i, Var j) { return ReduceSum(inputs[0](i, k1) * inputs[1](k1, j), {k1}); },
+      "C");
+  (*stages)->InsertLazily(C);
+  int bn                                    = 32;
+  auto [i_outer, i_inner, j_outer, j_inner] = (*stages)[C]->Tile(0, 1, bn, bn);  // NOLINT
+  auto [k_outer, k_inner]                   = (*stages)[C]->Split(k1->name, 4);  // NOLINT
+  (*stages)[C]->Reorder({i_outer, j_outer, k_outer, k_inner, i_inner, j_inner});
+
+  outs.push_back(C);
+  return outs;
+}
+
+// vectorize
+std::vector<ir::Tensor> MatmulVectorizeTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                                      poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  auto k1 = Var(input_shapes_[0][1], "k1");
+  CHECK_EQ(input_shapes_.size(), 2U) << "matmul's input shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[1].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0][1], input_shapes_[1][0]) << "matmul's reduce axis shape should be same\n";
+  auto C = Compute(
+      {Expr(input_shapes_[0][0]), Expr(input_shapes_[1][1])},
+      [&](Var i, Var j) { return ReduceSum(inputs[0](i, k1) * inputs[1](k1, j), {k1}); },
+      "C");
+  (*stages)->InsertLazily(C);
+  int bn                                    = 32;
+  auto [i_outer, i_inner, j_outer, j_inner] = (*stages)[C]->Tile(0, 1, bn, bn);  // NOLINT
+  auto [k_outer, k_inner]                   = (*stages)[C]->Split(k1->name, 4);  // NOLINT
+  (*stages)[C]->Reorder({i_outer, j_outer, k_outer, k_inner, i_inner, j_inner});
+  (*stages)[C]->Vectorize(j_inner, 8);
+
+  outs.push_back(C);
+  return outs;
+}
+
+// loop permutation
+std::vector<ir::Tensor> MatmulLoopPermutationTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                                            poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  auto k1 = Var(input_shapes_[0][1], "k1");
+  CHECK_EQ(input_shapes_.size(), 2U) << "matmul's input shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[1].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0][1], input_shapes_[1][0]) << "matmul's reduce axis shape should be same\n";
+  auto C = Compute(
+      {Expr(input_shapes_[0][0]), Expr(input_shapes_[1][1])},
+      [&](Var i, Var j) { return ReduceSum(inputs[0](i, k1) * inputs[1](k1, j), {k1}); },
+      "C");
+  (*stages)->InsertLazily(C);
+  int bn                                    = 32;
+  auto [i_outer, i_inner, j_outer, j_inner] = (*stages)[C]->Tile(0, 1, bn, bn);  // NOLINT
+  auto [k_outer, k_inner]                   = (*stages)[C]->Split(k1->name, 4);  // NOLINT
+  (*stages)[C]->Reorder({i_outer, j_outer, k_outer, i_inner, k_inner, j_inner});
+  (*stages)[C]->Vectorize(j_inner, 8);
+  (*stages)[C]->Unroll(5);
+
+  outs.push_back(C);
+  return outs;
+}
+
+// array packing
+std::vector<ir::Tensor> MatmulArrayPackingTester::CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                                         poly::StageMap *stages) {
+  CHECK_EQ(inputs.size(), 2U) << "matmul's input tensor should be 2.\n";
+  std::vector<ir::Tensor> outs;
+  CHECK_EQ(input_shapes_.size(), 2U) << "matmul's input shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[1].size(), 2U) << "matmul's input teosor's shape should be 2.\n";
+  CHECK_EQ(input_shapes_[0][1], input_shapes_[1][0]) << "matmul's reduce axis shape should be same\n";
+
+  Var k(input_shapes_[0][1], "k0");
+
+  Expr bn(32);
+
+  auto C_init = Compute(
+      {Expr(input_shapes_[0][0]), Expr(input_shapes_[1][1])}, [&](Var i, Var j) { return Expr(0.f); }, "C_init");
+  auto packedB = Compute(
+      {Expr(input_shapes_[1][1]) / bn, Expr(input_shapes_[0][1]), bn},
+      [&](Expr x, Expr y, Expr z) { return inputs[1](y, x * bn + z); },
+      "packedB");
+  auto C = Compute(
+      {Expr(input_shapes_[0][0]), Expr(input_shapes_[1][1])},
+      [&](Expr i, Expr j) { return ReduceSum(inputs[0](i, k) * packedB(j / bn, k, j % bn), {k}); },
+      "C");
+  (*stages)->InsertLazily(C);
+  (*stages)->InsertLazily(C_init);
+  (*stages)->InsertLazily(packedB);
+
+  (*stages)[C]->ShareBufferWith((*stages)[C_init]);
+  (*stages)[C]->CtrlDepend(C_init);
+  (*stages)[packedB]->Vectorize(2, 8);
+
+  {
+    auto [i_outer, i_inner, j_outer, j_inner] = (*stages)[C]->Tile(0, 1, bn.as_int32(), bn.as_int32());  // NOLINT
+    auto [k_outer, k_inner]                   = (*stages)[C]->Split("k0", 4);                            // NOLINT
+
+    (*stages)[C]->Reorder({i_outer, j_outer, k_outer, i_inner, k_inner, j_inner});
+    (*stages)[C]->Vectorize(j_inner, 8);
+  }
+  outs.push_back(packedB);
+  outs.push_back(C);
+  return outs;
+}
+
+TEST(test_matmul, default) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_default", attrs, type);
+}
+
+TEST(test_matmul, tile) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulTileTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_tile", attrs, type, false);
+}
+
+TEST(test_matmul, split) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulSplitTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_split", attrs, type, false);
+}
+
+TEST(test_matmul, block) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulBlockTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_block", attrs, type, false);
+}
+
+TEST(test_matmul, vectorize) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulVectorizeTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_vectorize", attrs, type, false);
+}
+
+TEST(test_matmul, loop_permutation) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulLoopPermutationTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_loop_permutation", attrs, type, false);
+}
+
+TEST(test_matmul, array_packing) {
+  int M = 1024;
+  int N = 1024;
+  int K = 1024;
+  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
+  std::string op_name = "matmul";
+  hlir::framework::NodeAttr attrs;
+  MatmulArrayPackingTester matmul_tester(op_name, input_shapes);
+  std::vector<Type> type{Float(32)};
+  matmul_tester.TestOp("matmul_array_packing", attrs, type, false);
+}
+
+}  // namespace tests
+}  // namespace cinn

--- a/tests/benchmark/test_matmul.h
+++ b/tests/benchmark/test_matmul.h
@@ -1,0 +1,109 @@
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "cinn/hlir/pe/transform.h"
+#include "tests/benchmark/test_utils.h"
+
+namespace cinn {
+namespace tests {
+
+class MatmulTester : public OpBenchmarkTester {
+ public:
+  MatmulTester(const std::string &op_name,
+               const std::vector<std::vector<int>> &input_shapes,
+               const common::Target &target = common::DefaultHostTarget(),
+               int repeat                   = 10,
+               float diff                   = 1e-5)
+      : OpBenchmarkTester(op_name, input_shapes, target, repeat, diff) {}
+
+  std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                 poly::StageMap *stages) override;
+};
+
+class MatmulTileTester : public MatmulTester {
+ public:
+  MatmulTileTester(const std::string &op_name,
+                   const std::vector<std::vector<int>> &input_shapes,
+                   const common::Target &target = common::DefaultHostTarget(),
+                   int repeat                   = 10,
+                   float diff                   = 1e-5)
+      : MatmulTester(op_name, input_shapes, target, repeat, diff) {}
+
+  std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                 poly::StageMap *stages) override;
+};
+
+class MatmulSplitTester : public MatmulTester {
+ public:
+  MatmulSplitTester(const std::string &op_name,
+                    const std::vector<std::vector<int>> &input_shapes,
+                    const common::Target &target = common::DefaultHostTarget(),
+                    int repeat                   = 10,
+                    float diff                   = 1e-5)
+      : MatmulTester(op_name, input_shapes, target, repeat, diff) {}
+
+  virtual std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs, poly::StageMap *stages);
+};
+
+class MatmulBlockTester : public MatmulTester {
+ public:
+  MatmulBlockTester(const std::string &op_name,
+                    const std::vector<std::vector<int>> &input_shapes,
+                    const common::Target &target = common::DefaultHostTarget(),
+                    int repeat                   = 10,
+                    float diff                   = 1e-5)
+      : MatmulTester(op_name, input_shapes, target, repeat, diff), input_shapes_(input_shapes) {}
+
+  std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                 poly::StageMap *stages) override;
+
+  std::vector<std::vector<int>> input_shapes_;
+};
+
+class MatmulVectorizeTester : public MatmulTester {
+ public:
+  MatmulVectorizeTester(const std::string &op_name,
+                        const std::vector<std::vector<int>> &input_shapes,
+                        const common::Target &target = common::DefaultHostTarget(),
+                        int repeat                   = 10,
+                        float diff                   = 1e-5)
+      : MatmulTester(op_name, input_shapes, target, repeat, diff), input_shapes_(input_shapes) {}
+
+  std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                 poly::StageMap *stages) override;
+  std::vector<std::vector<int>> input_shapes_;
+};
+
+class MatmulLoopPermutationTester : public MatmulTester {
+ public:
+  MatmulLoopPermutationTester(const std::string &op_name,
+                              const std::vector<std::vector<int>> &input_shapes,
+                              const common::Target &target = common::DefaultHostTarget(),
+                              int repeat                   = 10,
+                              float diff                   = 1e-5)
+      : MatmulTester(op_name, input_shapes, target, repeat, diff), input_shapes_(input_shapes) {}
+
+  std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                 poly::StageMap *stages) override;
+  std::vector<std::vector<int>> input_shapes_;
+};
+
+class MatmulArrayPackingTester : public MatmulTester {
+ public:
+  MatmulArrayPackingTester(const std::string &op_name,
+                           const std::vector<std::vector<int>> &input_shapes,
+                           const common::Target &target = common::DefaultHostTarget(),
+                           int repeat                   = 10,
+                           float diff                   = 1e-5)
+      : MatmulTester(op_name, input_shapes, target, repeat, diff), input_shapes_(input_shapes) {}
+
+  std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                 poly::StageMap *stages) override;
+  std::vector<std::vector<int>> input_shapes_;
+};
+
+}  // namespace tests
+}  // namespace cinn

--- a/tests/benchmark/test_utils.cc
+++ b/tests/benchmark/test_utils.cc
@@ -1,0 +1,136 @@
+#include "tests/benchmark/test_utils.h"
+
+#include "cinn/backends/llvm/execution_engine.h"
+#include "cinn/common/test_helper.h"
+#include "cinn/hlir/framework/op.h"
+#include "cinn/hlir/framework/op_strategy.h"
+#include "cinn/hlir/op/use_ops.h"
+#include "cinn/utils/timer.h"
+
+namespace cinn {
+namespace tests {
+using ir::Tensor;
+auto OpBenchmarkTester::CreateExecutionEngine(const cinn::ir::Module& module) {
+  auto engine = cinn::backends::ExecutionEngine::Create({});
+  engine->Link(module);
+  return engine;
+}
+
+void OpBenchmarkTester::TestOp(const std::string& test_name,
+                               const hlir::framework::NodeAttr& attrs,
+                               const std::vector<Type>& out_types,
+                               bool use_default_stragegy) {
+  auto module        = CreateCinnModule(attrs, out_types, use_default_stragegy);
+  auto engine        = CreateExecutionEngine(module);
+  auto test_func_ptr = reinterpret_cast<void (*)(void**, int32_t)>(engine->Lookup(op_name_));
+  CreateBuffer();
+  LOG(INFO) << "Testing " << test_name;
+  cinn::utils::Timer timer;
+  timer.Start();
+  for (int i = 0; i < repeat_; i++) {
+    test_func_ptr(reinterpret_cast<void**>(all_args_.data()), all_args_.size());
+  }
+  double test_op_time = timer.Stop() / repeat_;
+  LOG(INFO) << "repeat times: " << repeat_ << ", kernel run time: " << test_op_time << " ms";
+  Compare();
+  Reset();
+}
+
+Module OpBenchmarkTester::CreateCinnModule(const hlir::framework::NodeAttr& attrs,
+                                           const std::vector<Type>& out_types,
+                                           bool use_default_stragegy) {
+  std::vector<std::vector<Expr>> expr_shapes;
+  std::vector<Tensor> inputs;
+  std::vector<Tensor> outs;
+  std::vector<Tensor> rets;
+  poly::StageMap stages;
+  std::vector<Expr> output_shape_expr;
+  for (int i = 0; i < input_shapes_.size(); i++) {
+    std::vector<Expr> expr_shape;
+    for (int j = 0; j < input_shapes_[i].size(); ++j) {
+      expr_shape.push_back(Expr(input_shapes_[i][j]));
+    }
+    expr_shapes.push_back(expr_shape);
+    Placeholder<float> input(common::UniqName("input"), expr_shape);
+    inputs.push_back(input.tensor());
+    rets.push_back(input.tensor());
+  }
+  if (use_default_stragegy) {
+    auto strategy = hlir::framework::Operator::GetAttrs<hlir::framework::StrategyFunction>("CINNStrategy");
+    auto op       = hlir::framework::Operator::Get(op_name_);
+    CHECK(op) << op_name_ << " isn't supported yet\n";
+    auto impl = hlir::framework::OpStrategy::SelectImpl(strategy[op](attrs, inputs, out_types, input_shapes_, target_));
+    std::vector<common::CINNValue> temp_inputs;
+    for (auto& tensor : inputs) {
+      temp_inputs.push_back(common::CINNValue(tensor));
+    }
+    common::CINNValuePack C = impl->fcompute(common::CINNValuePack(temp_inputs));
+    stages                  = C.back();
+    C                       = impl->fschedule(C);
+    for (int i = 0; i < C->size() - 1; i++) {
+      ir::Expr temp = C[i];
+      stages->InsertLazily(temp.as_tensor_ref());
+      std::vector<Expr> output_shape_expr = temp.as_tensor_ref()->domain_without_reduce_axis();
+      std::vector<int> output_shape;
+      for (auto& shape : output_shape_expr) {
+        output_shape.push_back(shape.as_int32());
+      }
+      output_shapes_.push_back(output_shape);
+    }
+    C = impl->fschedule(C);
+    for (int i = 0; i < C->size() - 1; i++) {
+      ir::Expr temp = C[i];
+      rets.push_back(temp.as_tensor_ref());
+    }
+
+  } else {
+    stages = CreateStages(inputs);
+    outs   = CreateSpecificStrategy(inputs, &stages);
+
+    for (auto& out : outs) {
+      stages->InsertLazily(out);
+      rets.push_back(out);
+      std::vector<Expr> output_shape_expr = out->domain_without_reduce_axis();
+      std::vector<int> output_shape;
+      for (auto& shape : output_shape_expr) {
+        output_shape.push_back(shape.as_int32());
+      }
+      output_shapes_.push_back(output_shape);
+    }
+  }
+  auto func = Lower(op_name_, stages, rets);
+  LOG(INFO) << func;
+  Module::Builder builder("module_" + op_name_, target_);
+  builder.AddFunction(func);
+  return builder.Build();
+}
+
+void OpBenchmarkTester::CreateBuffer() {
+  std::vector<cinn_pod_value_t> args;
+  for (auto& input_shape : input_shapes_) {
+    auto* buffer = common::BufferBuilder(Float(32), input_shape).set_align(32).set_random().Build();
+    cinn_pod_value_t arg(buffer);
+    all_args_.push_back(arg);
+    all_datas_.push_back(reinterpret_cast<float*>(buffer->memory));
+  }
+  CHECK(!output_shapes_.empty()) << "output shapes shouldn't be empty\n";
+  // default only consider the last out as the kernel args
+  for (auto& output_shape : output_shapes_) {
+    auto* buffer = common::BufferBuilder(Float(32), output_shapes_.back()).set_align(32).set_zero().Build();
+    CHECK(buffer);
+    out_dims_ = buffer->num_elements();
+    cinn_pod_value_t arg(buffer);
+    all_args_.push_back(arg);
+    all_datas_.push_back(reinterpret_cast<float*>(buffer->memory));
+  }
+}
+
+void OpBenchmarkTester::Reset() {
+  CHECK(!all_datas_.empty());
+  for (int i = 0; i < out_dims_; ++i) {
+    all_datas_.back()[i] = 0.f;
+  }
+}
+
+}  // namespace tests
+}  // namespace cinn

--- a/tests/benchmark/test_utils.h
+++ b/tests/benchmark/test_utils.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "cinn/backends/llvm/execution_engine.h"
+#include "cinn/cinn.h"
+#include "cinn/hlir/framework/node.h"
+#include "cinn/runtime/cinn_runtime.h"
+
+namespace cinn {
+namespace tests {
+
+class OpBenchmarkTester {
+ public:
+  OpBenchmarkTester(const std::string &op_name,
+                    const std::vector<std::vector<int>> &input_shapes,
+                    const common::Target &target = common::DefaultHostTarget(),
+                    int repeat                   = 10,
+                    float diff                   = 1e-5)
+      : op_name_(op_name), input_shapes_(input_shapes), target_(target), repeat_(repeat), diff_(diff) {}
+
+  virtual ~OpBenchmarkTester() = default;
+
+  void CreateBuffer();
+
+  void TestOp(const std::string &test_name,
+              const hlir::framework::NodeAttr &attrs,
+              const std::vector<Type> &out_types,
+              bool use_default_stragegy = true);
+
+  Module CreateCinnModule(const hlir::framework::NodeAttr &attrs,
+                          const std::vector<Type> &out_types,
+                          bool use_default_stragegy = true);
+
+  // should define specific stragey if not use default schedule
+  virtual std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
+                                                         poly::StageMap *stages) {
+    CINN_NOT_IMPLEMENTED
+  }
+
+  auto CreateExecutionEngine(const cinn::ir::Module &module);
+
+  virtual void Compare() {}
+
+  virtual void Reset();
+
+  std::vector<float *> &GetAllDatas() { return all_datas_; }
+  int GetOutDims() { return out_dims_; }
+
+ private:
+  common::Target target_;
+  std::string op_name_;
+  float diff_;
+  int repeat_;
+  std::vector<std::vector<int>> input_shapes_;
+  std::vector<std::vector<int>> output_shapes_;
+  std::vector<cinn_pod_value_t> all_args_;
+  std::vector<float *> all_datas_;
+  int out_dims_;
+};
+
+}  // namespace tests
+}  // namespace cinn


### PR DESCRIPTION
add op C++ benchmark test framework(matmul, elementwise_add op benchmark test）（#271）

1. OpBenchmarkTester is the basic class to test the benchmark of op. It can test the op benchmark with default strategy or specific compute and schedule. You should feed it registered op_name, input_shapes and out_types.
e.g.： 
default:
TEST(test_matmul, default) {
  int M = 1024;
  int N = 1024;
  int K = 1024;
  std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
  std::string op_name = "matmul";
  hlir::framework::NodeAttr attrs;
  OpBenchmarkTester matmul_tester(op_name, input_shapes);
  std::vector<Type> type{Float(32)};
  matmul_tester.TestOp("matmul_default", attrs, type);
}

2. if you want to define specfic stragegy, you can inherit the OpBenchmarkTester class and overide the "CreateSpecificStrategy" funtion which depicts the out tensors' compute and stages. Then invoke TestOp function with the fourth arg set to be 'false' which indicates not to use the default stragegy.
e.g.
class MatmulTester : public OpBenchmarkTester {
 public:
  MatmulTester(const std::string &op_name,
               const std::vector<std::vector<int>> &input_shapes,
               const common::Target &target = common::DefaultHostTarget(),
               int repeat                   = 10,
               float diff                   = 1e-5)
      : OpBenchmarkTester(op_name, input_shapes, target, repeat, diff) {}

      std::vector<ir::Tensor> CreateSpecificStrategy(const std::vector<ir::Tensor> &inputs,
                                                 poly::StageMap *stages) override;
};
    TEST(test_matmul, tile) {
          int M = 1024;
          int N = 1024;
          int K = 1024;
          std::vector<std::vector<int>> input_shapes{{M, K}, {K, N}};
          std::string op_name = "matmul";
          hlir::framework::NodeAttr attrs;
          MatmulTileTester matmul_tester(op_name, input_shapes);
          std::vector<Type> type{Float(32)};
          matmul_tester.TestOp("matmul_tile", attrs, type, false);
    }

3. the benchmark result will be showed in the log temporily as follows:
I1109 07:31:30.700934 154627 test_utils.cc:27] Testing elementwise_add_default
I1109 07:31:30.701002 154627 test_utils.cc:34] repeat times: 10, kernel run time: 0.0043922 ms

