### PR TITLE
Make function call with a executable cache to optimize iteration performance

### DIFF
--- a/cinnrt/host_context/CMakeLists.txt
+++ b/cinnrt/host_context/CMakeLists.txt
@@ -15,11 +15,11 @@ set(srcs
         mlir_function_executable.cc
   )
 
-cc_test(test_host_context_value SRCS value_test.cc DEPS cinncore)
-cc_test(test_kernel_utils SRCS kernel_utils_test.cc DEPS cinncore)
-cc_test(test_kernel_registry SRCS kernel_registry_test.cc DEPS cinncore)
-cc_test(test_op_executable SRCS op_executable_test.cc DEPS cinncore)
-cc_test(test_core_runtime SRCS core_runtime_test.cc DEPS cinncore)
+cc_test(test_host_context_value SRCS value_test.cc DEPS cinncore ${MLIR_IR_LIBS})
+cc_test(test_kernel_utils SRCS kernel_utils_test.cc DEPS cinncore ${MLIR_IR_LIBS})
+cc_test(test_kernel_registry SRCS kernel_registry_test.cc DEPS cinncore ${MLIR_IR_LIBS})
+cc_test(test_op_executable SRCS op_executable_test.cc DEPS cinncore ${MLIR_IR_LIBS})
+cc_test(test_core_runtime SRCS core_runtime_test.cc DEPS cinncore ${MLIR_IR_LIBS})
 cc_test(test_mlir_to_runtime_translate SRCS mlir_to_runtime_translate_test.cc DEPS cinncore ${MLIR_IR_LIBS})
 
 cinn_exec_check(test_mlir_exec_on_basic mlir_tests/basic.mlir)

--- a/cinnrt/host_context/CMakeLists.txt
+++ b/cinnrt/host_context/CMakeLists.txt
@@ -12,7 +12,7 @@ set(srcs
         mlir_to_runtime_translate.cc
         tensor_metadata.cc
         function.cc
-        mlir_function.cc
+        mlir_function_executable.cc
   )
 
 cc_test(test_host_context_value SRCS value_test.cc DEPS cinncore)

--- a/cinnrt/host_context/core_runtime.cc
+++ b/cinnrt/host_context/core_runtime.cc
@@ -20,7 +20,7 @@ struct CoreRuntime::Impl {
 
 SymbolTable* CoreRuntime::symbol_table() { return &impl_->symbol_table; }
 
-CoreRuntime::CoreRuntime(CoreRuntime::Impl* impl) : impl_(impl) {}
+CoreRuntime::CoreRuntime(CoreRuntime::Impl* impl) : impl_(impl) { CHECK(impl); }
 
 void CoreRuntime::Execute() {
   int op_offset = 0;
@@ -37,6 +37,7 @@ CoreRuntimeBuilder::CoreRuntimeBuilder(KernelRegistry* kernel_registry) : CoreRu
 }
 
 OpExecutableBuilder* CoreRuntimeBuilder::NewOpExecutable(std::string_view op_name, const std::string& fn_name) {
+  CHECK(impl_.get());
   impl_->op_executables.emplace_back(op_name, symbol_table(), impl_->kernel_registry);
   return &impl_->op_executables.back();
 }
@@ -45,6 +46,11 @@ void CoreRuntimeBuilder::FeedInArgs(llvm::ArrayRef<std::pair<std::string, ValueR
   for (auto& item : args) {
     symbol_table()->Register(item.first, item.second);
   }
+}
+
+void CoreRuntimeBuilder::SetKernelRegistry(KernelRegistry* x) {
+  CHECK(x);
+  impl_->kernel_registry = x;
 }
 
 llvm::SmallVector<ValueRef, 4> CoreRuntime::GetResults(llvm::ArrayRef<std::string_view> arg_names) {

--- a/cinnrt/host_context/core_runtime.h
+++ b/cinnrt/host_context/core_runtime.h
@@ -52,6 +52,8 @@ class CoreRuntimeBuilder : public CoreRuntime {
 
   using CoreRuntime::symbol_table;
 
+  void SetKernelRegistry(KernelRegistry* x);
+
   //! Feed the input arguments, each item is a pair of arg-name and arg-value.
   void FeedInArgs(llvm::ArrayRef<std::pair<std::string, ValueRef>> args);
 

--- a/cinnrt/host_context/core_runtime.h
+++ b/cinnrt/host_context/core_runtime.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
-#include "cinnrt/host_context/value.h"
-
 #include <memory>
 #include <string>
+#include <utility>
+#include "cinnrt/host_context/value.h"
 
 namespace cinnrt::host_context {
 
@@ -18,7 +18,7 @@ class SymbolTable;
  * Each function call will bind to a CoreRuntime instance, push the argument Values in to the argument-list, and get the
  * result Values from the return-list.
  */
-class CoreRuntime {
+class CoreRuntime : public std::enable_shared_from_this<CoreRuntime> {
  public:
   //! Execute a program.
   void Execute();
@@ -31,6 +31,8 @@ class CoreRuntime {
   GetResults(llvm::ArrayRef<std::string_view> arg_names);
 
   ~CoreRuntime();
+
+  std::shared_ptr<CoreRuntime> getptr() { return std::shared_ptr<CoreRuntime>(this); }
 
  protected:
   //! Get the symbol table.

--- a/cinnrt/host_context/kernel_frame.h
+++ b/cinnrt/host_context/kernel_frame.h
@@ -95,6 +95,7 @@ std::ostream& operator<<(std::ostream& os, const KernelFrame& frame);
 class KernelFrameBuilder : public KernelFrame {
  public:
   void AddArgument(Value* value) {
+    CHECK(value);
     CHECK_EQ(num_results_, -1) << "Should call AddArgument before calling SetNumResults";
     value_or_attrs_.push_back(value);
     ++num_arguments_;

--- a/cinnrt/host_context/mlir_function.cc
+++ b/cinnrt/host_context/mlir_function.cc
@@ -40,7 +40,7 @@ void MlirFunction::BuildExecutables(llvm::ArrayRef<Value*> arguments, llvm::Muta
       continue;
     }
 
-    if (EmitCallOp(&op, CallArguments{&function_table_, arguments, results})) continue;
+    if (EmitCallOp(&op, &function_table_)) continue;
 
     if (EmitGeneralOp(&op)) continue;
     LOG(FATAL) << "Not supported op: " << DumpToString(op);

--- a/cinnrt/host_context/mlir_function_executable.h
+++ b/cinnrt/host_context/mlir_function_executable.h
@@ -21,18 +21,6 @@ class MlirFunctionExecutable : public Function, public MlirToRuntimeTranslator {
  public:
   using function_defs_t = std::unordered_map<std::string, mlir::FuncOp>;
 
-  /**
-   * @param func_op a function IR node from the original MLIR module.
-   * @param kernel_registry the kernel registry containing all the valid kernels.
-   * @param core_runtime_builder the CoreRuntimeBuilder
-   * @param function_table the symbol table for functions.
-   *
-   * construct, take a mlir::FuncOp and create an executable from it.
-   */
-  MlirFunctionExecutable(mlir::FuncOp func_op,
-                         CoreRuntimeBuilder* core_runtime_builder,
-                         function_defs_t& function_table);
-
   MlirFunctionExecutable(mlir::FuncOp func_op, KernelRegistry* kernel_registry, function_defs_t& function_table);
 
   /**
@@ -50,7 +38,7 @@ class MlirFunctionExecutable : public Function, public MlirToRuntimeTranslator {
 
  private:
   mlir::FuncOp func_op_;
-  std::unique_ptr<CoreRuntimeBuilder> core_runtime_builder_;
+  CoreRuntimeBuilder core_runtime_builder_;
   MlirToRuntimeTranslator::function_defs_t& function_table_;
   std::function<void()> copy_res_fn_;
 };

--- a/cinnrt/host_context/mlir_function_executable.h
+++ b/cinnrt/host_context/mlir_function_executable.h
@@ -15,18 +15,25 @@ struct KernelRegistry;
  * 1. cinn.call op
  * 2. main function call
  *
- * A MlirFunction might have one or more arguments and results.
+ * A MlirFunctionExecutable might have one or more arguments and results.
  */
-class MlirFunction : public Function, public MlirToRuntimeTranslator {
+class MlirFunctionExecutable : public Function, public MlirToRuntimeTranslator {
  public:
+  using function_defs_t = std::unordered_map<std::string, mlir::FuncOp>;
+
   /**
    * @param func_op a function IR node from the original MLIR module.
    * @param kernel_registry the kernel registry containing all the valid kernels.
+   * @param core_runtime_builder the CoreRuntimeBuilder
    * @param function_table the symbol table for functions.
+   *
+   * construct, take a mlir::FuncOp and create an executable from it.
    */
-  MlirFunction(mlir::FuncOp func_op,
-               KernelRegistry* kernel_registry,
-               MlirToRuntimeTranslator::function_table_t& function_table);
+  MlirFunctionExecutable(mlir::FuncOp func_op,
+                         CoreRuntimeBuilder* core_runtime_builder,
+                         function_defs_t& function_table);
+
+  MlirFunctionExecutable(mlir::FuncOp func_op, KernelRegistry* kernel_registry, function_defs_t& function_table);
 
   /**
    * Execute the function with the given arguments and results.
@@ -43,8 +50,8 @@ class MlirFunction : public Function, public MlirToRuntimeTranslator {
 
  private:
   mlir::FuncOp func_op_;
-  CoreRuntimeBuilder core_runtime_;
-  MlirToRuntimeTranslator::function_table_t& function_table_;
+  std::unique_ptr<CoreRuntimeBuilder> core_runtime_builder_;
+  MlirToRuntimeTranslator::function_defs_t& function_table_;
   std::function<void()> copy_res_fn_;
 };
 

--- a/cinnrt/host_context/mlir_to_runtime_translate.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate.cc
@@ -209,7 +209,7 @@ bool MlirToRuntimeTranslator::EmitGeneralOp(mlir::Operation* op) {
   }
   impl_->cur_op->SetResults(res_values);
 
-#ifndef NDEBUG
+#ifdef CINN_DEBUG
   {
     VLOG(3) << "check result";
     for (int i = 0; i < impl_->cur_op->frame().GetNumResults(); i++) {
@@ -267,27 +267,7 @@ bool MlirToRuntimeTranslator::EmitFunctions() {
   }
 }
 
-void MlirToRuntimeTranslator::EmitFunction(mlir::FuncOp op) { CINN_NOT_IMPLEMENTED }
-
-void MlirToRuntimeTranslator::EmitMainFunc() {
-  auto main_fn = impl_->module.lookupSymbol<mlir::FuncOp>("main");
-  CHECK(main_fn) << "need main function as entry point of the whole program";
-  CHECK_EQ(main_fn.getNumArguments(), 0) << "main function not support input arguments";
-  UpdateCurFuncName("main");
-
-  auto& block = main_fn.front();
-
-  for (auto& op : block) {
-    VLOG(3) << "instr: " << DumpToString(op);
-
-    if (EmitConstantOp(&op)) continue;
-    if (EmitBuildShapeOp(&op)) continue;
-    if (EmitReturnOp(&op, nullptr)) continue;
-    if (EmitCallOp(&op, &impl_->functions)) continue;
-    if (EmitGeneralOp(&op)) continue;
-    LOG(FATAL) << "failed to emit op: " << DumpToString(op);
-  }
-}
+void MlirToRuntimeTranslator::EmitFunction(mlir::FuncOp op){CINN_NOT_IMPLEMENTED}
 
 Value* MlirToRuntimeTranslator::GetOpResult(mlir::Operation* op) {
   auto it = impl_->op_results.find(op);

--- a/cinnrt/host_context/mlir_to_runtime_translate.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate.cc
@@ -20,7 +20,6 @@
 #include "cinnrt/host_context/core_runtime.h"
 #include "cinnrt/host_context/kernel_frame.h"
 #include "cinnrt/host_context/kernel_registry.h"
-#include "cinnrt/host_context/mlir_function_executable.h"
 #include "cinnrt/host_context/op_executable.h"
 #include "cinnrt/host_context/tensor_shape.h"
 #include "cinnrt/host_context/value.h"
@@ -47,8 +46,6 @@ struct MlirToRuntimeTranslator::Impl {
   // record the current function name.
   std::string cur_func_name;
 
-  // Record function built from the module, just like a symbol table.
-  std::unordered_map<std::string, std::unique_ptr<MlirFunctionExecutable>> functions;
   // Name to function definitions.
   std::unordered_map<std::string, mlir::FuncOp> func_defs;
 

--- a/cinnrt/host_context/mlir_to_runtime_translate.h
+++ b/cinnrt/host_context/mlir_to_runtime_translate.h
@@ -1,9 +1,17 @@
 #pragma once
 
-#include <mlir/IR/Function.h>
-#include <mlir/IR/Module.h>
+#include <llvm/ADT/SmallVector.h>
+#include <memory>
 #include <string>
 #include <unordered_map>
+
+namespace mlir {
+class FuncOp;
+class ModuleOp;
+class Operation;
+class Attribute;
+class Value;
+}  // namespace mlir
 
 namespace cinnrt::host_context {
 
@@ -11,23 +19,15 @@ class CoreRuntimeBuilder;
 class Value;
 class ValueRef;
 class KernelRegistry;
-class MlirFunction;
-
-template <typename T>
-std::string DumpToString(T& op) {  // NOLINT
-  std::string buffer;
-  llvm::raw_string_ostream os(buffer);
-  op.print(os);
-  os.flush();
-  return buffer;
-}
+class MlirFunctionExecutable;
 
 /**
  * MlirToRuntimeTranslator helpes to translate a MLIR to a CoreRuntime.
  */
 class MlirToRuntimeTranslator {
  public:
-  using function_table_t = std::unordered_map<std::string, std::unique_ptr<MlirFunction>>;
+  using function_table_t = std::unordered_map<std::string, std::unique_ptr<MlirFunctionExecutable>>;
+  using function_defs_t  = std::unordered_map<std::string, mlir::FuncOp>;
 
   MlirToRuntimeTranslator(CoreRuntimeBuilder* runtime);
   MlirToRuntimeTranslator(mlir::ModuleOp module, CoreRuntimeBuilder* runtime);
@@ -51,7 +51,7 @@ class MlirToRuntimeTranslator {
   //! Emit a single function, this is an API that should be implemented by inherients.
   virtual void EmitFunction(mlir::FuncOp op);
 
-  bool EmitCallOp(mlir::Operation* op, function_table_t* function_table);
+  bool EmitCallOp(mlir::Operation* op, function_defs_t* function_table);
 
   template <typename T>
   std::optional<T> EmitAttribute(const mlir::Attribute* attr);

--- a/cinnrt/host_context/mlir_to_runtime_translate.h
+++ b/cinnrt/host_context/mlir_to_runtime_translate.h
@@ -19,14 +19,12 @@ class CoreRuntimeBuilder;
 class Value;
 class ValueRef;
 class KernelRegistry;
-class MlirFunctionExecutable;
 
 /**
  * MlirToRuntimeTranslator helpes to translate a MLIR to a CoreRuntime.
  */
 class MlirToRuntimeTranslator {
  public:
-  using function_table_t = std::unordered_map<std::string, std::unique_ptr<MlirFunctionExecutable>>;
   using function_defs_t  = std::unordered_map<std::string, mlir::FuncOp>;
 
   MlirToRuntimeTranslator(CoreRuntimeBuilder* runtime);

--- a/cinnrt/host_context/mlir_to_runtime_translate.h
+++ b/cinnrt/host_context/mlir_to_runtime_translate.h
@@ -53,21 +53,7 @@ class MlirToRuntimeTranslator {
   //! Emit a single function, this is an API that should be implemented by inherients.
   virtual void EmitFunction(mlir::FuncOp op);
 
-  struct CallArguments {
-    CallArguments(function_table_t* function_table) : function_table(function_table) {}  // NOLINT
-    CallArguments(function_table_t* function_table,
-                  llvm::ArrayRef<Value*> arguments,
-                  llvm::MutableArrayRef<ValueRef> results)
-        : function_table(function_table), arguments(arguments), results(results) {}
-
-    function_table_t* function_table{};
-    // the input arguments passed to the function call.
-    llvm::ArrayRef<Value*> arguments{};
-    // the result arguments passed out.
-    llvm::MutableArrayRef<ValueRef> results{};
-  };
-
-  bool EmitCallOp(mlir::Operation* op, CallArguments call_arguments);
+  bool EmitCallOp(mlir::Operation* op, function_table_t* function_table);
 
   template <typename T>
   std::optional<T> EmitAttribute(const mlir::Attribute* attr);

--- a/cinnrt/host_context/mlir_to_runtime_translate.h
+++ b/cinnrt/host_context/mlir_to_runtime_translate.h
@@ -37,8 +37,6 @@ class MlirToRuntimeTranslator {
   virtual ~MlirToRuntimeTranslator();
 
  protected:
-  //! Emit the main function.
-  void EmitMainFunc();
   //! Emit a "cinn.constant.*" operation, return true if succeed.
   bool EmitConstantOp(mlir::Operation* op);
   //! Emit a "cinn.return" operation.

--- a/cinnrt/host_context/mlir_to_runtime_translate.h
+++ b/cinnrt/host_context/mlir_to_runtime_translate.h
@@ -21,11 +21,13 @@ class ValueRef;
 class KernelRegistry;
 
 /**
- * MlirToRuntimeTranslator helpes to translate a MLIR to a CoreRuntime.
+ * MlirToRuntimeTranslator helps to translate a MLIR program to a CoreRuntime.
+ * This is the base class of all the modules those parse a MLIR program and finally generate a CoreRuntime.
  */
 class MlirToRuntimeTranslator {
  public:
-  using function_defs_t  = std::unordered_map<std::string, mlir::FuncOp>;
+  //! Holds all the function definitions.
+  using function_defs_t = std::unordered_map<std::string, mlir::FuncOp>;
 
   MlirToRuntimeTranslator(CoreRuntimeBuilder* runtime);
   MlirToRuntimeTranslator(mlir::ModuleOp module, CoreRuntimeBuilder* runtime);

--- a/cinnrt/host_context/op_executable.h
+++ b/cinnrt/host_context/op_executable.h
@@ -1,9 +1,12 @@
 #pragma once
 #include <llvm/ADT/ArrayRef.h>
+#include <mlir/IR/Function.h>
 
 #include <memory>
 #include <string>
 #include <string_view>
+
+#include "cinnrt/host_context/mlir_to_runtime_translate.h"
 
 namespace cinnrt::host_context {
 
@@ -11,11 +14,16 @@ class SymbolTable;
 class KernelRegistry;
 class KernelFrame;
 class Value;
+class CoreRuntimeBuilder;
+class MlirFunctionExecutable;
 
 /**
  * OpExecutable is a runtime executable instance for an operation. It captures all the information(Tensors, attributes
  * and so on) needed for execution.
  * With the SymbolTable and op definition, it create and hold a KernelFrame once and execute any times.
+ *
+ * An OpExecutable is an item of a CoreRuntime, but it can holds a CoreRuntime instance for function call (e.g. a
+ * `cinn.call` op).
  */
 class OpExecutable {
  public:
@@ -30,7 +38,7 @@ class OpExecutable {
 
  protected:
   class Impl;
-  OpExecutable(Impl* impl);
+  explicit OpExecutable(Impl* impl);
 
   std::unique_ptr<Impl> impl_;
 };
@@ -50,6 +58,12 @@ class OpExecutableBuilder : public OpExecutable {
   void SetResults(llvm::ArrayRef<Value*> results);
 
   void AppendAttribute(Value* value);
+
+  MlirFunctionExecutable* CreateFunctionExecutable(mlir::FuncOp op,
+                                                   MlirToRuntimeTranslator::function_defs_t* function_defs);
+
+  //! Get the CoreRuntime instance for function call(used in `cinn.call` op).
+  CoreRuntimeBuilder* GetCallRuntimeBuilder();
 };
 
 }  // namespace cinnrt::host_context

--- a/cinnrt/host_context/op_executable.h
+++ b/cinnrt/host_context/op_executable.h
@@ -1,12 +1,15 @@
 #pragma once
 #include <llvm/ADT/ArrayRef.h>
-#include <mlir/IR/Function.h>
 
 #include <memory>
 #include <string>
 #include <string_view>
 
 #include "cinnrt/host_context/mlir_to_runtime_translate.h"
+
+namespace mlir {
+class FuncOp;
+}  // namespace mlir
 
 namespace cinnrt::host_context {
 

--- a/cinnrt/host_context/op_executable.h
+++ b/cinnrt/host_context/op_executable.h
@@ -5,8 +5,6 @@
 #include <string>
 #include <string_view>
 
-#include "cinnrt/host_context/mlir_to_runtime_translate.h"
-
 namespace mlir {
 class FuncOp;
 }  // namespace mlir
@@ -24,9 +22,6 @@ class MlirFunctionExecutable;
  * OpExecutable is a runtime executable instance for an operation. It captures all the information(Tensors, attributes
  * and so on) needed for execution.
  * With the SymbolTable and op definition, it create and hold a KernelFrame once and execute any times.
- *
- * An OpExecutable is an item of a CoreRuntime, but it can holds a CoreRuntime instance for function call (e.g. a
- * `cinn.call` op).
  */
 class OpExecutable {
  public:
@@ -51,6 +46,8 @@ class OpExecutable {
  */
 class OpExecutableBuilder : public OpExecutable {
  public:
+  using function_defs_t = std::unordered_map<std::string, mlir::FuncOp>;
+
   OpExecutableBuilder(std::string_view op_name, SymbolTable* symbol_table, KernelRegistry* kernel_registry = nullptr);
   OpExecutableBuilder(OpExecutableBuilder&& other);
 
@@ -62,8 +59,7 @@ class OpExecutableBuilder : public OpExecutable {
 
   void AppendAttribute(Value* value);
 
-  MlirFunctionExecutable* CreateFunctionExecutable(mlir::FuncOp op,
-                                                   MlirToRuntimeTranslator::function_defs_t* function_defs);
+  MlirFunctionExecutable* CreateFunctionExecutable(mlir::FuncOp op, function_defs_t* function_defs);
 
   //! Get the CoreRuntime instance for function call(used in `cinn.call` op).
   CoreRuntimeBuilder* GetCallRuntimeBuilder();

--- a/cinnrt/host_context/value.cc
+++ b/cinnrt/host_context/value.cc
@@ -37,7 +37,7 @@ void CopyTo(const Value& from, Value* to) {
           to->data = arg;
         else if constexpr (std::is_same_v<T, TensorShape>)
           to->data = arg;
-        else if constexpr (std::is_same_v<T, MlirFunction*>)
+        else if constexpr (std::is_same_v<T, MlirFunctionExecutable*>)
           to->data = arg;
         else if constexpr (std::is_same_v<T, DenseHostTensor>)
           to->data = arg;

--- a/cinnrt/host_context/value.h
+++ b/cinnrt/host_context/value.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <glog/logging.h>
 
+#include <llvm/ADT/SmallVector.h>
 #include <utility>
 #include <variant>
-
-#include <llvm/ADT/SmallVector.h>
+#include <vector>
 #include "cinn/common/object.h"
 #include "cinn/common/shared.h"
 #include "cinnrt/host_context/dense_host_tensor.h"
@@ -15,7 +15,7 @@
 namespace cinnrt {
 namespace host_context {
 
-struct MlirFunction;
+struct MlirFunctionExecutable;
 
 using ValueVariantType = std::variant<int16_t,
                                       int32_t,
@@ -24,7 +24,7 @@ using ValueVariantType = std::variant<int16_t,
                                       double,
                                       bool,
                                       TensorShape,
-                                      MlirFunction*,
+                                      MlirFunctionExecutable*,
                                       DenseHostTensor,
                                       std::vector<int16_t>,
                                       std::vector<int32_t>,
@@ -42,7 +42,7 @@ class Value : public cinn::common::Object {
  public:
   using variant_type = ValueVariantType;
 
-  explicit Value() {}
+  explicit Value() {}  // NOLINT
   explicit Value(int32_t x) : data(x) {}
   explicit Value(int64_t x) : data(x) {}
   explicit Value(float x) : data(x) {}
@@ -55,7 +55,7 @@ class Value : public cinn::common::Object {
   explicit Value(std::vector<double>&& x) : data(x) {}
   explicit Value(TensorShape&& x) : data(std::move(x)) {}
   explicit Value(DenseHostTensor&& x) : data(std::move(x)) {}
-  explicit Value(MlirFunction* x) : data(x) {}
+  explicit Value(MlirFunctionExecutable* x) : data(x) {}
 
   template <typename T>
   const T& get() const {

--- a/cinnrt/kernel/control_flow_kernels.cc
+++ b/cinnrt/kernel/control_flow_kernels.cc
@@ -1,14 +1,16 @@
 #include "cinnrt/kernel/control_flow_kernels.h"
+
 #include <glog/logging.h>
+
 #include "cinnrt/host_context/kernel_registry.h"
-#include "cinnrt/host_context/mlir_function.h"
+#include "cinnrt/host_context/mlir_function_executable.h"
 
 namespace cinnrt {
 namespace kernel {
 
 static void CINNCall(host_context::RemainingArguments args,
                      host_context::RemainingResults results,
-                     host_context::Attribute<host_context::MlirFunction*> fn) {
+                     host_context::Attribute<host_context::MlirFunctionExecutable*> fn) {
   VLOG(3) << "running call kernel ...";
   CHECK_EQ(fn.get()->num_arguments(), args.size());
   CHECK_EQ(fn.get()->num_results(), results.size());


### PR DESCRIPTION
Rename MlirFunction to MlirFunctionExecutable.

Make the MlirFunctionExecutable a member of OpExecutable, and it can be cached for multiple executions.