### PR TITLE
add SyncThreads and corresponding tests

### DIFF
--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -1081,6 +1081,7 @@ std::shared_ptr<OpStrategy> StrategyForSoftmax(const framework::NodeAttr &attrs,
         stages[tensor_b]->Bind(0, "blockIdx.x");
         stages[tensor_b]->Bind(1, "threadIdx.x");
       }
+      stages[tensor_a]->SyncThreads({tensor_b}, stages);
     }
     *ret = arg_pack;
   });

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -279,22 +279,6 @@ ir::Tensor BatchNorm_NCHW(const ir::Tensor &input,
  * @return The calculated output tensor.
  */
 std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string &output_name) {
-#ifdef CINN_WITH_CUDA
-  Var axis_j(A->shape[axis], UniqName("axis_j"));
-  auto temp = Compute(
-      A->shape,
-      [=](const std::vector<Expr> &indice) {
-        std::vector<Expr> new_indice = indice;
-        new_indice[axis]             = axis_j;
-        return lang::ReduceSum(lang::Exp(A(new_indice)), {axis_j});
-      },
-      UniqName("softmax_temp_out"));
-  ir::Tensor out = Compute(
-      A->shape,
-      [=](const std::vector<Expr> &indice) { return lang::Exp(A(indice)) / temp(indice); },
-      UniqName("softmax_out"));
-  return {temp, out};
-#else
   if (axis == -1) {
     axis = A->shape.size() - 1;
   }
@@ -334,7 +318,6 @@ std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string
       },
       UniqName("softmax_out"));
   return {temp, out};
-#endif
 }
 
 ir::Tensor Slice(const ir::Tensor &A,

--- a/cinn/ir/tensor.cc
+++ b/cinn/ir/tensor.cc
@@ -413,7 +413,7 @@ std::vector<Var> _Tensor_::axis_with_reduce() const {
   return axis;
 }
 
-bool _Tensor_::Uses(const Tensor &other) {
+bool _Tensor_::Uses(const Tensor &other) const {
   auto loads = ir::CollectIRNodes(body(), [&](const Expr *x) {
     auto *loadn = x->As<ir::Load>();
     if (!loadn) return false;

--- a/cinn/ir/tensor.h
+++ b/cinn/ir/tensor.h
@@ -240,7 +240,7 @@ class _Tensor_ : public ExprNode<_Tensor_> {
   /**
    * Tell if this tensor uses other tensors in the body.
    */
-  bool Uses(const ir::Tensor& other);
+  bool Uses(const ir::Tensor& other) const;
 
   //! Bind to a buffer, will persist data to the buffer in runtime.
   void Bind(lang::Buffer& buffer);  // NOLINT

--- a/cinn/poly/stage.h
+++ b/cinn/poly/stage.h
@@ -245,6 +245,15 @@ class Stage : public Object {
   ir::Tensor CacheWrite2(const std::string& memory_type, poly::StageMap stages);
 
   /**
+   * Generate the `syncthreads()` code to sync all threads on CUDA backends.
+   * For other backends like Opencl, generate corresponding code to sync multi threads.
+   * @param tensor the exact tensor computed just before syncthreads.
+   * @param after_tensors the tensors computed after syncthreads.
+   * @param stages the stagemap of all tensor.
+   */
+  void SyncThreads(const std::vector<ir::Tensor>& after_tensors, StageMap stages);
+
+  /**
    * Set thread scope.
    */
   void SetScope(ScopeKind scope) { scope_ = scope; }


### PR DESCRIPTION
在PR319的基础上添加了SyncThreads调度原语，保证了代码正确性。并添加了相关的测试
问题描述：
同kernel内当threads绑定不同时，会使多线程之间有依赖，不进行同步会导致计算结果错误。
解决方法：
新添加原语SyncThreads，用于在用户指定的位置生成同步多线程的代码，保证正确性。
举例：
CUDA端会生成syncthreads()
Opencl端会生成barrier(CLK_LOCAL_MEM_FENCE)