### PR TITLE
optimize mul's compute for better schedule

### DIFF
--- a/cinn/hlir/pe/transform.h
+++ b/cinn/hlir/pe/transform.h
@@ -39,6 +39,24 @@ ir::Tensor Matmul(const ir::Tensor& A,
                   int y_num_col_dims      = 1,
                   const std::string& name = UniqName("T_Transform_Matmul_out"));
 
+int GetMulReduceFactor(int reduce_shape, const Type& type, const common::Target& target);
+
+/**
+ * @brief basic PE that calculates a matrix multiplication
+ *
+ * @param A The first input tensor, [M, K]
+ * @param B The second input tensor, [N, K]
+ * @param name The name of the operation
+ * @param target if target is x86, we will split the reduce axis
+ *
+ * @return the output tensor
+Notes: this mul only support two-dims-tensor after flattening [M, K] * [N, K], K is the reduce axis
+ */
+std::vector<ir::Tensor> MulBase(const ir::Tensor& A,
+                                const ir::Tensor& B,
+                                const std::string& name      = UniqName("T_Transform_MulBase_out"),
+                                const common::Target& target = common::DefaultHostTarget());
+
 ir::Tensor Mul(const ir::Tensor& A,
                const ir::Tensor& B,
                int x_num_col_dims,

--- a/tests/benchmark/test_all_ops_default.cc
+++ b/tests/benchmark/test_all_ops_default.cc
@@ -90,14 +90,14 @@ TEST_DEFAULT(elementwise_add, add5_1, type1, type)
 TEST_DEFAULT(elementwise_add, add5_2, type1, type)
 TEST_DEFAULT(elementwise_add, add5_3, type1, type)
 // mul
-// std::vector<std::vector<int>> shapes_mul = {{1024, 1024, 1024}, {1024, 1024, 1024}};
-// TEST_DEFAULT(elementwise_mul, mul, type1, type)
-std::vector<std::vector<int>> shapes_mul1 = {{100, 32}, {100, 32}};
-TEST_DEFAULT(elementwise_mul, mul1, type1, type)
-std::vector<std::vector<int>> shapes_mul2 = {{1024, 14, 14}, {1024, 14, 14}};
-TEST_DEFAULT(elementwise_mul, mul2, type1, type)
-std::vector<std::vector<int>> shapes_mul3 = {{1}, {1}};
-TEST_DEFAULT(elementwise_mul, mul3, type1, type)
+std::vector<std::vector<int>> shapes_elementwise_mul = {{1024, 1024, 1024}, {1024, 1024, 1024}};
+TEST_DEFAULT(elementwise_mul, elementwise_mul, type1, type)
+std::vector<std::vector<int>> shapes_elementwise_mul1 = {{100, 32}, {100, 32}};
+TEST_DEFAULT(elementwise_mul, elementwise_mul1, type1, type)
+std::vector<std::vector<int>> shapes_elementwise_mul2 = {{1024, 14, 14}, {1024, 14, 14}};
+TEST_DEFAULT(elementwise_mul, elementwise_mul2, type1, type)
+std::vector<std::vector<int>> shapes_elementwise_mul3 = {{1}, {1}};
+TEST_DEFAULT(elementwise_mul, elementwise_mul3, type1, type)
 
 // relu
 std::vector<std::vector<int>> shapes_relu = {{2, 512, 7, 7}};
@@ -159,12 +159,22 @@ TEST_DEFAULT(sigmoid, sigmoid1, type, type)
 // matmul
 std::vector<std::vector<int>> shapes_matmul = {{32, 32}, {32, 32}};
 TEST_DEFAULT(matmul, matmul, type1, type)
-// std::vector<std::vector<int>> shapes_matmul1 = {{512,512}, {512,512}};
-// TEST_DEFAULT(matmul, matmul1, type1, type)
-// std::vector<std::vector<int>> shapes_matmul2 = {{100,32}, {32,100}};
-// TEST_DEFAULT(matmul, matmul2, type1, type)
-// std::vector<std::vector<int>> shapes_matmul3 = {{1024,1024}, {1024,1024}};
-// TEST_DEFAULT(matmul, matmul3, type1, type)
+std::vector<std::vector<int>> shapes_matmul1 = {{512, 512}, {512, 512}};
+TEST_DEFAULT(matmul, matmul1, type1, type)
+std::vector<std::vector<int>> shapes_matmul2 = {{100, 32}, {32, 100}};
+TEST_DEFAULT(matmul, matmul2, type1, type)
+std::vector<std::vector<int>> shapes_matmul3 = {{1024, 1024}, {1024, 1024}};
+TEST_DEFAULT(matmul, matmul3, type1, type)
+
+// matrix mul
+std::vector<std::vector<int>> shapes_mul = {{32, 32}, {32, 32}};
+TEST_DEFAULT(mul, mul, type1, type1)
+std::vector<std::vector<int>> shapes_mul1 = {{512, 512}, {512, 512}};
+TEST_DEFAULT(mul, mul1, type1, type1)
+std::vector<std::vector<int>> shapes_mul2 = {{100, 32}, {100, 32}};
+TEST_DEFAULT(mul, mul2, type1, type1)
+std::vector<std::vector<int>> shapes_mul3 = {{1024, 1024}, {1024, 1024}};
+TEST_DEFAULT(mul, mul3, type1, type1)
 
 // batchnorm
 std::vector<std::vector<int>> shapes_batchnorm = {{2, 32, 112, 112}, {32}, {32}, {32}, {32}};


### PR DESCRIPTION
optimize mul's compute for better schedule：
1、flatten mul's shape to 2 dim
2、split mul's reduce axis and  compute twice
for shape [1024, 1024], it can be optimized from 3418.75 to 290.575 ms.