### PR TITLE
optimize relu, relu6; optimize schedule with ugly shape

### DIFF
--- a/cinn/backends/codegen_c_x86.cc
+++ b/cinn/backends/codegen_c_x86.cc
@@ -14,13 +14,11 @@ void CodeGenCX86::Visit(const ir::Load *op) {
     CHECK(op->type().is_vector());
 
     int bits = op->type().bits() * op->type().lanes();
-    if (SupportsAVX512()) {
-      CHECK_EQ(bits, 512);
+    if (SupportsAVX512() && bits == 512) {
       os() << "cinn_avx512_load(";
       PrintAbsAddr(op);
       os() << ")";
-    } else if (SupportsAVX256()) {
-      CHECK_EQ(bits, 256);
+    } else if (SupportsAVX256() && bits == 256) {
       os() << "cinn_avx256_load(";
       PrintAbsAddr(op);
       os() << ")";
@@ -36,13 +34,11 @@ void CodeGenCX86::Visit(const ir::Broadcast *op) {
   CHECK_GT(op->type().lanes(), 1);
   int bits = op->type().bits() * op->type().lanes();
 
-  if (SupportsAVX512()) {
-    CHECK_EQ(bits, 512);
+  if (SupportsAVX512() && bits == 512) {
     os() << "cinn_avx512_set1(";
     PrintCastExpr(op->value.type().ElementOf(), op->value);
     os() << ")";
-  } else if (SupportsAVX256()) {
-    CHECK_EQ(bits, 256);
+  } else if (SupportsAVX256() && bits == 256) {
     os() << "cinn_avx256_set1(";
     PrintCastExpr(op->value.type().ElementOf(), op->value);
     os() << ")";
@@ -58,15 +54,13 @@ void CodeGenCX86::Visit(const ir::Store *op) {
   }
 
   int bits = op->type().bits() * op->type().lanes();
-  if (SupportsAVX512()) {
-    CHECK_EQ(bits, 512);
+  if (SupportsAVX512() && bits == 512) {
     os() << "cinn_avx512_store(";
     PrintAbsAddr(op);
     os() << ", ";
     Print(op->value);
     os() << ")";
-  } else if (SupportsAVX256()) {
-    CHECK_EQ(bits, 256);
+  } else if (SupportsAVX256() && bits == 256) {
     os() << "cinn_avx256_store(";
     PrintAbsAddr(op);
     os() << ", ";

--- a/cinn/backends/codegen_c_x86.h
+++ b/cinn/backends/codegen_c_x86.h
@@ -95,22 +95,20 @@ void CodeGenCX86::VisitBinaryOp(const Op *op, Expr a, Expr b, const std::string 
 
   // TODO(Superjomn) Consider support BLAS.
   int bits = a.type().bits() * a.type().lanes();
-  if (SupportsAVX512()) {
-    CHECK_EQ(bits, 512) << "the bits of computation should be times of 512";
+  if (SupportsAVX512() && bits == 512) {
     os() << "cinn_avx512_" << op_repr << "(";
     PrintVecInputArgument(&a);
     os() << ", ";
     PrintVecInputArgument(&b);
     os() << ")";
-  } else if (SupportsAVX256()) {
-    CHECK_EQ(bits, 256) << "the bits of computation should be times of 256";
+  } else if (SupportsAVX256() && bits == 256) {
     os() << "cinn_avx256_" << op_repr << "(";
     PrintVecInputArgument(&a);
     os() << ", ";
     PrintVecInputArgument(&b);
     os() << ")";
   } else {
-    CINN_NOT_IMPLEMENTED
+    CodeGenC::Visit(op);
   }
 }
 

--- a/cinn/backends/llvm/codegen_llvm.cc
+++ b/cinn/backends/llvm/codegen_llvm.cc
@@ -803,7 +803,7 @@ llvm::Value *CodeGenLLVM::Visit(const ir::Store *op) {
         auto *vtype =
             llvm::VectorType::get(ll_type_of(op->type().ElementOf()), llvm::ElementCount(lanes, false /*Scalable*/))
                 ->getPointerTo();
-        int alignment = lanes * op->type().ElementOf().bits() / 8;
+        int alignment = std::max(op->type().ElementOf().bits() / 8, 1);
         llvm::StoreInst *inst =
             b_->CreateAlignedStore(CreateVecSlice(value, offset, lanes), b_->CreatePointerCast(ptr, vtype), alignment);
         AddTbaaMetadata(inst, op->tensor.as_tensor()->name, base);
@@ -1086,7 +1086,7 @@ llvm::Value *CodeGenLLVM::DenseVectorLoad(const ir::Load *op) {
     llvm::Value *elt_ptr = CreateBufferPtr(op->type().ElementOf(), buffer, Visit(&slice_base));
     llvm::Value *vec_ptr = b_->CreatePointerCast(elt_ptr, slice_type->getPointerTo(), "get_vec_ptr");
 
-    int alignment = slice_lanes * op->type().ElementOf().bits() / 8;
+    int alignment = std::max(op->type().ElementOf().bits() / 8, 1);
 
     llvm::Instruction *load_inst = b_->CreateAlignedLoad(vec_ptr, llvm::Align(alignment), "load_vec");
     AddTbaaMetadata(load_inst, op->tensor.as_tensor()->name, op->index());

--- a/cinn/hlir/framework/tensor.h
+++ b/cinn/hlir/framework/tensor.h
@@ -49,7 +49,7 @@ class _Tensor_ : public Object {
   inline T* mutable_data(const Target& target) {
     set_type(type_of<T>());
     if (target == common::DefaultHostTarget()) {
-      int alignment = target.get_target_bits() * 8;
+      int alignment = type_of<T>().ElementOf().bits();
       buffer_->ResizeLazy(alignment, shape_.numel() * sizeof(T), target);
     } else {
       buffer_->ResizeLazy(shape_.numel() * sizeof(T), target);

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -40,10 +40,15 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     CINNValuePack arg_pack = args[0];
     CHECK_EQ(arg_pack.size(), 2UL);
     if (target.arch == Target::Arch::NVGPU) {
-      Expr Out              = arg_pack[0];
+      Expr out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
-      CHECK(Out.as_tensor());
-      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
+      CHECK(out.as_tensor());
+      pe::CudaScheduleInjective(stages[out.as_tensor_ref()], output_shapes.back(), target);
+    } else if (target.arch == Target::Arch::X86) {
+      Expr out              = arg_pack[0];
+      poly::StageMap stages = arg_pack[1];
+      CHECK(out.as_tensor());
+      pe::ScheduleInjectiveCPU(stages[out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });
@@ -92,10 +97,15 @@ std::shared_ptr<OpStrategy> StrategyForRelu6(const framework::NodeAttr &attrs,
     CINNValuePack arg_pack = args[0];
     CHECK_EQ(arg_pack.size(), 2UL);
     if (target.arch == Target::Arch::NVGPU) {
-      Expr Out              = arg_pack[0];
+      Expr out              = arg_pack[0];
       poly::StageMap stages = arg_pack[1];
-      CHECK(Out.as_tensor());
-      pe::CudaScheduleInjective(stages[Out.as_tensor_ref()], output_shapes.back(), target);
+      CHECK(out.as_tensor());
+      pe::CudaScheduleInjective(stages[out.as_tensor_ref()], output_shapes.back(), target);
+    } else if (target.arch == Target::Arch::X86) {
+      Expr out              = arg_pack[0];
+      poly::StageMap stages = arg_pack[1];
+      CHECK(out.as_tensor());
+      pe::ScheduleInjectiveCPU(stages[out.as_tensor_ref()], output_shapes.back(), target);
     }
     *ret = arg_pack;
   });

--- a/cinn/hlir/pe/nn.h
+++ b/cinn/hlir/pe/nn.h
@@ -214,7 +214,9 @@ ir::Tensor Pad(const ir::Tensor &tensor,
                const std::string &name     = UniqName("T_pad_out"),
                const std::string &pad_mode = "constant");
 
-std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis=-1, const std::string &output_name= UniqName("T_softmax_out"));
+std::vector<ir::Tensor> Softmax(const ir::Tensor &A,
+                                int axis                       = -1,
+                                const std::string &output_name = UniqName("T_softmax_out"));
 
 ir::Tensor Slice(const ir::Tensor &A,
                  const std::vector<int> &starts,

--- a/cinn/optim/vectorize_loops_test.cc
+++ b/cinn/optim/vectorize_loops_test.cc
@@ -65,7 +65,7 @@ void matmul(void* _args, int32_t num_args)
   const float* B = ((const float*)(_B->memory));
   float* C = ((float*)(_C->memory));
   for (int32_t i = 0; i < 100; i += 1) {
-    for (int32_t j = 0; j < 31; j += 1) {
+    for (int32_t j = 0; j < 32; j += 1) {
       C[StackVec<16,int32_t>::Ramp(((500 * i) + (16 * j)), 1, 16)] = (StackedVec<float,16>::Load(A,((500 * i) + (16 * j))) * StackedVec<float,16>::Load(B,((500 * i) + (16 * j))));
     };
   };
@@ -136,11 +136,13 @@ void matmul(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, stru
   float* D = (float*)(_C->memory);
   for (int32_t i = 0; i < 100; i += 1) {
     for (int32_t j_outer = 0; j_outer < 31; j_outer += 1) {
-      C[StackVec<16,int32_t>::Ramp(((500 * i) + (16 * j_outer)), 1, 16)] = (StackedVec<float,16>::Load(A,((500 * i) + (16 * j_outer))) * StackedVec<float,16>::Load(B,((500 * i) + (16 * j_outer))));
+      C[StackVec<16,int32_t>::Ramp(((500 * i) + (16 * j_outer)), 1, 16)] = (StackedVec<float,16>::Load(A,((500 * i) +
+      (16 * j_outer))) * StackedVec<float,16>::Load(B,((500 * i) + (16 * j_outer))));
     };
     for (int32_t j_outer = 31; j_outer < 32; j_outer += 1) {
       for (int32_t j_inner = 0; j_inner < (500 + (-16 * j_outer)); j_inner += 1) {
-        C[((500 * i) + ((16 * j_outer) + j_inner))] = (A[((500 * i) + ((16 * j_outer) + j_inner))] * B[((500 * i) + ((16 * j_outer) + j_inner))]);
+        C[((500 * i) + ((16 * j_outer) + j_inner))] = (A[((500 * i) + ((16 * j_outer) + j_inner))] * B[((500 * i) +
+        ((16 * j_outer) + j_inner))]);
       };
     };
   };

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -69,7 +69,7 @@ class SingleOpTester(unittest.TestCase):
         temp_inputs = []
         alignment = 0
         if self.target.arch == common.Target.Arch.X86:
-            alignment = 512
+            alignment = 32
         for in_data in inputs_data:
             temp_inputs.append(
                 runtime.cinn_buffer_t(in_data, runtime.cinn_x86_device,

--- a/tests/benchmark/test_utils.cc
+++ b/tests/benchmark/test_utils.cc
@@ -103,14 +103,14 @@ Module OpBenchmarkTester::CreateCinnModule(const std::vector<Tensor>& input_tens
 void OpBenchmarkTester::CreateBuffer() {
   std::vector<cinn_pod_value_t> args;
   for (size_t i = 0; i < input_shapes_.size(); i++) {
-    auto* buffer = common::BufferBuilder(input_types_[i], input_shapes_[i]).set_align(512).set_random().Build();
+    auto* buffer = common::BufferBuilder(input_types_[i], input_shapes_[i]).set_align(32).set_random().Build();
     cinn_pod_value_t arg(buffer);
     all_args_.push_back(arg);
   }
   CHECK(!output_shapes_.empty()) << "output shapes shouldn't be empty\n";
   CHECK_EQ(output_shapes_.size(), out_types_.size());
   for (size_t i = 0; i < output_shapes_.size(); i++) {
-    auto* buffer = common::BufferBuilder(out_types_[i], output_shapes_[i]).set_align(512).set_zero().Build();
+    auto* buffer = common::BufferBuilder(out_types_[i], output_shapes_[i]).set_align(32).set_zero().Build();
     CHECK(buffer);
     out_dims_ = buffer->num_elements();
     cinn_pod_value_t arg(buffer);


### PR DESCRIPTION
For shape like [2, 512, 7, 7], the last shape is not friendly to vectorize.
We try to find a better split factor to vectorize temporily, which is the nearest shape of the power of two larger than the last shape. It's relatively a better solution for most of the case although may not the best for some. In this case, for the last shape 7, we vectorize by a factor of 8. 
By applying the stragegy as above, relu op with the shape of [2, 512, 7, 7] can be optimized from 0.0324 to 0.00926 ms, gainging nearly 185% performance benefits.