### PR TITLE
optimize softmax compute

### DIFF
--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -279,13 +279,28 @@ ir::Tensor BatchNorm_NCHW(const ir::Tensor &input,
  * @return The calculated output tensor.
  */
 std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string &output_name) {
+#ifdef CINN_WITH_CUDA
+  Var axis_j(A->shape[axis], UniqName("axis_j"));
+  auto temp = Compute(
+      A->shape,
+      [=](const std::vector<Expr> &indice) {
+        std::vector<Expr> new_indice = indice;
+        new_indice[axis]             = axis_j;
+        return lang::ReduceSum(lang::Exp(A(new_indice)), {axis_j});
+      },
+      UniqName("softmax_temp_out"));
+  ir::Tensor out = Compute(
+      A->shape,
+      [=](const std::vector<Expr> &indice) { return lang::Exp(A(indice)) / temp(indice); },
+      UniqName("softmax_out"));
+  return {temp, out};
+#else
   if (axis == -1) {
     axis = A->shape.size() - 1;
   }
   Var reduce_axis(A->shape[axis], UniqName("reduce_axis"));
   std::vector<Expr> new_shapes;
-  for (size_t i = 0; i < A->shape.size(); i++)
-  {
+  for (size_t i = 0; i < A->shape.size(); i++) {
     if (static_cast<int>(i) != axis) {
       new_shapes.push_back(A->shape[i]);
     }
@@ -295,12 +310,11 @@ std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string
       [=](const std::vector<Expr> &indice) {
         std::vector<Expr> new_indice;
         int count = 0;
-        for (size_t i = 0; i < A->shape.size(); i++)
-        {
+        for (size_t i = 0; i < A->shape.size(); i++) {
           if (static_cast<int>(i) != axis) {
             new_indice.push_back(indice[count++]);
           } else {
-             new_indice.push_back(reduce_axis);
+            new_indice.push_back(reduce_axis);
           }
         }
         return lang::ReduceSum(lang::Exp(A(new_indice)), {reduce_axis});
@@ -311,15 +325,16 @@ std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string
       A->shape,
       [=](const std::vector<Expr> &indice) {
         std::vector<Expr> new_indice;
-        for (size_t i = 0; i < indice.size(); i++)
-        {
-          if(static_cast<int>(i) != axis) {
+        for (size_t i = 0; i < indice.size(); i++) {
+          if (static_cast<int>(i) != axis) {
             new_indice.push_back(indice[i]);
           }
         }
-        return lang::Exp(A(indice)) / temp(new_indice); },
+        return lang::Exp(A(indice)) / temp(new_indice);
+      },
       UniqName("softmax_out"));
   return {temp, out};
+#endif
 }
 
 ir::Tensor Slice(const ir::Tensor &A,

--- a/cinn/hlir/pe/nn.h
+++ b/cinn/hlir/pe/nn.h
@@ -214,7 +214,7 @@ ir::Tensor Pad(const ir::Tensor &tensor,
                const std::string &name     = UniqName("T_pad_out"),
                const std::string &pad_mode = "constant");
 
-std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string &output_name);
+std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis=-1, const std::string &output_name= UniqName("T_softmax_out"));
 
 ir::Tensor Slice(const ir::Tensor &A,
                  const std::vector<int> &starts,

--- a/cinn/ir/tensor.cc
+++ b/cinn/ir/tensor.cc
@@ -234,9 +234,11 @@ ir::Tensor _Tensor_::InitReduction(poly::StageMap stages, const Target &target) 
       shape, [=](const std::vector<Expr> &axis) { return GetReduceInitVal(); }, init_reduce_tensor_name);
   stages->InsertLazily(init_tensor);
   if (target.arch == Target::Arch::NVGPU) {
-    stages[init_tensor]->Split(1, 2);
-    stages[init_tensor]->Bind(0, "blockIdx.x");
-    stages[init_tensor]->Bind(1, "threadIdx.x");
+    if (init_tensor->shape.size() > 1) {
+      stages[init_tensor]->Split(1, 2);
+      stages[init_tensor]->Bind(0, "blockIdx.x");
+      stages[init_tensor]->Bind(1, "threadIdx.x");
+    }
   }
   stages[this]->CtrlDepend(init_tensor);
   stages[this]->ShareBufferWith(stages[init_tensor]);


### PR DESCRIPTION
optimize softmax compute，for  [1024, 2048] case，softmax's benchmark is optimized from 36782.7 ms to 35.0168 ms which will gain more than 500000+% performance benefits.
there is something wrong with softmax compute which will influence its' performance
some of original ir：
 ```
 for (i, 1024)
  {
    for (j, 2048)
    {
      softmax_temp_out__reduce_init[i, j] = 0
    }
  }
  for (i, 1024)
  {
    for (j, 2048)
    {
      for (axis_j, 2048)
      {
        softmax_temp_out[i, j] = (softmax_temp_out[i, j] + cinn_cpu_exp_fp32(input[i, axis_j]))
      }
    }
  }
  for (i, 1024)
  {
    for (j, 2048)
    {
      softmax_out[i, j] = (cinn_cpu_exp_fp32(input[i, j]) * (1 / softmax_temp_out[i, j]))
    }
  }
}
```
Input tensor's shape is [1024, 2048] and j is the reduce axis. So j axis is redundant which will result in more computations.
optimized ir：
```
  for (i, 1024)
  {
    for (j, 2048)
    {
      softmax_temp_out__reduce_init[i, j] = 0
    }
  }
  for (i, 1024)
  {
      for (axis_j, 2048)
      {
        softmax_temp_out[i] = (softmax_temp_out[i] + cinn_cpu_exp_fp32(input[i, axis_j]))
      }
  }
  for (i, 1024)
  {
    for (j, 2048)
    {
      softmax_out[i, j] = (cinn_cpu_exp_fp32(input[i, j]) * (1 / softmax_temp_out[i]))
    }
  }
}
```