### PR TITLE
Add paddle benchmark script

### DIFF
--- a/tools/paddle_benchmark/paddle_save_model.py
+++ b/tools/paddle_benchmark/paddle_save_model.py
@@ -1,0 +1,30 @@
+import numpy
+import sys, os
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+
+#For paddlepaddle version >=2.0rc, we need to set paddle.enable_static()
+paddle.enable_static()
+
+a = fluid.data(name="A", shape=[512, 512], dtype='float32')
+b = fluid.data(name="B", shape=[512, 512], dtype='float32')
+
+label = fluid.layers.data(name="label", shape=[512, 512], dtype='float32')
+
+a1 = fluid.layers.mul(a, b)
+
+#cost = fluid.layers.square_error_cost(a1, label)
+#avg_cost = fluid.layers.mean(cost)
+
+#optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+#optimizer.minimize(avg_cost)
+
+cpu = fluid.core.CPUPlace()
+loss = exe = fluid.Executor(cpu)
+
+exe.run(fluid.default_startup_program())
+
+fluid.io.save_inference_model("./elementwise_add_model", [a.name, b.name],
+                              [a1], exe)
+print('input and output names are: ', a.name, b.name, a1.name)

--- a/tools/paddle_benchmark/paddle_save_model.py
+++ b/tools/paddle_benchmark/paddle_save_model.py
@@ -14,12 +14,6 @@ label = fluid.layers.data(name="label", shape=[512, 512], dtype='float32')
 
 a1 = fluid.layers.mul(a, b)
 
-#cost = fluid.layers.square_error_cost(a1, label)
-#avg_cost = fluid.layers.mean(cost)
-
-#optimizer = fluid.optimizer.SGD(learning_rate=0.001)
-#optimizer.minimize(avg_cost)
-
 cpu = fluid.core.CPUPlace()
 loss = exe = fluid.Executor(cpu)
 

--- a/tools/paddle_benchmark/paddle_test_benchmark.py
+++ b/tools/paddle_benchmark/paddle_test_benchmark.py
@@ -1,0 +1,62 @@
+import argparse
+import time
+import numpy as np
+from paddle.fluid.core import AnalysisConfig
+from paddle.fluid.core import create_paddle_predictor
+
+
+def main():
+    args = parse_args()
+
+    config = set_config(args)
+
+    predictor = create_paddle_predictor(config)
+
+    input_names = predictor.get_input_names()
+    input_tensor = predictor.get_input_tensor(input_names[0])
+    fake_input = np.random.randn(512, 512).astype("float32")
+    input_tensor.reshape([512, 512])
+    input_tensor.copy_from_cpu(fake_input)
+
+    input_tensor2 = predictor.get_input_tensor(input_names[1])
+    fake_input2 = np.random.randn(512, 512).astype("float32")
+    input_tensor2.reshape([512, 512])
+    input_tensor2.copy_from_cpu(fake_input2)
+
+    for _ in range(0, 10):
+        predictor.zero_copy_run()
+    #time_start = time.time()
+    for i in range(0, 500):
+        predictor.zero_copy_run()
+    output_names = predictor.get_output_names()
+    output_tensor = predictor.get_output_tensor(output_names[0])
+    output_data = output_tensor.copy_to_cpu()
+    #time_end = time.time()
+    #print('totally cost',(time_end-time_start)/2)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_dir", type=str, help="model filename")
+    #parser.add_argument("--params_file", type=str, help="parameter filename")
+    #parser.add_argument("--batch_size", type=int, default=1, help="batch size")
+
+    return parser.parse_args()
+
+
+def set_config(args):
+    config = AnalysisConfig(args.model_dir)
+    config.enable_profile()
+    config.enable_use_gpu(1000, 1)
+    config.gpu_device_id()
+    config.switch_use_feed_fetch_ops(False)
+    config.switch_specify_input_names(True)
+    config.switch_ir_optim(False)
+    #To test cpu backend, just uncomment the following 2 lines.
+    #config.disable_gpu()
+    #config.enable_mkldnn()
+    return config
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/paddle_benchmark/paddle_test_benchmark.py
+++ b/tools/paddle_benchmark/paddle_test_benchmark.py
@@ -25,21 +25,16 @@ def main():
 
     for _ in range(0, 10):
         predictor.zero_copy_run()
-    #time_start = time.time()
     for i in range(0, 500):
         predictor.zero_copy_run()
     output_names = predictor.get_output_names()
     output_tensor = predictor.get_output_tensor(output_names[0])
     output_data = output_tensor.copy_to_cpu()
-    #time_end = time.time()
-    #print('totally cost',(time_end-time_start)/2)
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_dir", type=str, help="model filename")
-    #parser.add_argument("--params_file", type=str, help="parameter filename")
-    #parser.add_argument("--batch_size", type=int, default=1, help="batch size")
 
     return parser.parse_args()
 


### PR DESCRIPTION
添加了用于测试paddlepaddle 单op benchmark性能的脚本。
注意如果在docker中运行，则需要在启动容器时加入 --privileged=true 命令，否则enable_profiler()命令会由于权限不够出错。
使用方法:
1.用`python paddle_save_model.py`来生成单op模型
2.用`python paddle_test_benchmark.py --model_dir ./elementwise_add_model`来测试性能。`elementwise_add_model`可以根据第1步中存储模型文件的位置更改。
3.通过`config.disable_gpu()`,`config.enable_mkldnn()`端口控制cpu/gpu。