### PR TITLE
Enhance test of cacheread and cachewrite

### DIFF
--- a/cinn/backends/codegen_cuda_dev_test.cc
+++ b/cinn/backends/codegen_cuda_dev_test.cc
@@ -657,52 +657,6 @@ TEST(elementwise_add1, share_local_cache) {
   CodeGenCUDA_Dev codegen(common::DefaultNVGPUTarget());
   auto source_code = codegen.Compile(builder.Build());
 
-  LOG(INFO) << "device source code elementwise_add1:\n" << source_code;
-
-  std::string source_target = R"ROC(
-extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-#endif
-
-
-
-__global__
-void elementwise_add1(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
-{
-  float _A_read_cache [ ((1 * (((1 * 100) * 200) / 100)) / 200) ];
-  float _A_read_cache_read_cache [ 100 * 200 ];
-  float* A_read_cache = _A_read_cache;
-  float* A_read_cache_read_cache = _A_read_cache_read_cache;
-  if ((blockIdx.x < 100)) {
-  {
-    if ((threadIdx.x < 200)) {
-    {
-      A_read_cache[0] = A[((200 * blockIdx.x) + threadIdx.x)];
-    }
-    };
-  }
-  };
-  if ((blockIdx.x < 100)) {
-  {
-    if ((threadIdx.x < 200)) {
-    {
-      A_read_cache_read_cache[0] = A_read_cache[0];
-      C[((200 * blockIdx.x) + threadIdx.x)] = (A_read_cache_read_cache[0] + B[((200 * blockIdx.x) + threadIdx.x)]);
-    }
-    };
-  }
-  };
-}
-
-}
-)ROC";
-  ASSERT_EQ(utils::Trim(source_target), source_code);
-
   backends::NVRTC_Compiler compiler;
 
   common::CudaModuleTester tester;
@@ -748,7 +702,7 @@ void elementwise_add1(const float* __restrict__ A, const float* __restrict__ B, 
   cuMemFree(reinterpret_cast<CUdeviceptr>(C_dev));
 }
 
-TEST(elementwise_add, share_local_cache) {
+TEST(elementwise_add0, share_local_cache) {
   Expr M(100);
   Expr N(20);
 
@@ -796,58 +750,6 @@ TEST(elementwise_add, share_local_cache) {
   auto source_code = codegen.Compile(builder.Build());
 
   LOG(INFO) << "device source code elementwise_add0:\n" << source_code;
-
-  std::string source_target = R"ROC(
-extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-#endif
-
-
-
-__global__
-void elementwise_add0(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
-{
-  __shared__ float _A_read_cache_0 [ 100 * 20 ];
-  float _C_cache_write_out [ ((1 * (((1 * 100) * 20) / 100)) / 20) ];
-  float* A_read_cache_0 = _A_read_cache_0;
-  float* C_cache_write_out = _C_cache_write_out;
-  if ((blockIdx.x < 100)) {
-  {
-    if ((threadIdx.x < 20)) {
-    {
-      A_read_cache_0[((20 * blockIdx.x) + threadIdx.x)] = A[((20 * blockIdx.x) + threadIdx.x)];
-    }
-    };
-  }
-  };
-  if ((blockIdx.x < 100)) {
-  {
-    if ((threadIdx.x < 20)) {
-    {
-      C_cache_write_out[0] = (A_read_cache_0[((20 * blockIdx.x) + threadIdx.x)] + B[((20 * blockIdx.x) + threadIdx.x)]);
-    }
-    };
-  }
-  };
-  if ((blockIdx.x < 100)) {
-  {
-    if ((threadIdx.x < 20)) {
-    {
-      C[((20 * blockIdx.x) + threadIdx.x)] = C_cache_write_out[0];
-    }
-    };
-  }
-  };
-}
-
-}
-)ROC";
-  ASSERT_EQ(utils::Trim(source_target), source_code);
 
   backends::NVRTC_Compiler compiler;
 
@@ -1302,15 +1204,10 @@ TEST(ElementwiseAdd, cache_read_shared) {
     auto AL = stages[A]->CacheRead2("shared", temp, stages);
 
     stages[C]->Split(1, 10);
-
-    // If the shape is larger than shared memory, then the threadIdx should be shared across all the blocks, that means
-    // the shared memory producer should be `ComputeAt` at(inside) the producer's innermost blockIdx axis, that will
-    // make the producer share the blockIdx and sees only the threadIdx.
-    stages[AL]->ComputeAt(stages[C], 0, poly::Stage::kComputeAtAuto, A->name);
-
+    stages[AL]->Split(1, 10);
+    stages[AL]->ComputeAt(stages[C], 1);
     stages[C]->Bind(0, "blockIdx.x");
     stages[C]->Bind(1, "threadIdx.x");
-    stages[AL]->Bind(1, "threadIdx.x");
 
     return std::make_tuple(A, B, C, AL, stages);
   };
@@ -1342,21 +1239,19 @@ typedef char int8_t;
 __global__
 void fn2(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
 {
-  __shared__ float _A_read_cache [ 1 * 200 ];
+  __shared__ float _A_read_cache [ 1 * 10 ];
   float* A_read_cache = _A_read_cache;
   if ((blockIdx.x < 100)) {
   {
-    if (((blockIdx.x >= 0) && (blockIdx.x <= 99))) {
-      if ((threadIdx.x < 200)) {
-      {
-        A_read_cache[threadIdx.x] = A[((200 * blockIdx.x) + threadIdx.x)];
-      }
-      };
-    };
     if ((threadIdx.x < 20)) {
     {
-      for (int32_t j = 0; j < 10; j += 1) {
-        C[((200 * blockIdx.x) + ((10 * threadIdx.x) + j))] = A_read_cache[((10 * threadIdx.x) + j)];
+      if (((((blockIdx.x >= 0) && (blockIdx.x <= 99)) && (threadIdx.x >= 0)) && (threadIdx.x <= 19))) {
+        for (int32_t j_inner = 0; j_inner < 10; j_inner += 1) {
+          A_read_cache[j_inner] = A[((200 * blockIdx.x) + ((10 * threadIdx.x) + j_inner))];
+        };
+      };
+      for (int32_t i = 0; i < 10; i += 1) {
+        C[((200 * blockIdx.x) + ((10 * threadIdx.x) + i))] = A_read_cache[i];
       };
     }
     };

--- a/cinn/backends/codegen_cuda_dev_test.cc
+++ b/cinn/backends/codegen_cuda_dev_test.cc
@@ -1205,9 +1205,9 @@ TEST(ElementwiseAdd, cache_read_shared) {
 
     stages[C]->Split(1, 10);
     stages[AL]->Split(1, 10);
-    stages[AL]->ComputeAt(stages[C], 1);
     stages[C]->Bind(0, "blockIdx.x");
     stages[C]->Bind(1, "threadIdx.x");
+    stages[AL]->ComputeAt(stages[C], 1);
 
     return std::make_tuple(A, B, C, AL, stages);
   };

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -33,22 +33,6 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     auto out    = pe::Relu<float>(A.as_tensor_ref(), 0.0, UniqName("Relu_output"));
     auto stages = CreateStages({out});
     *ret        = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}};
-
-    /*     auto out      = pe::Relu<float>(A.as_tensor_ref(), 0.0, UniqName("Relu_output"));
-        ir::Tensor At = A.as_tensor_ref();
-        auto stages   = CreateStages({At, out});
-        if (target.arch == Target::Arch::NVGPU) {
-          if (output_shapes[0].size() < 2) LOG(FATAL) << "Error of size!";
-          std::vector<ir::Tensor> temp{out};
-          auto AA = stages[At]->CacheRead2("local", temp, stages);
-          auto AL = stages[AA]->CacheRead2("local", temp, stages);
-          stages[AA]->Bind(0, "blockIdx.x");
-          stages[AA]->Bind(1, "threadIdx.x");
-          stages[out]->Bind(0, "blockIdx.x");
-          stages[out]->Bind(1, "threadIdx.x");
-          stages[AL]->ComputeAt2(stages[out], 1);
-        }
-        *ret = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}}; */
   });
 
   framework::CINNSchedule relu_schedule([=](lang::Args args, lang::RetValue *ret) {

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -30,21 +30,25 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     CHECK(!a.empty()) << "at least one input tensor for relu compute\n";
     Expr A = a[0];
     CHECK(A.as_tensor());
-    auto out      = pe::Relu<float>(A.as_tensor_ref(), 0.0, UniqName("Relu_output"));
-    ir::Tensor At = A.as_tensor_ref();
-    auto stages   = CreateStages({At, out});
-    if (target.arch == Target::Arch::NVGPU) {
-      if (output_shapes[0].size() < 2) LOG(FATAL) << "Error of size!";
-      std::vector<ir::Tensor> temp{out};
-      auto AA = stages[At]->CacheRead2("local", temp, stages);
-      auto AL = stages[AA]->CacheRead2("local", temp, stages);
-      stages[AA]->Bind(0, "blockIdx.x");
-      stages[AA]->Bind(1, "threadIdx.x");
-      stages[out]->Bind(0, "blockIdx.x");
-      stages[out]->Bind(1, "threadIdx.x");
-      stages[AL]->ComputeAt2(stages[out], 1);
-    }
-    *ret = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}};
+    auto out    = pe::Relu<float>(A.as_tensor_ref(), 0.0, UniqName("Relu_output"));
+    auto stages = CreateStages({out});
+    *ret        = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}};
+
+    /*     auto out      = pe::Relu<float>(A.as_tensor_ref(), 0.0, UniqName("Relu_output"));
+        ir::Tensor At = A.as_tensor_ref();
+        auto stages   = CreateStages({At, out});
+        if (target.arch == Target::Arch::NVGPU) {
+          if (output_shapes[0].size() < 2) LOG(FATAL) << "Error of size!";
+          std::vector<ir::Tensor> temp{out};
+          auto AA = stages[At]->CacheRead2("local", temp, stages);
+          auto AL = stages[AA]->CacheRead2("local", temp, stages);
+          stages[AA]->Bind(0, "blockIdx.x");
+          stages[AA]->Bind(1, "threadIdx.x");
+          stages[out]->Bind(0, "blockIdx.x");
+          stages[out]->Bind(1, "threadIdx.x");
+          stages[AL]->ComputeAt2(stages[out], 1);
+        }
+        *ret = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}}; */
   });
 
   framework::CINNSchedule relu_schedule([=](lang::Args args, lang::RetValue *ret) {
@@ -52,10 +56,10 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     CINNValuePack arg_pack = args[0];
     CHECK_EQ(arg_pack.size(), 2UL);
     if (target.arch == Target::Arch::NVGPU) {
-      /*       Expr Out              = arg_pack[0];
-            poly::StageMap stages = arg_pack[1];
-            CHECK(Out.as_tensor());
-            pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target); */
+      Expr Out              = arg_pack[0];
+      poly::StageMap stages = arg_pack[1];
+      CHECK(Out.as_tensor());
+      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });

--- a/cinn/optim/replace_var_with_expr.cc
+++ b/cinn/optim/replace_var_with_expr.cc
@@ -55,9 +55,10 @@ void ReplaceVarWithExpr(Expr* source, const Var& var, const Expr& expr) {
 struct ReplaceVarIndexOfCacheMutator : public ir::IRMutator<> {
   ReplaceVarIndexOfCacheMutator(const Var& var,
                                 const Expr& expr,
-                                const std::map<std::string, ir::Tensor>* global_tensor_map,
-                                bool blockidx)
-      : var_(var), expr_(expr), global_tensor_map_(global_tensor_map), blockidx_(blockidx) {}
+                                std::map<std::string, ir::Tensor>* global_tensor_map,
+                                bool blockidx,
+                                const Expr& extent)
+      : var_(var), expr_(expr), global_tensor_map_(global_tensor_map), blockidx_(blockidx), extent_(extent) {}
 
   void Execute(Expr* expr) {
     auto* for_     = expr->As<ir::For>();
@@ -66,6 +67,21 @@ struct ReplaceVarIndexOfCacheMutator : public ir::IRMutator<> {
       ir::IRMutator<>::Visit(&for_->body, &for_->body);
     } else {
       ir::IRMutator<>::Visit(&poly_for->body, &poly_for->body);
+    }
+  }
+
+  void ResizeTempMemory(const std::string& tensor_name) {
+    if (extent_.defined()) {
+      auto buffer_shape = (*global_tensor_map_)[tensor_name]->buffer->shape;
+      Expr prod(1);
+      for (auto i : buffer_shape) {
+        prod = ir::Mul::Make(prod, i);
+      }
+      prod = ir::Div::Make(prod, extent_);
+      std::vector<Expr> new_shape{prod};
+      (*global_tensor_map_)[tensor_name]->buffer->shape = new_shape;
+    } else {
+      VLOG(3) << "extent not defined";
     }
   }
 
@@ -85,6 +101,7 @@ struct ReplaceVarIndexOfCacheMutator : public ir::IRMutator<> {
     VLOG(2) << "Store 's tensor name is : " << tensor->name;
     if ((utils::Endswith(tensor->name, "_read_cache") || utils::Endswith(tensor->name, "_cache_write_out")) &&
         ((*global_tensor_map_).at(tensor->name)->buffer->memory_type == ir::MemoryType::GPULocal || blockidx_)) {
+      ResizeTempMemory(tensor->name);
       bool temp_replace = do_replace;
       do_replace        = true;
       for (auto& index : node->indices) {
@@ -113,19 +130,21 @@ struct ReplaceVarIndexOfCacheMutator : public ir::IRMutator<> {
   }
 
  private:
-  const std::map<std::string, ir::Tensor>* global_tensor_map_;
+  std::map<std::string, ir::Tensor>* global_tensor_map_;
   const Var& var_;
   const Expr& expr_;
   bool blockidx_;
   bool do_replace{false};
+  const Expr& extent_;
 };
 
 void CUDAReplaceIndexOfCachePass(Expr* source,
                                  const Var& var,
                                  const Expr& expr,
-                                 const std::map<std::string, ir::Tensor>* global_tensor_map,
-                                 bool blockidx) {
-  ReplaceVarIndexOfCacheMutator mutator(var, expr, global_tensor_map, blockidx);
+                                 std::map<std::string, ir::Tensor>* global_tensor_map,
+                                 bool blockidx,
+                                 const Expr& extent) {
+  ReplaceVarIndexOfCacheMutator mutator(var, expr, global_tensor_map, blockidx, extent);
   mutator.Execute(source);
 }
 

--- a/cinn/optim/replace_var_with_expr.h
+++ b/cinn/optim/replace_var_with_expr.h
@@ -1,4 +1,8 @@
 #pragma once
+#include <map>
+#include <string>
+#include <vector>
+
 #include "cinn/ir/ir.h"
 
 namespace cinn {
@@ -22,7 +26,8 @@ void ReplaceVarWithExpr(Expr *source, const Var &var, const Expr &expr);
 void CUDAReplaceIndexOfCachePass(Expr *source,
                                  const Var &var,
                                  const Expr &expr,
-                                 const std::map<std::string, ir::Tensor> *global_tensor_map,
-                                 bool blockidx);
+                                 std::map<std::string, ir::Tensor> *global_tensor_map,
+                                 bool blockidx,
+                                 const Expr &extent);
 }  // namespace optim
 }  // namespace cinn

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -181,22 +181,6 @@ void MarkGpuForloop(const std::string &statement,
             Expr var_expr(cuda_var);
             VLOG(2) << "gpu replacing var " << axis_var->name << " to " << cuda_var->name;
             optim::ReplaceVarWithExpr(expr, axis_var, var_expr);
-            if ((utils::Endswith(statement, "_read_cache") || utils::Endswith(statement, "_cache_write_out")) &&
-                (*global_tensor_map).count(statement) > 0) {
-              if ((*global_tensor_map)[statement]->buffer->memory_type == ir::MemoryType::GPULocal) {
-                /*                 Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
-                                if (extent.defined()) {
-                                  auto buffer_shape = (*global_tensor_map)[statement]->buffer->shape;
-                                  Expr prod(1);
-                                  for (auto i : buffer_shape) {
-                                    prod = ir::Mul::Make(prod, i);
-                                  }
-                                  prod = ir::Div::Make(prod, extent);
-                                  std::vector<Expr> new_shape{prod};
-                                  (*global_tensor_map)[statement]->buffer->shape = new_shape;
-                                } */
-              }
-            }
             Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
             VLOG(2) << "gpu replacing var " << cuda_var->name << " to Expr(0)";
             optim::CUDAReplaceIndexOfCachePass(expr, var_expr, ir::Expr(0), global_tensor_map, false, extent);
@@ -205,23 +189,6 @@ void MarkGpuForloop(const std::string &statement,
             Expr var_expr(cuda_var);
             VLOG(2) << "gpu replacing var " << axis_var->name << " to " << cuda_var->name;
             optim::ReplaceVarWithExpr(expr, axis_var, var_expr);
-            if ((utils::Endswith(statement, "_read_cache") || utils::Endswith(statement, "_cache_write_out")) &&
-                (*global_tensor_map).count(statement) > 0) {
-              if (((*global_tensor_map)[statement]->buffer->memory_type == ir::MemoryType::GPULocal) ||
-                  ((*global_tensor_map)[statement]->buffer->memory_type == ir::MemoryType::GPUShared)) {
-                /*                 Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
-                                if (extent.defined()) {
-                                  auto buffer_shape = (*global_tensor_map)[statement]->buffer->shape;
-                                  Expr prod(1);
-                                  for (auto i : buffer_shape) {
-                                    prod = ir::Mul::Make(prod, i);
-                                  }
-                                  prod = ir::Div::Make(prod, extent);
-                                  std::vector<Expr> new_shape{prod};
-                                  (*global_tensor_map)[statement]->buffer->shape = new_shape;
-                                } */
-              }
-            }
             Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
             VLOG(3) << "gpu replacing var " << cuda_var->name << " to Expr(0)";
             optim::CUDAReplaceIndexOfCachePass(expr, var_expr, ir::Expr(0), global_tensor_map, true, extent);

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -184,21 +184,22 @@ void MarkGpuForloop(const std::string &statement,
             if ((utils::Endswith(statement, "_read_cache") || utils::Endswith(statement, "_cache_write_out")) &&
                 (*global_tensor_map).count(statement) > 0) {
               if ((*global_tensor_map)[statement]->buffer->memory_type == ir::MemoryType::GPULocal) {
-                Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
-                if (extent.defined()) {
-                  auto buffer_shape = (*global_tensor_map)[statement]->buffer->shape;
-                  Expr prod(1);
-                  for (auto i : buffer_shape) {
-                    prod = ir::Mul::Make(prod, i);
-                  }
-                  prod = ir::Div::Make(prod, extent);
-                  std::vector<Expr> new_shape{prod};
-                  (*global_tensor_map)[statement]->buffer->shape = new_shape;
-                }
+                /*                 Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
+                                if (extent.defined()) {
+                                  auto buffer_shape = (*global_tensor_map)[statement]->buffer->shape;
+                                  Expr prod(1);
+                                  for (auto i : buffer_shape) {
+                                    prod = ir::Mul::Make(prod, i);
+                                  }
+                                  prod = ir::Div::Make(prod, extent);
+                                  std::vector<Expr> new_shape{prod};
+                                  (*global_tensor_map)[statement]->buffer->shape = new_shape;
+                                } */
               }
             }
+            Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
             VLOG(2) << "gpu replacing var " << cuda_var->name << " to Expr(0)";
-            optim::CUDAReplaceIndexOfCachePass(expr, var_expr, ir::Expr(0), global_tensor_map, false);
+            optim::CUDAReplaceIndexOfCachePass(expr, var_expr, ir::Expr(0), global_tensor_map, false, extent);
           } else if (it->second.for_type == ir::ForType::GPUBlock) {
             Var cuda_var(backends::cuda_block_axis_name(forloop_info.offset));
             Expr var_expr(cuda_var);
@@ -208,21 +209,22 @@ void MarkGpuForloop(const std::string &statement,
                 (*global_tensor_map).count(statement) > 0) {
               if (((*global_tensor_map)[statement]->buffer->memory_type == ir::MemoryType::GPULocal) ||
                   ((*global_tensor_map)[statement]->buffer->memory_type == ir::MemoryType::GPUShared)) {
-                Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
-                if (extent.defined()) {
-                  auto buffer_shape = (*global_tensor_map)[statement]->buffer->shape;
-                  Expr prod(1);
-                  for (auto i : buffer_shape) {
-                    prod = ir::Mul::Make(prod, i);
-                  }
-                  prod = ir::Div::Make(prod, extent);
-                  std::vector<Expr> new_shape{prod};
-                  (*global_tensor_map)[statement]->buffer->shape = new_shape;
-                }
+                /*                 Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
+                                if (extent.defined()) {
+                                  auto buffer_shape = (*global_tensor_map)[statement]->buffer->shape;
+                                  Expr prod(1);
+                                  for (auto i : buffer_shape) {
+                                    prod = ir::Mul::Make(prod, i);
+                                  }
+                                  prod = ir::Div::Make(prod, extent);
+                                  std::vector<Expr> new_shape{prod};
+                                  (*global_tensor_map)[statement]->buffer->shape = new_shape;
+                                } */
               }
             }
+            Expr extent = for_ ? for_->extent : poly_for->ExtractExtent();
             VLOG(3) << "gpu replacing var " << cuda_var->name << " to Expr(0)";
-            optim::CUDAReplaceIndexOfCachePass(expr, var_expr, ir::Expr(0), global_tensor_map, true);
+            optim::CUDAReplaceIndexOfCachePass(expr, var_expr, ir::Expr(0), global_tensor_map, true, extent);
           } else {
             CINN_NOT_IMPLEMENTED
           }


### PR DESCRIPTION
增加CacheRead和CacheWrite的使用测试；
修复compute at导致的cache_read/cache_write 临时变量分配空间错误bug。
问题描述：
当使用ComputeAt调度原语时，会出现一个for loop中有多个赋值语句。此多个赋值语句的statement会变为同一个，如果根据statement名称判定是否为临时变量，会导致遗漏。
解决方案：
不根据statement名称来找临时变量并进行buffer shape的修改，改为在Store语句中寻找CacheRead和CacheWrite创建的临时tensor，并根据其对block, thread的绑定修改其buffer shape。
最终效果：
修改前代码生成：
```
__global__
void elementwise_add1(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
{
  float _A_read_cache_read_cache [ 100 * 200 ];
  float _A_read_cache [ ((1 * (((1 * 100) * 200) / 100)) / 200) ];
  float* A_read_cache = _A_read_cache;
  float* A_read_cache_read_cache = _A_read_cache_read_cache;
  if ((blockIdx.x < 100)) {
  {
    if ((threadIdx.x < 200)) {
    {
      A_read_cache[0] = A[((200 * blockIdx.x) + threadIdx.x)];
    }
    };
  }
  };
  if ((blockIdx.x < 100)) {
  {
    if ((threadIdx.x < 200)) {
    {
      A_read_cache_read_cache[0] = A_read_cache[0];
      C[((200 * blockIdx.x) + threadIdx.x)] = (A_read_cache_read_cache[0] + B[((200 * blockIdx.x) + threadIdx.x)]);
    }
    };
  }
  };
}
```

修改后代码生成：
```
__global__
void elementwise_add1(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
{
  float _A_read_cache_read_cache [ ((1 * (((1 * 100) * 200) / 100)) / 200) ];
  float _A_read_cache [ ((1 * (((1 * 100) * 200) / 100)) / 200) ];
  float* A_read_cache = _A_read_cache;
  float* A_read_cache_read_cache = _A_read_cache_read_cache;
  if ((blockIdx.x < 100)) {
  {
    if ((threadIdx.x < 200)) {
    {
      A_read_cache[0] = A[((200 * blockIdx.x) + threadIdx.x)];
    }
    };
  }
  };
  if ((blockIdx.x < 100)) {
  {
    if ((threadIdx.x < 200)) {
    {
      A_read_cache_read_cache[0] = A_read_cache[0];
      C[((200 * blockIdx.x) + threadIdx.x)] = (A_read_cache_read_cache[0] + B[((200 * blockIdx.x) + threadIdx.x)]);
    }
    };
  }
  };
}
```