### PR TITLE
add llvm fmuladd intrinsic and codegenC support

### DIFF
--- a/cinn/backends/_x86_builtin_source.cc
+++ b/cinn/backends/_x86_builtin_source.cc
@@ -3,6 +3,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <immintrin.h>
+#include <math.h>
 #include <stdint.h>
 
 #include <vector>
@@ -337,6 +338,20 @@ inline __m256 cinn_avx256_mul(const __m256& a, const __m256& b) { return _mm256_
 inline __m256d cinn_avx256_mul(const __m256d& a, const __m256d& b) { return _mm256_mul_pd(a, b); }
 inline __m512 cinn_avx512_mul(const __m512& a, const __m512& b) { return _mm512_mul_ps(a, b); }
 inline __m512d cinn_avx512_mul(const __m512d& a, const __m512d& b) { return _mm512_mul_pd(a, b); }
+// @}
+
+//! fma
+// @{
+inline __m128 cinn_avx128_fma(const __m128& a, const __m128& b, const __m128& c) { return _mm_fmadd_ps(a, b, c); }
+inline __m128d cinn_avx128_fma(const __m128d& a, const __m128d& b, const __m128d& c) { return _mm_fmadd_pd(a, b, c); }
+inline __m256 cinn_avx256_fma(const __m256& a, const __m256& b, const __m256& c) { return _mm256_fmadd_ps(a, b, c); }
+inline __m256d cinn_avx256_fma(const __m256d& a, const __m256d& b, const __m256d& c) {
+  return _mm256_fmadd_pd(a, b, c);
+}
+inline __m512 cinn_avx512_fma(const __m512& a, const __m512& b, const __m512& c) { return _mm512_fmadd_ps(a, b, c); }
+inline __m512d cinn_avx512_fma(const __m512d& a, const __m512d& b, const __m512d& c) {
+  return _mm512_fmadd_pd(a, b, c);
+}
 // @}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -671,8 +671,7 @@ void CodeGenC::Visit(const ir::intrinsics::ArgsConstruct *op) {
   os() << ")";
 }
 
-void CodeGenC::Visit(const ir::intrinsics::UnaryIntrin *op) {
-  os() << runtime::intrisic::unary_intrin_repr << "_";
+void CodeGenC::Visit(const ir::intrinsics::LLVMIntrin *op) {
   os() << op->name << "(";
   if (!op->args.empty()) {
     for (int i = 0; i < op->args.size() - 1; i++) {
@@ -681,6 +680,7 @@ void CodeGenC::Visit(const ir::intrinsics::UnaryIntrin *op) {
     }
     Print(op->args.back());
   }
+  os() << ")";
 }
 
 std::string ReadWholeFile(const std::string &path) {

--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -671,7 +671,7 @@ void CodeGenC::Visit(const ir::intrinsics::ArgsConstruct *op) {
   os() << ")";
 }
 
-void CodeGenC::Visit(const ir::intrinsics::LLVMIntrin *op) {
+void CodeGenC::Visit(const ir::intrinsics::BuiltinIntrin *op) {
   os() << op->name << "(";
   if (!op->args.empty()) {
     for (int i = 0; i < op->args.size() - 1; i++) {

--- a/cinn/backends/codegen_c.h
+++ b/cinn/backends/codegen_c.h
@@ -88,7 +88,7 @@ class CodeGenC : public ir::IrPrinter {
   NODETY_FORALL(__DEFINE_VISIT)
 #undef __DEFINE_VISIT
 
-#define __DEFINE_VISIT(op__) void Visit(const ir::intrinsics::op__* op);
+#define __DEFINE_VISIT(op__) void Visit(const ir::intrinsics::op__* op) override;
   INTRINSIC_KIND_FOR_EACH(__DEFINE_VISIT)
 #undef __DEFINE_VISIT
 

--- a/cinn/backends/codegen_c_test.cc
+++ b/cinn/backends/codegen_c_test.cc
@@ -177,7 +177,7 @@ void add1(void* _args, int32_t num_args)
   for (int32_t i_outer = 0; i_outer < 25; i_outer += 1) {
     for (int32_t i_inner = 0; i_inner < 4; i_inner += 1) {
       for (int32_t j = 0; j < 20; j += 1) {
-        C[((20 * i_inner) + ((80 * i_outer) + j))] = (1 + ((3 * A[((20 * i_inner) + ((80 * i_outer) + j))]) + B[((20 * i_inner) + ((80 * i_outer) + j))]));
+        C[((20 * i_inner) + ((80 * i_outer) + j))] = (1 + fma(3, A[((20 * i_inner) + ((80 * i_outer) + j))], B[((20 * i_inner) + ((80 * i_outer) + j))]));
       };
     };
   };
@@ -185,7 +185,7 @@ void add1(void* _args, int32_t num_args)
     for (int32_t i_inner = 0; i_inner < 4; i_inner += 1) {
       for (int32_t j_outer = 0; j_outer < 2; j_outer += 1) {
         for (int32_t j_inner = 0; j_inner < cinn_min(16, (20 + (-16 * j_outer))); j_inner += 1) {
-          D[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))] = ((2 * C[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))]) + (4 * (C[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))] * A[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))])));
+          D[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))] = fma(4, (C[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))] * A[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))]), (2 * C[((20 * i_inner) + ((80 * i_outer) + ((16 * j_outer) + j_inner)))]));
         };
       };
     };
@@ -378,7 +378,7 @@ void matmul(void* _args, int32_t num_args)
           C_init[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = 0;
           for (int32_t k0_outer = 0; k0_outer < 50; k0_outer += 1) {
             for (int32_t k0_inner = 0; k0_inner < 4; k0_inner += 1) {
-              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = (C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] + (A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))] * B[((32 * j_outer) + ((500 * k0_inner) + ((2000 * k0_outer) + j_inner)))]));
+              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = fma(A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))], B[((32 * j_outer) + ((500 * k0_inner) + ((2000 * k0_outer) + j_inner)))], C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))]);
             };
           };
         };
@@ -467,7 +467,7 @@ void matmul_with_packing(void* _args, int32_t num_args)
         for (int32_t j_inner = 0; j_inner < cinn_min(32, (500 + (-32 * j_outer))); j_inner += 1) {
           for (int32_t k0_outer = 0; k0_outer < 50; k0_outer += 1) {
             for (int32_t k0_inner = 0; k0_inner < 4; k0_inner += 1) {
-              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = (C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] + (A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))] * PackedB[((6400 * (j_inner / 32)) + ((j_inner % 32) + ((6400 * j_outer) + ((32 * k0_inner) + (128 * k0_outer)))))]));
+              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = fma(A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))], PackedB[((6400 * (j_inner / 32)) + ((j_inner % 32) + ((6400 * j_outer) + ((32 * k0_inner) + (128 * k0_outer)))))], C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))]);
             };
           };
         };

--- a/cinn/backends/codegen_c_x86.cc
+++ b/cinn/backends/codegen_c_x86.cc
@@ -94,5 +94,46 @@ void CodeGenCX86::PrintVecInputArgument(const Expr *op) {
   }
 }
 
+void CodeGenCX86::Visit(const ir::intrinsics::LLVMIntrin *op) {
+  if (op->type().lanes() == 1) {
+    CodeGenC::Visit(op);
+    return;
+  }
+  int bits = op->type().bits() * op->type().lanes();
+  if (SupportsAVX512() && bits == 512) {
+    os() << "cinn_avx512_" << op->name << "(";
+    if (!op->args.empty()) {
+      for (int i = 0; i < op->args.size() - 1; i++) {
+        PrintVecInputArgument(&op->args[i]);
+        os() << ", ";
+      }
+      Print(op->args.back());
+    }
+    os() << ")";
+  } else if (SupportsAVX256() && bits == 256) {
+    os() << "cinn_avx256_" << op->name << "(";
+    if (!op->args.empty()) {
+      for (int i = 0; i < op->args.size() - 1; i++) {
+        PrintVecInputArgument(&op->args[i]);
+        os() << ", ";
+      }
+      PrintVecInputArgument(&op->args.back());
+    }
+    os() << ")";
+  } else if (bits == 128) {
+    os() << "cinn_avx128_" << op->name << "(";
+    if (!op->args.empty()) {
+      for (int i = 0; i < op->args.size() - 1; i++) {
+        PrintVecInputArgument(&op->args[i]);
+        os() << ", ";
+      }
+      PrintVecInputArgument(&op->args.back());
+    }
+    os() << ")";
+  } else {
+    CodeGenC::Visit(op);
+  }
+}
+
 }  // namespace backends
 }  // namespace cinn

--- a/cinn/backends/codegen_c_x86.cc
+++ b/cinn/backends/codegen_c_x86.cc
@@ -94,7 +94,7 @@ void CodeGenCX86::PrintVecInputArgument(const Expr *op) {
   }
 }
 
-void CodeGenCX86::Visit(const ir::intrinsics::LLVMIntrin *op) {
+void CodeGenCX86::Visit(const ir::intrinsics::BuiltinIntrin *op) {
   if (op->type().lanes() == 1) {
     CodeGenC::Visit(op);
     return;

--- a/cinn/backends/codegen_c_x86.h
+++ b/cinn/backends/codegen_c_x86.h
@@ -49,7 +49,7 @@ class CodeGenCX86 : public CodeGenC {
   void Visit(const ir::Load *op) override;
   void Visit(const ir::Store *op) override;
   void Visit(const ir::Broadcast *op) override;
-  void Visit(const ir::intrinsics::LLVMIntrin *op);
+  void Visit(const ir::intrinsics::BuiltinIntrin *op);
 
   //! Check the features.
   // @{

--- a/cinn/backends/codegen_c_x86.h
+++ b/cinn/backends/codegen_c_x86.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "cinn/backends/codegen_c.h"
+#include "cinn/ir/intrinsic_ops.h"
 
 namespace cinn {
 namespace backends {
@@ -45,10 +46,10 @@ class CodeGenCX86 : public CodeGenC {
   void Visit(const ir::GE *op) override { CodeGenC::Visit(op); }
   void Visit(const ir::And *op) override { CodeGenC::Visit(op); }
   void Visit(const ir::Or *op) override { CodeGenC::Visit(op); }
-
   void Visit(const ir::Load *op) override;
   void Visit(const ir::Store *op) override;
   void Visit(const ir::Broadcast *op) override;
+  void Visit(const ir::intrinsics::LLVMIntrin *op);
 
   //! Check the features.
   // @{

--- a/cinn/backends/llvm/codegen_llvm.cc
+++ b/cinn/backends/llvm/codegen_llvm.cc
@@ -1331,7 +1331,7 @@ llvm::Function *CodeGenLLVM::GetIntrinsicDecl(llvm::Intrinsic::ID id,
   return nullptr;
 }
 
-llvm::Value *CodeGenLLVM::Visit(const ir::intrinsics::UnaryIntrin *op) {
+llvm::Value *CodeGenLLVM::Visit(const ir::intrinsics::LLVMIntrin *op) {
   std::string func_name = op->name;
   if (op->id == -1) {
     if (func_name == "bitwise_and") {

--- a/cinn/backends/llvm/codegen_llvm.cc
+++ b/cinn/backends/llvm/codegen_llvm.cc
@@ -1331,7 +1331,7 @@ llvm::Function *CodeGenLLVM::GetIntrinsicDecl(llvm::Intrinsic::ID id,
   return nullptr;
 }
 
-llvm::Value *CodeGenLLVM::Visit(const ir::intrinsics::LLVMIntrin *op) {
+llvm::Value *CodeGenLLVM::Visit(const ir::intrinsics::BuiltinIntrin *op) {
   std::string func_name = op->name;
   if (op->id == -1) {
     if (func_name == "bitwise_and") {

--- a/cinn/backends/llvm/llvm_intrin_rule.h
+++ b/cinn/backends/llvm/llvm_intrin_rule.h
@@ -25,9 +25,9 @@ inline void MakeFloatIntrinOp(lang::Args args, lang::RetValue *rv) {
   CHECK_GE(node->read_args.size(), arg_nums);
   if (add_float_suffix) {
     CHECK(node->type().is_float());
-    *rv = ir::intrinsics::LLVMIntrin::Make(node->name + "f", node->read_args, id, arg_nums, node->type());
+    *rv = ir::intrinsics::BuiltinIntrin::Make(node->name + "f", node->read_args, id, arg_nums, node->type());
   } else {
-    *rv = ir::intrinsics::LLVMIntrin::Make(node->name, node->read_args, id, arg_nums, node->type());
+    *rv = ir::intrinsics::BuiltinIntrin::Make(node->name, node->read_args, id, arg_nums, node->type());
   }
 }
 

--- a/cinn/backends/llvm/llvm_intrin_rule.h
+++ b/cinn/backends/llvm/llvm_intrin_rule.h
@@ -25,9 +25,9 @@ inline void MakeFloatIntrinOp(lang::Args args, lang::RetValue *rv) {
   CHECK_GE(node->read_args.size(), arg_nums);
   if (add_float_suffix) {
     CHECK(node->type().is_float());
-    *rv = ir::intrinsics::UnaryIntrin::Make(node->name + "f", node->read_args, id, arg_nums, node->type());
+    *rv = ir::intrinsics::LLVMIntrin::Make(node->name + "f", node->read_args, id, arg_nums, node->type());
   } else {
-    *rv = ir::intrinsics::UnaryIntrin::Make(node->name, node->read_args, id, arg_nums, node->type());
+    *rv = ir::intrinsics::LLVMIntrin::Make(node->name, node->read_args, id, arg_nums, node->type());
   }
 }
 
@@ -56,8 +56,10 @@ void RegisterCpuIntrinRule() {
       RegisterBitwise(right_shift)
 #undef RegisterBitwise
 
-          ir::Registry::Register("lower_cpu_intrinsic_bitwise_not", true)
-              .SetBody(MakeFloatIntrinOp<-1, 1, false>);
+          ir::Registry::Register("lower_cpu_intrinsic_fma", true)
+              .SetBody(MakeFloatIntrinOp<::llvm::Intrinsic::fmuladd, 3, false>);
+
+  ir::Registry::Register("lower_cpu_intrinsic_bitwise_not", true).SetBody(MakeFloatIntrinOp<-1, 1, false>);
 
   ir::Registry::Register("lower_cpu_intrinsic_isnan", true).SetBody(MakeFloatIntrinOp<-1, 1, false>);
 

--- a/cinn/ir/intrinsic_ops.cc
+++ b/cinn/ir/intrinsic_ops.cc
@@ -97,9 +97,9 @@ Expr intrinsics::ArgsConstruct::Make(Var var, llvm::ArrayRef<Expr> args) {
   return Expr(n);
 }
 
-Expr intrinsics::LLVMIntrin::Make(
+Expr intrinsics::BuiltinIntrin::Make(
     const std::string& name, llvm::ArrayRef<Expr> args, llvm::Intrinsic::ID id, int64_t arg_nums, const Type& type) {
-  auto* n = new LLVMIntrin;
+  auto* n = new BuiltinIntrin;
   n->name = name;
   n->args.assign(args.begin(), args.end());
   n->id       = id;

--- a/cinn/ir/intrinsic_ops.cc
+++ b/cinn/ir/intrinsic_ops.cc
@@ -97,9 +97,9 @@ Expr intrinsics::ArgsConstruct::Make(Var var, llvm::ArrayRef<Expr> args) {
   return Expr(n);
 }
 
-Expr intrinsics::UnaryIntrin::Make(
+Expr intrinsics::LLVMIntrin::Make(
     const std::string& name, llvm::ArrayRef<Expr> args, llvm::Intrinsic::ID id, int64_t arg_nums, const Type& type) {
-  auto* n = new UnaryIntrin;
+  auto* n = new LLVMIntrin;
   n->name = name;
   n->args.assign(args.begin(), args.end());
   n->id       = id;

--- a/cinn/ir/intrinsic_ops.h
+++ b/cinn/ir/intrinsic_ops.h
@@ -23,7 +23,7 @@ namespace cinn::ir {
   macro__(BufferCreate)                                  \
   macro__(GetAddr)                                       \
   macro__(ArgsConstruct)                                 \
-  macro__(LLVMIntrin)
+  macro__(BuiltinIntrin)
 // clang-format on
 
 enum class IntrinsicKind {
@@ -167,13 +167,13 @@ struct ArgsConstruct : public IntrinsicOp {
 /**
  * The llvm intrinsic op
  */
-struct LLVMIntrin : public IntrinsicOp {
-  LLVMIntrin() : IntrinsicOp(IntrinsicKind::kLLVMIntrin, {}, {}) {}
+struct BuiltinIntrin : public IntrinsicOp {
+  BuiltinIntrin() : IntrinsicOp(IntrinsicKind::kBuiltinIntrin, {}, {}) {}
 
   static Expr Make(
       const std::string& name, llvm::ArrayRef<Expr> args, llvm::Intrinsic::ID id, int64_t arg_nums, const Type& type);
 
-  static bool classof(const IntrinsicOp* s) { return s->getKind() == IntrinsicKind::kLLVMIntrin; }
+  static bool classof(const IntrinsicOp* s) { return s->getKind() == IntrinsicKind::kBuiltinIntrin; }
 
   std::string name;
   llvm::SmallVector<Expr, 4> args;

--- a/cinn/ir/intrinsic_ops.h
+++ b/cinn/ir/intrinsic_ops.h
@@ -23,7 +23,7 @@ namespace cinn::ir {
   macro__(BufferCreate)                                  \
   macro__(GetAddr)                                       \
   macro__(ArgsConstruct)                                 \
-  macro__(UnaryIntrin)
+  macro__(LLVMIntrin)
 // clang-format on
 
 enum class IntrinsicKind {
@@ -165,15 +165,15 @@ struct ArgsConstruct : public IntrinsicOp {
 };
 
 /**
- * The operation of unary computation
+ * The llvm intrinsic op
  */
-struct UnaryIntrin : public IntrinsicOp {
-  UnaryIntrin() : IntrinsicOp(IntrinsicKind::kUnaryIntrin, {}, {}) {}
+struct LLVMIntrin : public IntrinsicOp {
+  LLVMIntrin() : IntrinsicOp(IntrinsicKind::kLLVMIntrin, {}, {}) {}
 
   static Expr Make(
       const std::string& name, llvm::ArrayRef<Expr> args, llvm::Intrinsic::ID id, int64_t arg_nums, const Type& type);
 
-  static bool classof(const IntrinsicOp* s) { return s->getKind() == IntrinsicKind::kUnaryIntrin; }
+  static bool classof(const IntrinsicOp* s) { return s->getKind() == IntrinsicKind::kLLVMIntrin; }
 
   std::string name;
   llvm::SmallVector<Expr, 4> args;

--- a/cinn/ir/ir_mutator.h
+++ b/cinn/ir/ir_mutator.h
@@ -266,8 +266,8 @@ void IRMutator<T>::Visit(const IntrinsicOp *expr, T op) {
       auto *n = llvm::dyn_cast<intrinsics::PodValueToX>(node);
       Visit(&n->pod_value_ptr, &n->pod_value_ptr);
     } break;
-    case ir::IntrinsicKind::kLLVMIntrin: {
-      auto *n = llvm::dyn_cast<intrinsics::LLVMIntrin>(node);
+    case ir::IntrinsicKind::kBuiltinIntrin: {
+      auto *n = llvm::dyn_cast<intrinsics::BuiltinIntrin>(node);
       for (auto &expr : n->args) {
         Visit(&expr, &expr);
       }

--- a/cinn/ir/ir_mutator.h
+++ b/cinn/ir/ir_mutator.h
@@ -266,6 +266,12 @@ void IRMutator<T>::Visit(const IntrinsicOp *expr, T op) {
       auto *n = llvm::dyn_cast<intrinsics::PodValueToX>(node);
       Visit(&n->pod_value_ptr, &n->pod_value_ptr);
     } break;
+    case ir::IntrinsicKind::kLLVMIntrin: {
+      auto *n = llvm::dyn_cast<intrinsics::LLVMIntrin>(node);
+      for (auto &expr : n->args) {
+        Visit(&expr, &expr);
+      }
+    } break;
   }
 }
 

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -412,8 +412,8 @@ void IrPrinter::Visit(const intrinsics::ArgsConstruct *x) {
   os() << ")";
 }
 
-void IrPrinter::Visit(const intrinsics::LLVMIntrin *x) {
-  os_ << runtime::intrisic::llvm_intrin_repr << "_";
+void IrPrinter::Visit(const intrinsics::BuiltinIntrin *x) {
+  os_ << runtime::intrisic::builtin_intrin_repr << "_";
   os_ << x->name << "(";
   if (!x->args.empty()) {
     for (int i = 0; i < x->args.size() - 1; i++) {

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -412,8 +412,8 @@ void IrPrinter::Visit(const intrinsics::ArgsConstruct *x) {
   os() << ")";
 }
 
-void IrPrinter::Visit(const intrinsics::UnaryIntrin *x) {
-  os_ << runtime::intrisic::unary_intrin_repr << "_";
+void IrPrinter::Visit(const intrinsics::LLVMIntrin *x) {
+  os_ << runtime::intrisic::llvm_intrin_repr << "_";
   os_ << x->name << "(";
   if (!x->args.empty()) {
     for (int i = 0; i < x->args.size() - 1; i++) {

--- a/cinn/ir/ir_printer.h
+++ b/cinn/ir/ir_printer.h
@@ -39,7 +39,7 @@ struct IrPrinter : public IRVisitor {
   NODETY_FORALL(__)
 #undef __
 
-#define __(op__) void Visit(const intrinsics::op__ *x);
+#define __(op__) virtual void Visit(const intrinsics::op__ *x);
   INTRINSIC_KIND_FOR_EACH(__)
 #undef __
 

--- a/cinn/optim/ir_copy.cc
+++ b/cinn/optim/ir_copy.cc
@@ -392,8 +392,8 @@ Expr IRCopyVisitor::Visit(const ir::intrinsics::ArgsConstruct* op) {
   }
   return intrinsics::ArgsConstruct::Make(op->var, args);
 }
-Expr IRCopyVisitor::Visit(const ir::intrinsics::LLVMIntrin* op) {
-  return intrinsics::LLVMIntrin::Make(op->name, op->args, op->id, op->arg_nums, op->type());
+Expr IRCopyVisitor::Visit(const ir::intrinsics::BuiltinIntrin* op) {
+  return intrinsics::BuiltinIntrin::Make(op->name, op->args, op->id, op->arg_nums, op->type());
 }
 
 Expr IRCopy(Expr x) {

--- a/cinn/optim/ir_copy.cc
+++ b/cinn/optim/ir_copy.cc
@@ -392,8 +392,8 @@ Expr IRCopyVisitor::Visit(const ir::intrinsics::ArgsConstruct* op) {
   }
   return intrinsics::ArgsConstruct::Make(op->var, args);
 }
-Expr IRCopyVisitor::Visit(const ir::intrinsics::UnaryIntrin* op) {
-  return intrinsics::UnaryIntrin::Make(op->name, op->args, op->id, op->arg_nums, op->type());
+Expr IRCopyVisitor::Visit(const ir::intrinsics::LLVMIntrin* op) {
+  return intrinsics::LLVMIntrin::Make(op->name, op->args, op->id, op->arg_nums, op->type());
 }
 
 Expr IRCopy(Expr x) {

--- a/cinn/optim/lower_intrin.h
+++ b/cinn/optim/lower_intrin.h
@@ -9,10 +9,10 @@ namespace cinn {
 namespace optim {
 
 static const std::set<std::string> kIntrinsicCalls{
-    {"exp",         "exp2",       "sqrt",        "log",         "log2",       "log10", "floor",
-     "ceil",        "round",      "trunc",       "cos",         "cosh",       "tan",   "tanh",
-     "sin",         "sinh",       "fabs",        "isnan",       "isfinite",   "isinf", "left_shift",
-     "right_shift", "bitwise_or", "bitwise_and", "bitwise_xor", "bitwise_not"}};
+    {"exp",         "exp2",       "sqrt",        "log",         "log2",        "log10", "floor",
+     "ceil",        "round",      "trunc",       "cos",         "cosh",        "tan",   "tanh",
+     "sin",         "sinh",       "fabs",        "isnan",       "isfinite",    "isinf", "left_shift",
+     "right_shift", "bitwise_or", "bitwise_and", "bitwise_xor", "bitwise_not", "fma"}};
 
 /**
  * Map the Call nodes to llvm intrinsic.

--- a/cinn/optim/transform_polyfor_to_for_test.cc
+++ b/cinn/optim/transform_polyfor_to_for_test.cc
@@ -82,7 +82,7 @@ void matmul(void* _args, int32_t num_args)
       for (int32_t j_outer = 0; j_outer < 63; j_outer += 1) {
         for (int32_t j_inner = 0; j_inner < cinn_min(8, (500 + (-8 * j_outer))); j_inner += 1) {
           for (int32_t k0 = 0; k0 < 200; k0 += 1) {
-            C[((500 * i_inner) + ((4000 * i_outer) + ((8 * j_outer) + j_inner)))] = (C[((500 * i_inner) + ((4000 * i_outer) + ((8 * j_outer) + j_inner)))] + (A[((200 * i_inner) + ((1600 * i_outer) + k0))] * B[((8 * j_outer) + ((500 * k0) + j_inner))]));
+            C[((500 * i_inner) + ((4000 * i_outer) + ((8 * j_outer) + j_inner)))] = fma(A[((200 * i_inner) + ((1600 * i_outer) + k0))], B[((8 * j_outer) + ((500 * k0) + j_inner))], C[((500 * i_inner) + ((4000 * i_outer) + ((8 * j_outer) + j_inner)))]);
           };
         };
       };

--- a/cinn/runtime/intrinsic.h
+++ b/cinn/runtime/intrinsic.h
@@ -60,7 +60,7 @@ static const char* get_address_repr = "get_address";
 
 static const char* args_construct_repr = "cinn_args_construct";
 
-static const char* llvm_intrin_repr = "cinn_intrin";
+static const char* builtin_intrin_repr = "cinn_builtin_intrin";
 
 //! Name of the helper intrinsic used to display debug string.
 static const char* debug_log_repr = "cinn_print_debug_string";

--- a/cinn/runtime/intrinsic.h
+++ b/cinn/runtime/intrinsic.h
@@ -60,7 +60,7 @@ static const char* get_address_repr = "get_address";
 
 static const char* args_construct_repr = "cinn_args_construct";
 
-static const char* unary_intrin_repr = "cinn_unary_intrin";
+static const char* llvm_intrin_repr = "cinn_intrin";
 
 //! Name of the helper intrinsic used to display debug string.
 static const char* debug_log_repr = "cinn_print_debug_string";

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -mavx -Wno-write-strings -Wno-psabi")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -mavx -mfma -Wno-write-strings -Wno-psabi")
 
 set(PADDLE_RESOURCE_URL "http://paddle-inference-dist.bj.bcebos.com" CACHE STRING "inference download url")
 

--- a/tests/test02_matmul_case.cc
+++ b/tests/test02_matmul_case.cc
@@ -58,7 +58,7 @@ TEST(test02, basic) {
     }
   }
 
-  auto compare = [&](float diff = 1e-5) {
+  auto compare = [&](float diff = 1e-4) {
     for (int i = 0; i < M; i++) {
       for (int j = 0; j < N; j++) {
         ASSERT_NEAR(Cd[i * N + j], Cd_target[i * N + j], diff);


### PR DESCRIPTION
add llvm fmuladd intrinsic and codegenC support
for matmul shape[1024, 1024], the performance can further be optimized from 40 ms to 28ms