### PR TITLE
Add schedule_injective and enhance tvm & cinn op test

### DIFF
--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -14,7 +14,17 @@ namespace cinn {
 namespace backends {
 using ir::Module;
 
-void Compiler::Build(const Module& module) {
+void Compiler::Build(const Module& module, const std::string& code) {
+  if (target_.arch == Target::Arch::NVGPU) {
+    CompileCudaModule(module, code);
+  } else if (target_.arch == Target::Arch::X86) {
+    CompileX86Module(module);
+  } else {
+    CINN_NOT_IMPLEMENTED
+  }
+}
+
+void Compiler::BuildDefault(const Module& module) {
   if (target_.arch == Target::Arch::NVGPU) {
     CompileCudaModule(module);
   } else if (target_.arch == Target::Arch::X86) {
@@ -24,7 +34,7 @@ void Compiler::Build(const Module& module) {
   }
 }
 
-void Compiler::CompileCudaModule(const Module& module) {
+void Compiler::CompileCudaModule(const Module& module, const std::string& code) {
 #ifdef CINN_WITH_CUDA
   auto [host_module, device_module] = SplitCudaAndHostModule(module);  // NOLINT
   LOG(INFO) << "[CUDA] host module:\n" << host_module;
@@ -33,6 +43,7 @@ void Compiler::CompileCudaModule(const Module& module) {
     LOG(INFO) << "[CUDA] device module:\n" << device_module;
     CodeGenCUDA_Dev codegen(target_);
     auto source_code = codegen.Compile(device_module);
+    if (!code.empty()) source_code = code;
     LOG(INFO) << "[CUDA] source code:\n" << source_code;
     using runtime::cuda::CUDAModule;
 

--- a/cinn/backends/compiler.h
+++ b/cinn/backends/compiler.h
@@ -24,7 +24,9 @@ class Compiler final {
   /**
    * Compile and link to a CINN module.
    */
-  void Build(const ir::Module& module);
+  void Build(const ir::Module& module, const std::string& code = "");
+
+  void BuildDefault(const ir::Module& module);
 
   /**
    * Retrieve a function by \p fn_name.
@@ -33,7 +35,7 @@ class Compiler final {
   lower_func_ptr_t Lookup(std::string_view fn_name);
 
  private:
-  void CompileCudaModule(const ir::Module& module);
+  void CompileCudaModule(const ir::Module& module, const std::string& code = "");
 
   void CompileX86Module(const ir::Module& module);
 

--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -28,6 +28,11 @@ int Target::runtime_arch() const {
   return -1;
 }
 
+int Target::max_num_threads() const {
+  CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max number of threads.";
+  return 1024;
+}
+
 std::ostream &operator<<(std::ostream &os, const Target &target) {
   os << "Target<";
   switch (target.os) {

--- a/cinn/common/target.h
+++ b/cinn/common/target.h
@@ -50,6 +50,8 @@ struct Target {
   //! Get the Runtime architecture, it is casted to integer to avoid header file depending.
   int runtime_arch() const;
 
+  int max_num_threads() const;
+
   bool operator==(const Target& other) const;
   bool operator!=(const Target& other) const { return !(*this == other); }
   friend std::ostream& operator<<(std::ostream& os, const Target& target);

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -20,7 +20,7 @@ void GraphCompiler::PrintFunc() {
   }
 }
 
-std::unique_ptr<Program> GraphCompiler::Build() {
+std::unique_ptr<Program> GraphCompiler::Build(const std::string& code) {
   auto [nodes, edges] = graph_->topological_order();
   for (auto& n : nodes) {
     auto* node = n->safe_as<Node>();
@@ -43,7 +43,7 @@ std::unique_ptr<Program> GraphCompiler::Build() {
     LOG(INFO) << "[X86] C Code is:\n" << out;
   }
 
-  compiler_->Build(build_module);
+  compiler_->Build(build_module, code);
 
   return std::unique_ptr<Program>(new Program(scope_, BuildInstructions()));
 }

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -75,7 +75,7 @@ class GraphCompiler final {
   GraphCompiler(Target target, const std::shared_ptr<Scope>& scope, const std::shared_ptr<Graph>& graph)
       : target_(std::move(target)), scope_(scope), graph_(graph), m_builder_(UniqName("module"), target) {}
 
-  std::unique_ptr<Program> Build();
+  std::unique_ptr<Program> Build(const std::string& code = "");
 
   void PrintFunc();
 

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -50,6 +50,12 @@ class Program {
     }
   }
 
+  void ExecuteTest(int repeat_) {
+    CHECK_EQ(instrs_.size(), 1);
+    for (auto& ins : instrs_) {
+      ins->RunTest(repeat_);
+    }
+  }
   /**
    * Get the number of instructions.
    */

--- a/cinn/hlir/framework/instruction.h
+++ b/cinn/hlir/framework/instruction.h
@@ -5,6 +5,7 @@
 
 #include "cinn/common/test_helper.h"
 #include "cinn/hlir/framework/scope.h"
+#include "cinn/utils/timer.h"
 
 namespace cinn {
 namespace hlir {
@@ -38,6 +39,21 @@ class Instruction {
    * @param fn The JIT compiled function address.
    */
   void SetLoweredFunc(lower_func_ptr_t fn) { fn_ = fn; }
+
+  void RunTest(int repeat_) {
+    CHECK(fn_) << "The LoweredFunc address should be set first by calling SetLoweredFunc method";
+    auto& pod_args = PreparePodArgs();
+    cinn::utils::Timer timer;
+    for (int i = 0; i < 100; i++) {
+      fn_(pod_args.data(), pod_args.size());
+    }
+    timer.Start();
+    for (int i = 0; i < repeat_; i++) {
+      fn_(pod_args.data(), pod_args.size());
+    }
+    double test_op_time = timer.Stop() / repeat_;
+    LOG(INFO) << "Repeat times: [" << repeat_ << "], average op run time: [" << test_op_time << "] ms";
+  }
 
   /**
    * Run the Instruction.

--- a/cinn/hlir/op/broadcast.cc
+++ b/cinn/hlir/op/broadcast.cc
@@ -57,9 +57,7 @@ std::shared_ptr<OpStrategy> StrategyForElementwiseAdd(const framework::NodeAttr 
       Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
-      pe::CudaSplitSchedule(stages[Out.as_tensor_ref()], output_shapes.back());
-      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
-      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });
@@ -106,9 +104,7 @@ std::shared_ptr<OpStrategy> StrategyForElementwiseMul(const framework::NodeAttr 
       Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
-      pe::CudaSplitSchedule(stages[Out.as_tensor_ref()], output_shapes.back());
-      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
-      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });
@@ -177,9 +173,7 @@ std::shared_ptr<OpStrategy> StrategyForScale(const framework::NodeAttr &attrs,
       Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
-      pe::CudaSplitSchedule(stages[Out.as_tensor_ref()], output_shapes.back());
-      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
-      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -42,9 +42,7 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
       Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
-      pe::CudaSplitSchedule(stages[Out.as_tensor_ref()], output_shapes.back());
-      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
-      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });
@@ -96,9 +94,7 @@ std::shared_ptr<OpStrategy> StrategyForRelu6(const framework::NodeAttr &attrs,
       Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
-      pe::CudaSplitSchedule(stages[Out.as_tensor_ref()], output_shapes.back());
-      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
-      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });
@@ -1004,9 +1000,7 @@ std::shared_ptr<OpStrategy> StrategyForSigmoid(const framework::NodeAttr &attrs,
       Expr Out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
       CHECK(Out.as_tensor());
-      pe::CudaSplitSchedule(stages[Out.as_tensor_ref()], output_shapes.back());
-      stages[Out.as_tensor_ref()]->Bind(0, "blockIdx.x");
-      stages[Out.as_tensor_ref()]->Bind(1, "threadIdx.x");
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -49,10 +49,7 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
       stage->Bind(0, "blockIdx.x");
       stage->Bind(1, "threadIdx.x");
     } else {
-      auto [Thread_x, Block_x] = stage->Split(0, 2);
-      stage->Reorder({Block_x, Thread_x});
-      stage->Bind(0, "blockIdx.x");
-      stage->Bind(1, "threadIdx.x");
+      stage->Bind(0, "threadIdx.x");
     }
   }
   return;

--- a/cinn/hlir/pe/nn.h
+++ b/cinn/hlir/pe/nn.h
@@ -12,6 +12,8 @@ namespace cinn {
 namespace hlir {
 namespace pe {
 
+void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_shape, const common::Target &target);
+
 void CudaSplitSchedule(poly::Stage *stage, const std::vector<int> &output_shape);
 
 /**

--- a/cinn/poly/stage.h
+++ b/cinn/poly/stage.h
@@ -299,6 +299,11 @@ class Stage : public Object {
 
   ir::Tensor LookupCtrlDepend(const std::string& tensor_name) const;
 
+  //! Get number of transform output dimensions, this equals to the number of forloops in generated code.
+  inline int n_in_dims() const { return isl_map_dim(transform_.get(), isl_dim_in); }
+  //! Get number of transform output dimensions, this equals to the number of dimensions of corresponding tensor.
+  inline int n_out_dims() const { return isl_map_dim(transform_.get(), isl_dim_out); }
+
  private:
   explicit Stage(const isl::set& domain, Expr expr = Expr(), ir::_Tensor_* tensor = nullptr);
 
@@ -317,11 +322,6 @@ class Stage : public Object {
   bool is_axis_locked(uint32_t level) const;
   //! Assert that the axis is not locked, abort if fail.
   void AssertAxisIsNotLocked(uint32_t level);
-
-  //! Get number of transform output dimensions, this equals to the number of forloops in generated code.
-  inline int n_in_dims() const { return isl_map_dim(transform_.get(), isl_dim_in); }
-  //! Get number of transform output dimensions, this equals to the number of dimensions of corresponding tensor.
-  inline int n_out_dims() const { return isl_map_dim(transform_.get(), isl_dim_out); }
 
   static constexpr char* __type_info__ = "Stage";
 

--- a/cinn/pybind/backends.cc
+++ b/cinn/pybind/backends.cc
@@ -53,7 +53,7 @@ void BindExecutionEngine(py::module *m) {
     py::class_<Compiler> compiler(*m, "Compiler");
     compiler
         .def_static("create", &Compiler::Create)  //
-        .def("build", &Compiler::Build)           //
+        .def("build", &Compiler::BuildDefault)    //
         .def("lookup", lookup);
   }
 }

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -168,17 +168,8 @@ void BindFrontend(pybind11::module *m) {
                  CINN_NOT_IMPLEMENTED
                }
              }
-             cinn::utils::Timer timer;
-             // Here we run 100 times to preheat.
-             for (int i = 0; i < repeat_ + 100; i++) {
-               if (i == 100) {
-                 timer.Start();
-               }
-               program->Execute();
-             }
-             double test_op_time = timer.Stop() / repeat_;
              LOG(INFO) << info;
-             LOG(INFO) << "Repeat times: " << repeat_ << ", average op run time: " << test_op_time << " ms";
+             program->ExecuteTest(repeat_);
              auto out = scope->GetTensor(tensor_out->id);
              return out;
            });

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -172,6 +172,48 @@ void BindFrontend(pybind11::module *m) {
              program->ExecuteTest(repeat_);
              auto out = scope->GetTensor(tensor_out->id);
              return out;
+           })
+      .def("test_benchmark_with_code",
+           [](Program &self,
+              const common::Target &target,
+              const std::vector<Variable> &tensor_inputs,
+              const std::vector<py::array> &input_data,
+              const Variable &tensor_out,
+              int repeat_,
+              const std::string &info,
+              const std::string &code) {
+             std::shared_ptr<hlir::framework::Graph> g(new hlir::framework::Graph(self));
+             hlir::framework::ApplyPass(g.get(), "InferShape");
+             std::shared_ptr<hlir::framework::Scope> scope = hlir::framework::BuildScope(target, g);
+             hlir::framework::GraphCompiler gc(target, scope, g);
+             auto program = gc.Build(code);
+             for (size_t i = 0; i < tensor_inputs.size(); i++) {
+               auto in_tensor = scope->GetTensor(tensor_inputs[i]->id);
+               auto *data     = in_tensor->mutable_data<float>(target);
+               CHECK_EQ(input_data[i].size(), in_tensor->shape().numel())
+                   << "The size of tensor [" << tensor_inputs[i]->id
+                   << "] is different with the input data's size! Please check.";
+               if (target.arch == Target::Arch::NVGPU) {
+#ifdef CINN_WITH_CUDA
+                 CUDA_CALL(cudaMemcpy(reinterpret_cast<void *>(data),
+                                      input_data[i].data(),
+                                      in_tensor->shape().numel() * sizeof(float),
+                                      cudaMemcpyHostToDevice));
+#else
+                 LOG(FATAL) <<"To use CUDA backends, you need to set WITH_CUDA ON!";
+#endif
+               } else if (target.arch == Target::Arch::X86) {
+                 for (size_t j = 0; j < in_tensor->shape().numel(); j++) {
+                   data[j] = reinterpret_cast<const float *>(input_data[i].data())[j];  // All random data
+                 }
+               } else {
+                 CINN_NOT_IMPLEMENTED
+               }
+             }
+             LOG(INFO) << info;
+             program->ExecuteTest(repeat_);
+             auto out = scope->GetTensor(tensor_out->id);
+             return out;
            });
 
   py::class_<frontend::Interpreter>(*m, "Interpreter")

--- a/python/tests/test_op_benchmark.py
+++ b/python/tests/test_op_benchmark.py
@@ -77,16 +77,16 @@ class TestBenchmark(unittest.TestCase):
 
     def test_elementwise(self):
         prog = Program()
-        a = Variable("A").set_type(Float(32)).set_shape([2, 512, 7, 7])
-        b = Variable("B").set_type(Float(32)).set_shape([2, 512, 7, 7])
+        a = Variable("A").set_type(Float(32)).set_shape([64, 64])
+        b = Variable("B").set_type(Float(32)).set_shape([64, 64])
         c = prog.add(a, b)
         tensor_data = [
-            np.random.random([2, 512, 7, 7]).astype("float32"),
-            np.random.random([2, 512, 7, 7]).astype("float32")
+            np.random.random([64, 64]).astype("float32"),
+            np.random.random([64, 64]).astype("float32")
         ]
         result = prog.test_benchmark(
             self.target, [a, b], tensor_data, c, 200,
-            "TESTING [elementwise_add] time cost with shape [2, 512, 7, 7]...")
+            "TESTING [elementwise_add] time cost with shape [64,64]...")
 
     def test_batchnorm(self):
         prog = Program()
@@ -109,12 +109,12 @@ class TestBenchmark(unittest.TestCase):
 
     def test_relu(self):
         prog = Program()
-        a = Variable("A").set_type(Float(32)).set_shape([2, 512, 7, 7])
+        a = Variable("A").set_type(Float(32)).set_shape([64, 64])
         c = prog.relu(a)
-        tensor_data = [np.random.random([2, 512, 7, 7]).astype("float32")]
+        tensor_data = [np.random.random([64, 64]).astype("float32")]
         result = prog.test_benchmark(
             self.target, [a], tensor_data, c, 200,
-            "TESTING [relu] time cost with shape [2, 512, 7, 7]...")
+            "TESTING [relu] time cost with shape [64,64]...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
添加了cuda端的shcedule_injective（用于elementwise op，例如relu，elementwise_add，batchnorm等）
修改了tvm测试脚本，现在能够打印出生成的cuda代码
增强了cinn op测试，现在支持注入自定义cuda代码进行性能测试，使用方法参考https://github.com/PaddlePaddle/CINN/blob/a9f6c8a2bdf231ce225e0b9741ce219d7a38bf67/python/tests/test_op_benchmark.py#L100