### PR TITLE
add mul schedule

### DIFF
--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -311,6 +311,11 @@ std::shared_ptr<OpStrategy> StrategyForMul(const framework::NodeAttr &attrs,
     CHECK(out.as_tensor());
     if (target.arch == Target::Arch::NVGPU) {
       pe::CudaScheduleMul(stages, out.as_tensor_ref(), output_shapes.back(), target);
+    } else if (target.arch == Target::Arch::X86) {
+      CHECK_EQ(arg_pack.size(), 3UL);
+      Expr reduce_first = arg_pack[1];
+      CHECK(reduce_first.as_tensor());
+      pe::MulScheduleCPU(stages, out.as_tensor_ref(), reduce_first.as_tensor_ref(), target);
     }
     *ret = arg_pack;
   });

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -15,6 +15,11 @@ int GetBasicFactor(const Type &type, const common::Target &target);
 
 int GetBetterSplitFactor(int shape, int split_factor);
 
+void MulScheduleCPU(poly::StageMap stage,
+                    const ir::Tensor &output,
+                    const ir::Tensor &input_tensor,
+                    const common::Target &target);
+
 void ScheduleInjectiveCPU(poly::Stage *stage, const std::vector<int> &output_shape, const common::Target &target);
 
 void CudaScheduleMul(poly::StageMap stages,

--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -81,7 +81,7 @@ std::vector<Tensor> Matmul(
 int GetMulReduceFactor(int reduce_shape, const Type& type, const common::Target& target) {
   int split_base   = GetBasicFactor(type, target);
   int split_factor = 1;
-  for (size_t i = split_base * 2; i >= 1; --i) {
+  for (size_t i = split_base; i >= 1; --i) {
     if (reduce_shape % i == 0) {
       split_factor = i;
       break;

--- a/cinn/ir/tensor.cc
+++ b/cinn/ir/tensor.cc
@@ -244,6 +244,10 @@ ir::Tensor _Tensor_::InitReduction(poly::StageMap stages, const Target &target) 
   return init_tensor;
 }
 
+ir::Tensor _Tensor_::GetInitTensor(poly::StageMap stages, const Target &target) const {
+  return InitReduction(stages, target);
+}
+
 Expr _Tensor_::tensor_store_expanded_body() {
   CHECK(!is_placeholder_node()) << "placeholder should not expand store";
 

--- a/cinn/ir/tensor.h
+++ b/cinn/ir/tensor.h
@@ -250,6 +250,7 @@ class _Tensor_ : public ExprNode<_Tensor_> {
   //! Create a buffer belong to this tensor.
   void WithBuffer(const Type& type = Void());
   void WithBuffer(const std::string& memory_type, const Type& type = Void());
+  Tensor GetInitTensor(poly::StageMap stages, const Target& target = common::DefaultHostTarget()) const;
 
  private:
   //! Initialize the axis field after the shape field is assigned.

--- a/cinn/poly/ast_gen.cc
+++ b/cinn/poly/ast_gen.cc
@@ -1,8 +1,9 @@
 #include "cinn/poly/ast_gen.h"
 
+#include <llvm/Support/FormatVariadic.h>
+
 #include <utility>
 
-#include <llvm/Support/FormatVariadic.h>
 #include "cinn/common/common.h"
 #include "cinn/ir/ir.h"
 
@@ -95,8 +96,8 @@ isl::set TransIdentityExtentToContextId(isl::set set) {
     isl::set new_set(res_set.ctx(), set_repr);
 
     res_set = res_set.intersect(new_set);
-    return res_set;
   }
+  return res_set;
 }
 
 isl::union_set TransIdentityExtentToContextId(isl::union_set set) {

--- a/tests/benchmark/test_all_ops_default.cc
+++ b/tests/benchmark/test_all_ops_default.cc
@@ -177,6 +177,10 @@ std::vector<std::vector<int>> shapes_mul2 = {{100, 32}, {100, 32}};
 TEST_DEFAULT(mul, mul2, type1, type1)
 std::vector<std::vector<int>> shapes_mul3 = {{1024, 1024}, {1024, 1024}};
 TEST_DEFAULT(mul, mul3, type1, type1)
+std::vector<std::vector<int>> shapes_mul4 = {{1}, {1}};
+TEST_DEFAULT(mul, mul4, type1, type1)
+std::vector<std::vector<int>> shapes_mul5 = {{1,30}, {1,30}};
+TEST_DEFAULT(mul, mul5, type1, type1)
 
 // batchnorm
 std::vector<std::vector<int>> shapes_batchnorm = {{2, 32, 112, 112}, {32}, {32}, {32}, {32}};


### PR DESCRIPTION
add mul schedule
for shape[1024, 1024], it can be optimized from 290.575 ms to 187.686 ms. 
Without parallel schedule, tvm's inference time is 380.00429625ms. So the schedule can basically meet the requirements.
Next to do is to add parallel schedule.