### PR TITLE
add some unary ops' mkl support

### DIFF
--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -998,9 +998,10 @@ std::shared_ptr<OpStrategy> StrategyForSigmoid(const framework::NodeAttr &attrs,
     CHECK(!a.empty()) << "at least one input tensor for sigmoid compute\n";
     Expr A = a[0];
     CHECK(A.as_tensor());
-    auto out    = pe::Sigmoid(A.as_tensor_ref(), UniqName("Sigmoid_output"));
+    auto out = pe::Sigmoid(A.as_tensor_ref(), UniqName("Sigmoid_output"));
+    CHECK(!out.empty());
     auto stages = CreateStages({out});
-    *ret        = CINNValuePack{{CINNValue(Expr(out.get())), CINNValue(stages)}};
+    *ret        = CINNValuePack{{CINNValue(Expr(out.front())), CINNValue(stages)}};
   });
 
   framework::CINNSchedule sigmoid_schedule([=](lang::Args args, lang::RetValue *ret) {

--- a/cinn/hlir/pe/elementwise.h
+++ b/cinn/hlir/pe/elementwise.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "cinn/ir/ir.h"
 
@@ -15,8 +16,9 @@ namespace pe {
  *
  * @return The result Tensor.
  */
-#define HLIR_DCL_UNARY_PE(name__) \
-  ir::Tensor name__(const ir::Tensor& A, const std::string& output_name = "T_" #name__ "_out");
+#define HLIR_DCL_UNARY_PE(name__)                                                                            \
+  std::vector<ir::Tensor> name__(const ir::Tensor& A, const std::string& output_name = "T_" #name__ "_out"); \
+  std::vector<ir::Tensor> name__##MKL(const ir::Tensor& A, const std::string& output_name = "T_" #name__ "_mkl_out");
 
 HLIR_DCL_UNARY_PE(Exp);
 HLIR_DCL_UNARY_PE(Erf);

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -188,7 +188,7 @@ std::vector<Tensor> Depthwise_Conv2d_NCHW(const Tensor &input,
       (input->shape[3] - weight->shape[3] + 2 * pad_w) / stride_w + 1   // W
   };
   auto input_pad =
-      (pad_h == 0 && pad_w == 0) ? Identity(input) : Pad(input, {Expr(0), Expr(0), Expr(pad_h), Expr(pad_w)});
+      (pad_h == 0 && pad_w == 0) ? Identity(input).front() : Pad(input, {Expr(0), Expr(0), Expr(pad_h), Expr(pad_w)});
 
   Var kernel_h = Var(weight->shape[2], "kh");
   Var kernel_w = Var(weight->shape[3], "kw");
@@ -225,7 +225,7 @@ std::vector<Tensor> Depthwise_Conv2d_NHWC(const Tensor &input,
   };
 
   auto input_pad =
-      (pad_h == 0 && pad_w == 0) ? Identity(input) : Pad(input, {Expr(0), Expr(pad_h), Expr(pad_w), Expr(0)});
+      (pad_h == 0 && pad_w == 0) ? Identity(input).front() : Pad(input, {Expr(0), Expr(pad_h), Expr(pad_w), Expr(0)});
 
   Var kernel_h = Var(weight->shape[2], "kh");
   Var kernel_w = Var(weight->shape[3], "kw");
@@ -668,7 +668,7 @@ Tensor DropoutInfer(const ir::Tensor &tensor,
   if (dropout_implementation == "downgrade_in_infer") {
     return Multiply(tensor, Expr(1 - dropout_prob));
   } else if (dropout_implementation == "upscale_in_train") {
-    return Identity(tensor);
+    return Identity(tensor).front();
   } else {
     LOG(FATAL) << "dropout_implementation attr must be 'downgrade_in_infer' or 'upscale_in_train'\n";
   }

--- a/cinn/runtime/cpu/mkl_math.cc
+++ b/cinn/runtime/cpu/mkl_math.cc
@@ -10,59 +10,82 @@
 #include "cinn/backends/function_prototype.h"
 #include "cinn/runtime/cpu/host_intrinsics.h"
 
-void cinn_mkl_tanh_v_fp32(cinn_buffer_t *x, cinn_buffer_t *out) {
-  CHECK_EQ(x->num_elements(), out->num_elements());
-  vsTanh(x->num_elements(), reinterpret_cast<float *>(x->memory), reinterpret_cast<float *>(out->memory));
-}
-void cinn_mkl_tanh_v_fp64(cinn_buffer_t *x, cinn_buffer_t *out) {
-  CHECK_EQ(x->num_elements(), out->num_elements());
-  vdTanh(x->num_elements(), reinterpret_cast<double *>(x->memory), reinterpret_cast<double *>(out->memory));
-}
-void cinn_mkl_exp_v_fp32(cinn_buffer_t *x, cinn_buffer_t *out) {
-  CHECK_EQ(x->num_elements(), out->num_elements());
-  vsExp(x->num_elements(), reinterpret_cast<float *>(x->memory), reinterpret_cast<float *>(out->memory));
-}
-void cinn_mkl_exp_v_fp64(cinn_buffer_t *x, cinn_buffer_t *out) {
-  CHECK_EQ(x->num_elements(), out->num_elements());
-  vdExp(x->num_elements(), reinterpret_cast<double *>(x->memory), reinterpret_cast<double *>(out->memory));
-}
+#define CINN_MKL_VECTOR_MATH_FP(fn__, name__)                                                                    \
+  void cinn_mkl_##name__##_v_fp32(cinn_buffer_t *x, cinn_buffer_t *out) {                                        \
+    CHECK_EQ(x->num_elements(), out->num_elements());                                                            \
+    vs##fn__(x->num_elements(), reinterpret_cast<float *>(x->memory), reinterpret_cast<float *>(out->memory));   \
+  }                                                                                                              \
+  void cinn_mkl_##name__##_v_fp64(cinn_buffer_t *x, cinn_buffer_t *out) {                                        \
+    CHECK_EQ(x->num_elements(), out->num_elements());                                                            \
+    vd##fn__(x->num_elements(), reinterpret_cast<double *>(x->memory), reinterpret_cast<double *>(out->memory)); \
+  }
 
-/*
-void cinn_mkl_cos_v_fp32(cinn_buffer_t *x, cinn_buffer_t *out) {
-  CHECK_EQ(x->num_elements(), out->num_elements());
-  vsCosh(x->num_elements(), reinterpret_cast<float *>(x->memory), reinterpret_cast<float *>(out->memory));
-}
-void cinn_mkl_cos_v_fp64(cinn_buffer_t *x, cinn_buffer_t *out) {
-  CHECK_EQ(x->num_elements(), out->num_elements());
-  vdCosh(x->num_elements(), reinterpret_cast<double *>(x->memory), reinterpret_cast<double *>(out->memory));
-}
-*/
+CINN_MKL_VECTOR_MATH_FP(Exp, exp);
+CINN_MKL_VECTOR_MATH_FP(Erf, erf);
+CINN_MKL_VECTOR_MATH_FP(Sqrt, sqrt);
+CINN_MKL_VECTOR_MATH_FP(Ln, log);
+CINN_MKL_VECTOR_MATH_FP(Floor, floor);
+CINN_MKL_VECTOR_MATH_FP(Ceil, ceil);
+CINN_MKL_VECTOR_MATH_FP(Round, round);
+CINN_MKL_VECTOR_MATH_FP(Tanh, tanh);
+//! Todo: current mklml.so not support
+// CINN_MKL_VECTOR_MATH_FP(Log2, log2);
+// CINN_MKL_VECTOR_MATH_FP(Log10, log10);
+// CINN_MKL_VECTOR_MATH_FP(Trunc, trunc);
+// CINN_MKL_VECTOR_MATH_FP(Cos, cos);
+// CINN_MKL_VECTOR_MATH_FP(Sin, sin);
+// CINN_MKL_VECTOR_MATH_FP(Cosh, cosh);
+// CINN_MKL_VECTOR_MATH_FP(Tan, tan);
+// CINN_MKL_VECTOR_MATH_FP(Sinh, sinh);
+// CINN_MKL_VECTOR_MATH_FP(Acos, acos);
+// CINN_MKL_VECTOR_MATH_FP(Acosh, acosh);
+// CINN_MKL_VECTOR_MATH_FP(Asin, asin);
+// CINN_MKL_VECTOR_MATH_FP(Asinh, asinh);
+// CINN_MKL_VECTOR_MATH_FP(Atan, atan);
+// CINN_MKL_VECTOR_MATH_FP(Atanh, atanh);
 
 CINN_REGISTER_HELPER(mkl_math) {
   using cinn::backends::FunctionProto;
 
   auto host_target = cinn::common::DefaultHostTarget();
 
-  REGISTER_EXTERN_FUNC_HELPER(cinn_mkl_tanh_v_fp32, host_target)
-      .SetRetType<void>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddOutputType<cinn_buffer_t *>()
-      .SetShapeInference(FunctionProto::ShapeFollowNthArgument(0))
+#define REGISTER_MKL_FUNCS(fn__)                                     \
+  REGISTER_EXTERN_FUNC_HELPER(cinn_mkl_##fn__##_v_fp32, host_target) \
+      .SetRetType<void>()                                            \
+      .AddInputType<cinn_buffer_t *>()                               \
+      .AddOutputType<cinn_buffer_t *>()                              \
+      .SetShapeInference(FunctionProto::ShapeFollowNthArgument(0))   \
+      .End();                                                        \
+  REGISTER_EXTERN_FUNC_HELPER(cinn_mkl_##fn__##_v_fp64, host_target) \
+      .SetRetType<void>()                                            \
+      .AddInputType<cinn_buffer_t *>()                               \
+      .AddOutputType<cinn_buffer_t *>()                              \
+      .SetShapeInference(FunctionProto::ShapeFollowNthArgument(0))   \
       .End();
 
-  REGISTER_EXTERN_FUNC_HELPER(cinn_mkl_tanh_v_fp64, host_target)
-      .SetRetType<void>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddOutputType<cinn_buffer_t *>()
-      .SetShapeInference(FunctionProto::ShapeFollowNthArgument(0))
-      .End();
-
-  REGISTER_EXTERN_FUNC_HELPER(cinn_mkl_exp_v_fp32, host_target)
-      .SetRetType<void>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddOutputType<cinn_buffer_t *>()
-      .SetShapeInference(FunctionProto::ShapeFollowNthArgument(0))
-      .End();
+  REGISTER_MKL_FUNCS(exp);
+  REGISTER_MKL_FUNCS(erf);
+  REGISTER_MKL_FUNCS(sqrt);
+  REGISTER_MKL_FUNCS(log);
+  REGISTER_MKL_FUNCS(floor);
+  REGISTER_MKL_FUNCS(ceil);
+  REGISTER_MKL_FUNCS(round);
+  REGISTER_MKL_FUNCS(tanh);
+  //! Todo: current mklml.so not support
+  // REGISTER_MKL_FUNCS(log2);
+  // REGISTER_MKL_FUNCS(log10);
+  // REGISTER_MKL_FUNCS(trunc);
+  // REGISTER_MKL_FUNCS(cos);
+  // REGISTER_MKL_FUNCS(sin);
+  // REGISTER_MKL_FUNCS(cosh);
+  // REGISTER_MKL_FUNCS(tan);
+  // REGISTER_MKL_FUNCS(sinh);
+  // REGISTER_MKL_FUNCS(acos);
+  // REGISTER_MKL_FUNCS(acosh);
+  // REGISTER_MKL_FUNCS(asin);
+  // REGISTER_MKL_FUNCS(asinh);
+  // REGISTER_MKL_FUNCS(atan);
+  // REGISTER_MKL_FUNCS(atanh);
 
   return true;
 }

--- a/cinn/runtime/cpu/mkl_math.h
+++ b/cinn/runtime/cpu/mkl_math.h
@@ -9,10 +9,31 @@ extern "C" {
 
 //! 1 buffer as input, and 1 buffer as output
 // @{
-void cinn_mkl_tanh_v_fp32(cinn_buffer_t* x, cinn_buffer_t* out);
-void cinn_mkl_tanh_v_fp64(cinn_buffer_t* x, cinn_buffer_t* out);
-void cinn_mkl_exp_v_fp32(cinn_buffer_t* x, cinn_buffer_t* out);
-void cinn_mkl_cos_v_fp32(cinn_buffer_t* x, cinn_buffer_t* out);
-void cinn_mkl_cos_v_fp64(cinn_buffer_t* x, cinn_buffer_t* out);
+#define CINN_DECL_MKL_VECTOR_MATH_FP(fn__)                             \
+  void cinn_mkl_##fn__##_v_fp32(cinn_buffer_t* x, cinn_buffer_t* out); \
+  void cinn_mkl_##fn__##_v_fp64(cinn_buffer_t* x, cinn_buffer_t* out);
+
+CINN_DECL_MKL_VECTOR_MATH_FP(exp);
+CINN_DECL_MKL_VECTOR_MATH_FP(erf);
+CINN_DECL_MKL_VECTOR_MATH_FP(sqrt);
+CINN_DECL_MKL_VECTOR_MATH_FP(log);
+CINN_DECL_MKL_VECTOR_MATH_FP(log2);
+CINN_DECL_MKL_VECTOR_MATH_FP(log10);
+CINN_DECL_MKL_VECTOR_MATH_FP(floor);
+CINN_DECL_MKL_VECTOR_MATH_FP(ceil);
+CINN_DECL_MKL_VECTOR_MATH_FP(round);
+CINN_DECL_MKL_VECTOR_MATH_FP(trunc);
+CINN_DECL_MKL_VECTOR_MATH_FP(cos);
+CINN_DECL_MKL_VECTOR_MATH_FP(sin);
+CINN_DECL_MKL_VECTOR_MATH_FP(cosh);
+CINN_DECL_MKL_VECTOR_MATH_FP(tan);
+CINN_DECL_MKL_VECTOR_MATH_FP(tanh);
+CINN_DECL_MKL_VECTOR_MATH_FP(sinh);
+CINN_DECL_MKL_VECTOR_MATH_FP(acos);
+CINN_DECL_MKL_VECTOR_MATH_FP(acosh);
+CINN_DECL_MKL_VECTOR_MATH_FP(asin);
+CINN_DECL_MKL_VECTOR_MATH_FP(asinh);
+CINN_DECL_MKL_VECTOR_MATH_FP(atan);
+CINN_DECL_MKL_VECTOR_MATH_FP(atanh);
 // @}
 }

--- a/cinn/runtime/cpu/mkl_math_test.cc
+++ b/cinn/runtime/cpu/mkl_math_test.cc
@@ -97,20 +97,22 @@ bool isinf(float e) { return std::isinf(e); }
 
 #define TEST_MKL_MATH_FP32(test_name__, is_elementwise) \
   TEST(mkl_math, test_name__) { TestCallElementwise(#test_name__, test_name__, is_elementwise); }
+#define TEST_CINN_MKL_MATH_FP32(test_name__, is_elementwise) \
+  TEST(mkl_math, test_name__) { TestCallElementwise("cinn_mkl_" #test_name__ "_v_fp32", test_name__, is_elementwise); }
 #define TEST_MKL_MATH_FP32_BOOL(test_name__, is_elementwise) \
   TEST(mkl_math, test_name__) { TestCallElementwise(#test_name__, test_name__, is_elementwise, Bool()); }
 #define TEST_MKL_MATH_FP32_SET(test_name__, is_elementwise, value) \
   TEST(mkl_math, test_name__) { TestCallElementwise(#test_name__, test_name__, is_elementwise, Float(32), value); }
 
-TEST_MKL_MATH_FP32(exp, true)
-TEST_MKL_MATH_FP32(erf, true)
-TEST_MKL_MATH_FP32(sqrt, true)
-TEST_MKL_MATH_FP32(log, true)
+TEST_CINN_MKL_MATH_FP32(exp, false)
+TEST_CINN_MKL_MATH_FP32(erf, false)
+TEST_CINN_MKL_MATH_FP32(sqrt, false)
+TEST_CINN_MKL_MATH_FP32(log, false)
 TEST_MKL_MATH_FP32(log2, true)
 TEST_MKL_MATH_FP32(log10, true)
-TEST_MKL_MATH_FP32(floor, true)
-TEST_MKL_MATH_FP32(ceil, true)
-TEST_MKL_MATH_FP32(round, true)
+TEST_CINN_MKL_MATH_FP32(floor, false)
+TEST_CINN_MKL_MATH_FP32(ceil, false)
+TEST_CINN_MKL_MATH_FP32(round, false)
 TEST_MKL_MATH_FP32(trunc, true)
 TEST_MKL_MATH_FP32(cos, true)
 TEST_MKL_MATH_FP32(cosh, true)
@@ -124,7 +126,7 @@ TEST_MKL_MATH_FP32(asinh, true)
 TEST_MKL_MATH_FP32(atan, true)
 TEST_MKL_MATH_FP32(atanh, true)
 TEST_MKL_MATH_FP32_BOOL(isnan, true)
-TEST_MKL_MATH_FP32(tanh, true)
+TEST_CINN_MKL_MATH_FP32(tanh, false)
 TEST_MKL_MATH_FP32_BOOL(isfinite, true)
 TEST_MKL_MATH_FP32_BOOL(isinf, true)
 
@@ -149,9 +151,9 @@ TEST(cinn_cpu_mkl_gemm_fp32, test) {
                                     K,                           // K
                                     common::make_bool(false),    // ta
                                     common::make_bool(false),    // tb
-                                    M,                           // lda
-                                    K,                           // ldb
-                                    M,                           // ldc
+                                    K,                           // lda
+                                    N,                           // ldb
+                                    N,                           // ldc
                                     common::make_zero<float>(),  // beta
                                     A.tensor(),                  // A
                                     B.tensor(),                  // B

--- a/python/tests/test_pe_elementwise.py
+++ b/python/tests/test_pe_elementwise.py
@@ -92,8 +92,11 @@ class TestPEElementwise(unittest.TestCase):
 
         func_name = "test_" + fn_name
 
-        stages = create_stages([x.to_tensor(), y])
-        func = lang.lower(func_name, stages, [x.to_tensor(), y])
+        args = [x.to_tensor()]
+        for out in y:
+            args.append(out)
+        stages = create_stages(args)
+        func = lang.lower(func_name, stages, args)
 
         builder = lang.Module.Builder("elementwise_module", self.target)
         builder.add_function(func)

--- a/tests/benchmark/test_all_ops_default.cc
+++ b/tests/benchmark/test_all_ops_default.cc
@@ -211,21 +211,27 @@ TEST_DEFAULT1(slice, slice, type, type, attr_store_slice)
   TEST_DEFAULT(op__, unary_##op__, type, type)                           \
   TEST_DEFAULT(op__, unary_##op__##1, type, type)
 
-TEST_DEFAULT_UNARY(exp)
-TEST_DEFAULT_UNARY(erf)
+#define TEST_DEFAULT_UNARY1(op__)                                        \
+  std::vector<std::vector<int>> shapes_unary_##op__    = {{1024, 2048}}; \
+  std::vector<std::vector<int>> shapes_unary_##op__##1 = {{3, 1000}};    \
+  TEST_DEFAULT(op__, unary_##op__, type, type1)                          \
+  TEST_DEFAULT(op__, unary_##op__##1, type, type1)
+
+TEST_DEFAULT_UNARY1(exp)
+TEST_DEFAULT_UNARY1(erf)
 TEST_DEFAULT_UNARY(sigmoid)
-TEST_DEFAULT_UNARY(sqrt)
-TEST_DEFAULT_UNARY(log)
+TEST_DEFAULT_UNARY1(sqrt)
+TEST_DEFAULT_UNARY1(log)
 TEST_DEFAULT_UNARY(log2)
 TEST_DEFAULT_UNARY(log10)
-TEST_DEFAULT_UNARY(floor)
-TEST_DEFAULT_UNARY(ceil)
-TEST_DEFAULT_UNARY(round)
+TEST_DEFAULT_UNARY1(floor)
+TEST_DEFAULT_UNARY1(ceil)
+TEST_DEFAULT_UNARY1(round)
 TEST_DEFAULT_UNARY(trunc)
 TEST_DEFAULT_UNARY(cos)
 TEST_DEFAULT_UNARY(cosh)
 TEST_DEFAULT_UNARY(tan)
-TEST_DEFAULT_UNARY(tanh)
+TEST_DEFAULT_UNARY1(tanh)
 TEST_DEFAULT_UNARY(sin)
 TEST_DEFAULT_UNARY(sinh)
 TEST_DEFAULT_UNARY(acos)


### PR DESCRIPTION
add some unary ops' mkl support
e.g. for exp with shape[1024,2048], it can be optimized from 8.146118 to 0.0949286 ms.
Currently only support exp, erf, sqrt, log, tanh, floor, ceil, round  with mkl. See whether there is necessity to support next.
