### PR TITLE
isl for1 wrong elimination after splitting

### DIFF
--- a/tests/test02_helper.h
+++ b/tests/test02_helper.h
@@ -180,6 +180,7 @@ ir::Module CreateMatmulLoopPermutation(Target target, int m, int n, int k_) {
 }
 
 ir::Module CreateMatmulArrayPacking(Target target, int m, int n, int k_) {
+  m=n=k_=16;
   auto [M, N, K] = std::make_tuple(Expr(m), Expr(n), Expr(k_));
 
   Placeholder<float> A("A", {M, K});
@@ -187,7 +188,7 @@ ir::Module CreateMatmulArrayPacking(Target target, int m, int n, int k_) {
 
   Var k(K.as_int32(), "k0");
 
-  Expr bn(32);
+  Expr bn(16);
 
   auto C_init = Compute(
       {M, N}, [&](Var i, Var j) { return Expr(0.f); }, "C_init");
@@ -207,7 +208,7 @@ ir::Module CreateMatmulArrayPacking(Target target, int m, int n, int k_) {
     auto [k_outer, k_inner]                   = stages[C]->Split("k0", 4);                            // NOLINT
 
     stages[C]->Reorder({i_outer, j_outer, k_outer, i_inner, k_inner, j_inner});
-    stages[C]->Vectorize(j_inner, 8);
+    stages[C]->Vectorize(j_inner, 16);
   }
 
   Module::Builder builder("module_array_packing", target);

--- a/tests/test02_matmul_case.cc
+++ b/tests/test02_matmul_case.cc
@@ -129,25 +129,25 @@ TEST(test02, basic) {
   compare();                                                                   \
   reset();
 
-  TEST_FUNC(matmul)
+  // TEST_FUNC(matmul)
 
-  TEST_FUNC(matmul_tile)
+  // TEST_FUNC(matmul_tile)
 
-  TEST_FUNC(matmul_split)
+  // TEST_FUNC(matmul_split)
 
-  TEST_FUNC(matmul_block)
+  // TEST_FUNC(matmul_block)
 
-  TEST_FUNC(matmul_vectorize)
+  // TEST_FUNC(matmul_vectorize)
 
-  TEST_FUNC(matmul_loop_permutation)
+  // TEST_FUNC(matmul_loop_permutation)
 
-  TEST_FUNC1(matmul_array_packing, 1e-5)
+  // TEST_FUNC1(matmul_array_packing, 1e-5)
 
-  TEST_FUNC2(matmul_dynamic_shape, 1e-5);
+  // TEST_FUNC2(matmul_dynamic_shape, 1e-5);
 
-  TEST_FUNC2(matmul_dynamic_shape_tile, 1e-5);
+  // TEST_FUNC2(matmul_dynamic_shape_tile, 1e-5);
 
-  TEST_FUNC3(matmul_array_packing_dynamic_shape, 1e-5);
+  // TEST_FUNC3(matmul_array_packing_dynamic_shape, 1e-5);
 
   // Currently, the execution of a LoweredFunc is scheduled by the outer framework, so no need to Call inside another
   // LoweredFunc.
@@ -175,34 +175,34 @@ TEST(test02, basic) {
   target.bits = cinn::Target::Bit::k32;
   target.os   = cinn::Target::OS::Linux;
 
-  TEST_LLVM_MATMUL(basic, target);
-  TEST_LLVM_MATMUL(tile, target);
-  TEST_LLVM_MATMUL(block, target);
-  TEST_LLVM_MATMUL(vectorize, target);
-  TEST_LLVM_MATMUL(loop_permutation, target);
+  // TEST_LLVM_MATMUL(basic, target);
+  // TEST_LLVM_MATMUL(tile, target);
+  // TEST_LLVM_MATMUL(block, target);
+  // TEST_LLVM_MATMUL(vectorize, target);
+  // TEST_LLVM_MATMUL(loop_permutation, target);
   TEST_LLVM_MATMUL1(array_packing, target);
 
-  {
-    auto module    = cinn::tests::CreateMatmulBasicModule(target, 1024, 1024, 1024);
-    auto jit       = cinn::tests::CreateSimpleJit(module);
-    auto matmul_fn = reinterpret_cast<void (*)(void**, int32_t)>(jit->Lookup("matmul_basic"));
-    TEST_FUNC(matmul_fn);
-  }
+  // {
+  //   auto module    = cinn::tests::CreateMatmulBasicModule(target, 1024, 1024, 1024);
+  //   auto jit       = cinn::tests::CreateSimpleJit(module);
+  //   auto matmul_fn = reinterpret_cast<void (*)(void**, int32_t)>(jit->Lookup("matmul_basic"));
+  //   TEST_FUNC(matmul_fn);
+  // }
 
 #undef TEST_LLVM_MATMUL
 }
 
 // include the generated C source code:
 // @{
-#include "tests/test02_matmul.cc"
-#include "tests/test02_matmul_array_packing.cc"
-#include "tests/test02_matmul_array_packing_dynamic_shape.cc"
-#include "tests/test02_matmul_block.cc"
-#include "tests/test02_matmul_call.cc"
-#include "tests/test02_matmul_loop_permutation.cc"
-#include "tests/test02_matmul_split.cc"
-#include "tests/test02_matmul_tile.cc"
-#include "tests/test02_matmul_varient_shape.cc"
-#include "tests/test02_matmul_varient_shape_tile.cc"
-#include "tests/test02_matmul_vectorize.cc"
+// #include "tests/test02_matmul.cc"
+// #include "tests/test02_matmul_array_packing.cc"
+// #include "tests/test02_matmul_array_packing_dynamic_shape.cc"
+// #include "tests/test02_matmul_block.cc"
+// #include "tests/test02_matmul_call.cc"
+// #include "tests/test02_matmul_loop_permutation.cc"
+// #include "tests/test02_matmul_split.cc"
+// #include "tests/test02_matmul_tile.cc"
+// #include "tests/test02_matmul_varient_shape.cc"
+// #include "tests/test02_matmul_varient_shape_tile.cc"
+// #include "tests/test02_matmul_vectorize.cc"
 // @}


### PR DESCRIPTION
isl for1 wrong elimination after splitting
执行test02_matmul_case
i_outer和j_outer是for1，isl错误消除，导致最后一个轴vectorize根据level找不到for轴