### PR TITLE
add benchmark op. support executing region. add BenchmarkStats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 *.swp
+*.swo
+*.swn
 *.pyc
 *.o
 *.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ add_dependencies(cinncore GEN_LLVM_RUNTIME_IR_HEADER
         # MLIR td file generations
         ops_inc
         basic_kernels_inc
+        test_kernels_inc
         cinn_base_inc
         tensor_shape_inc
         dense_tensor_inc

--- a/cinnrt/dialect/CMakeLists.txt
+++ b/cinnrt/dialect/CMakeLists.txt
@@ -51,3 +51,4 @@ cc_test(test_mlir_loader SRCS mlir_loader_test.cc DEPS cinncore ${MLIR_IR_LIBS})
 # execute mlir and run FileCheck
 cinn_exec_check(run_and_check_tensor_type mlir_tests/tensor_type.mlir)
 cinn_exec_check(run_and_check_basic mlir_tests/basic.mlir)
+cinn_exec_check(run_and_check_benchmark mlir_tests/benchmark.mlir)

--- a/cinnrt/dialect/CMakeLists.txt
+++ b/cinnrt/dialect/CMakeLists.txt
@@ -4,6 +4,7 @@ core_gather_srcs(SRCS
     dialect.cc
     types.cc
     basic_kernels.cc
+    test_kernels.cc
     cinn_base.cc
     init_cinn_dialects.cc
     tensor_shape.cc
@@ -16,6 +17,7 @@ core_gather_srcs(SRCS
 
 mlir_tablegen_on(ops)
 mlir_tablegen_on(basic_kernels)
+mlir_tablegen_on(test_kernels)
 mlir_tablegen_on(cinn_base DIALECT cinn)
 mlir_tablegen_on(tensor_shape DIALECT ts)
 mlir_tablegen_on(dense_tensor DIALECT dt)

--- a/cinnrt/dialect/basic_kernels.h
+++ b/cinnrt/dialect/basic_kernels.h
@@ -2,8 +2,9 @@
 #include <mlir/IR/OpDefinition.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 
-namespace cinnrt::dialect {
 using namespace mlir;  // NOLINT
+
+namespace cinnrt::dialect {
 #define GET_OP_CLASSES
 #include "cinnrt/dialect/basic_kernels.hpp.inc"
 }  // namespace cinnrt::dialect

--- a/cinnrt/dialect/cinn_base.cc
+++ b/cinnrt/dialect/cinn_base.cc
@@ -2,6 +2,7 @@
 
 #include "cinnrt/dialect/basic_kernels.h"
 #include "cinnrt/dialect/dense_tensor.h"
+#include "cinnrt/dialect/test_kernels.h"
 
 namespace cinnrt::dialect {
 
@@ -12,11 +13,14 @@ void CINNDialect::initialize() {
 
   addTypes<cinnrt::dt::TensorType>();
 
-#define GET_OP_LIST
   addOperations<
+#define GET_OP_LIST
 #include "cinnrt/dialect/basic_kernels.cpp.inc"
       >();
-#undef GET_OP_LIST
+  addOperations<
+#define GET_OP_LIST
+#include "cinnrt/dialect/test_kernels.cpp.inc"
+      >();
 }
 
 mlir::Type CINNDialect::parseType(mlir::DialectAsmParser &parser) const {

--- a/cinnrt/dialect/mlir_tests/benchmark.mlir
+++ b/cinnrt/dialect/mlir_tests/benchmark.mlir
@@ -1,6 +1,17 @@
 // CHECK-LABEL: @benchmark
 func @benchmark() {
-  cinn.benchmark "add.f32"() duration_secs = 1, max_count = 10, num_warmup_runs = 0
+  // CHECK-LABEL: BM:add.f32:Duration(ns)
+  // CHECK-LABEL: BM:add.f32:Count: 3
+  // CHECK-LABEL: BM:add.f32:Time Min(ns)
+  // CHECK-LABEL: BM:add.f32:Time 50%(ns)
+  // CHECK-LABEL: BM:add.f32:Time 95%(ns)
+  // CHECK-LABEL: BM:add.f32:Time 99%(ns)
+  // CHECK-LABEL: BM:add.f32:CPU Min(ns)
+  // CHECK-LABEL: BM:add.f32:CPU 50%(ns)
+  // CHECK-LABEL: BM:add.f32:CPU 95%(ns)
+  // CHECK-LABEL: BM:add.f32:CPU 99%(ns)
+  // CHECK-LABEL: BM:add.f32:CPU utilization(percent)
+  cinn.benchmark "add.f32"() duration_secs = 1, max_count = 3, num_warmup_runs = 3
   {
     %0 = cinn.constant.f32 1.0
     %1 = cinn.constant.f32 2.0

--- a/cinnrt/dialect/mlir_tests/benchmark.mlir
+++ b/cinnrt/dialect/mlir_tests/benchmark.mlir
@@ -1,0 +1,12 @@
+// CHECK-LABEL: @benchmark
+func @benchmark() {
+  cinn.benchmark "add.f32"() duration_secs = 1, max_count = 10, num_warmup_runs = 0
+  {
+    %0 = cinn.constant.f32 1.0
+    %1 = cinn.constant.f32 2.0
+    %res = "cinn.add.f32"(%0, %1) : (f32, f32) -> f32
+    "cinn.print.f32"(%res) : (f32) -> ()
+    cinn.return %res : f32
+  }
+  cinn.return
+}

--- a/cinnrt/dialect/test_kernels.cc
+++ b/cinnrt/dialect/test_kernels.cc
@@ -1,0 +1,138 @@
+#include "cinnrt/dialect/test_kernels.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/IR/TypeUtilities.h"
+
+namespace cinnrt::dialect {
+
+//===----------------------------------------------------------------------===//
+// BenchmarkOp
+//===----------------------------------------------------------------------===//
+
+// Parse the BenchmarkOp in the following format
+// cinn.benchmark "add.i32"(%c : i32, %d : f32)
+//       max_count = 100, duration_secs = 1 {
+// ...
+// }
+
+static ParseResult parseBenchmarkOp(OpAsmParser &parser, OperationState &result) {
+  StringAttr nameAttr;
+  if (parser.parseAttribute(nameAttr, "name", result.attributes)) return failure();
+
+  // Parse the operands, e.g. (%c : i32, %d : f32)
+  if (parser.parseLParen()) return failure();
+
+  SmallVector<OpAsmParser::OperandType, 4> operands;
+  SmallVector<Type, 4> types;
+  llvm::SMLoc type_loc = parser.getCurrentLocation();
+
+  if (parser.parseOptionalRParen()) {
+    // Parse non-empty operands
+    do {
+      // Parse %c : i32,
+      OpAsmParser::OperandType operand;
+      Type type;
+
+      if (parser.parseOperand(operand) || parser.parseColonType(type)) return failure();
+
+      operands.push_back(operand);
+      types.push_back(type);
+
+    } while (succeeded(parser.parseOptionalComma()));
+
+    if (parser.parseRParen()) return failure();
+  }
+
+  if (parser.resolveOperands(operands, types, type_loc, result.operands)) return failure();
+
+  // Parse the keyword attribute, e.g. max_count = 100, duration_secs = 1
+  do {
+    StringRef attr;
+    Attribute resultAttr;
+    if (parser.parseKeyword(&attr) || parser.parseEqual() ||
+        parser.parseAttribute(resultAttr, parser.getBuilder().getIntegerType(32), attr, result.attributes))
+      return failure();
+  } while (succeeded(parser.parseOptionalComma()));
+
+  // Set the default attribute num_warmup_runs to 1 if unset
+  auto setDefaultAttrIfUnset = [&](const char *attr_name, int value) {
+    bool found =
+        llvm::any_of(result.attributes, [attr_name](const NamedAttribute &attr) { return attr.first == attr_name; });
+    if (!found) {
+      IntegerAttr default_val = parser.getBuilder().getI32IntegerAttr(value);
+      result.addAttribute(attr_name, default_val);
+    }
+  };
+  setDefaultAttrIfUnset("num_warmup_runs", 1);
+
+  Region *target = result.addRegion();
+  return parser.parseRegion(*target,
+                            operands,
+                            types,
+                            /*enableNameShadowing=*/true);
+}
+
+// Print the BenchmarkOp in the following format
+// cinn.benchmark "add.i32"(%c : i32, %d : f32)
+//       max_count = 100, duration_secs = 1 {
+// ...
+// }
+static void print(OpAsmPrinter &p, BenchmarkOp op) {
+  p << "cinn.benchmark ";
+
+  // Print the name attribute, e.g "add.i32"
+  auto name_attr = op.getAttr("name");
+  p << name_attr;
+
+  // Print the operands and types, e.g. (%c : i32, %d : f32)
+  p << '(';
+  llvm::interleaveComma(llvm::zip(op.getOperands(), op.getOperandTypes()), p, [&](const auto &it) {
+    p << std::get<0>(it) << " : " << std::get<1>(it);
+  });
+  p << ") ";
+
+  bool need_comma = false;
+  // Print the attributes, e.g. max_count = 100, duration_secs = 1
+  for (auto &name_attr : op.getAttrs()) {
+    auto id = name_attr.first;
+    if (id == "name") continue;
+    if (need_comma) p << ", ";
+    auto attr = name_attr.second;
+    p << id << " = ";
+    if (auto int_attr = attr.dyn_cast<IntegerAttr>()) {
+      int_attr.getValue().print(p.getStream(), /*isSigned=*/false);
+    } else {
+      op.emitOpError("Unexpected attribute");
+    }
+    need_comma = true;
+  }
+  p << ' ';
+
+  // Print the region
+  // Reuse the argument names provided to the op for the bbarg names within
+  // the region.
+  p.shadowRegionArgs(op.region(), op.getOperands());
+  p.printRegion(op.region(), /*printEntryBlockArgs=*/false);
+}
+
+static LogicalResult verify(BenchmarkOp op) {
+  // Verify that the target benchmark region has exactly one return value.
+  auto &region  = op.region();
+  auto &last_op = region.front().back();
+  if (last_op.getName().getStringRef() != "cinn.return") {
+    return op.emitOpError("missing return statement");
+  }
+  if (last_op.getNumOperands() != 1) {
+    return op.emitOpError("incorrect number of return values. One return value is expected");
+  }
+
+  return success();
+}
+
+#define GET_OP_CLASSES
+#include "cinnrt/dialect/test_kernels.cpp.inc"
+
+}  // namespace cinnrt::dialect

--- a/cinnrt/dialect/test_kernels.h
+++ b/cinnrt/dialect/test_kernels.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+namespace cinnrt::dialect {
+using namespace mlir;  // NOLINT
+#define GET_OP_CLASSES
+#include "cinnrt/dialect/test_kernels.hpp.inc"
+}  // namespace cinnrt::dialect

--- a/cinnrt/dialect/test_kernels.td
+++ b/cinnrt/dialect/test_kernels.td
@@ -1,0 +1,65 @@
+// Operation definitions for testing.
+
+#ifdef TEST_OPS
+#else
+#define TEST_OPS
+
+include "cinnrt/dialect/cinn_base.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+// Base class for Test dialect ops.
+class Test_Op<string mnemonic, list<OpTrait> traits = []> :
+    Op<CINN_Dialect, mnemonic, !listconcat(traits, [IsolatedFromAbove])> {
+
+  // Each registered op in the Test namespace needs to provide all of a printer,
+  // parser and verifier.
+  let printer = [{ return cinnrt::dialect::print(p, *this); }];
+  let verifier = [{ return cinnrt::dialect::verify(*this); }];
+  let parser = [{ return cinnrt::dialect::parse$cppClass(parser, result); }];
+}
+
+def BenchmarkOp : Test_Op<"benchmark"> {
+  let summary = "benchmark operation";
+  let description = [{
+     The "cinn.benchmark" operation benchmarks the performance of an MLIR
+     region by executing the given MLIR region repeatedly up to the
+     `duratino_secs` seconds or `max_count` times. `num_warmup_runs` specifies
+     the number of warm up runs to run the given MLIR region before the
+     benchmark starts.
+
+     The target MLIR region can take an arbitrary number of arguments and
+     should return exactly one value. The arguments for the MLIR region are
+     provided as the operands of the cinn.benchmark op.
+
+     Example:
+       cinn.benchmark "add.i32"(%c : i32, %d : f32) max_count = 100, duration_secs = 1 {
+         // code for benchmarking
+         ...
+       }
+
+       cinn.benchmark "add.i32"(%c : i32)
+         duration_secs = 1,
+         max_count = 100,
+         num_warmup_runs = 10 {
+         // The MLIR code to be benchmarked goes here.
+         // The following code benchmarks the cinn.add.i32 kernel.
+         %x = cinn.add.i32 %c, %c
+         // The benchmarked function needs to return exactly one value.
+         cinn.return %x : i32
+       }
+  }];
+
+  let regions = (region SizedRegion<1>:$region);
+
+  let arguments = (ins
+    Variadic<AnyType>,
+    I32Attr:$duration_secs,
+    I32Attr:$max_count,
+    StrAttr:$name,
+    DefaultValuedAttr<I32Attr, "1">:$num_warmup_runs
+  );
+
+  let results = (outs);
+}
+
+#endif  // TEST_OPS

--- a/cinnrt/host_context/core_runtime.cc
+++ b/cinnrt/host_context/core_runtime.cc
@@ -23,6 +23,7 @@ SymbolTable* CoreRuntime::symbol_table() { return &impl_->symbol_table; }
 CoreRuntime::CoreRuntime(CoreRuntime::Impl* impl) : impl_(impl) { CHECK(impl); }
 
 void CoreRuntime::Execute() {
+  // std::cout << "CoreRuntime::Execute" << std::endl;
   int op_offset = 0;
   for (auto& op : impl_->op_executables) {
     VLOG(3) << "running op " << op_offset++ << " " << op.name();

--- a/cinnrt/host_context/function.h
+++ b/cinnrt/host_context/function.h
@@ -28,7 +28,9 @@ class Function {
   size_t num_arguments() const { return num_arguments_; }
   size_t num_results() const { return num_results_; }
 
-  virtual void Execute(llvm::ArrayRef<Value*> arguments, llvm::MutableArrayRef<ValueRef> results) const {}
+  virtual void Execute(llvm::ArrayRef<Value*> arguments,
+                       llvm::MutableArrayRef<ValueRef> results,
+                       bool is_region = false) const {}
 
   virtual ~Function() = default;
 

--- a/cinnrt/host_context/mlir_exec.cc
+++ b/cinnrt/host_context/mlir_exec.cc
@@ -12,6 +12,7 @@
 #include "cinnrt/kernel/control_flow_kernels.h"
 #include "cinnrt/kernel/tensor_kernels.h"
 #include "cinnrt/kernel/tensor_shape_kernels.h"
+#include "cinnrt/kernel/test_kernels.h"
 #include "llvm/Support/DynamicLibrary.h"
 
 static llvm::cl::list<std::string> cl_shared_libs(  // NOLINT
@@ -32,6 +33,7 @@ int main(int argc, char** argv) {
   host_context::KernelRegistry registry;
 
   kernel::RegisterBasicKernels(&registry);
+  kernel::RegisterTestKernels(&registry);
   kernel::RegisterTensorShapeKernels(&registry);
   kernel::RegisterTensorKernels(&registry);
   kernel::RegisterControlFlowKernels(&registry);

--- a/cinnrt/host_context/mlir_function_executable.h
+++ b/cinnrt/host_context/mlir_function_executable.h
@@ -1,6 +1,9 @@
 #pragma once
-
 #include <mlir/IR/Function.h>
+
+#include <string>
+#include <unordered_map>
+
 #include "cinnrt/host_context/core_runtime.h"
 #include "cinnrt/host_context/function.h"
 #include "cinnrt/host_context/mlir_to_runtime_translate.h"
@@ -23,21 +26,26 @@ class MlirFunctionExecutable : public Function, public MlirToRuntimeTranslator {
 
   MlirFunctionExecutable(mlir::FuncOp func_op, KernelRegistry* kernel_registry, function_defs_t& function_table);
 
+  MlirFunctionExecutable(mlir::Region* region,
+                         mlir::FunctionType func_type,
+                         KernelRegistry* kernel_registry,
+                         MlirToRuntimeTranslator::function_defs_t& function_table);
+
   /**
    * Execute the function with the given arguments and results.
    * NOTE the \param arguments and \param results should not be altered.
    */
-  void Execute(llvm::ArrayRef<Value*> arguments, llvm::MutableArrayRef<ValueRef> results) const override;
+  void Execute(llvm::ArrayRef<Value*> arguments, llvm::MutableArrayRef<ValueRef> results, bool is_region = false) const;
 
  private:
   /**
    * Build the runtime executables once the function call arguments and results are passed in.
    * This will trigger in the first execution.
    */
-  void BuildExecutables(llvm::ArrayRef<Value*> arguments, llvm::MutableArrayRef<ValueRef> results);
+  void BuildExecutables(llvm::ArrayRef<Value*> arguments, llvm::MutableArrayRef<ValueRef> results, bool is_region);
 
  private:
-  mlir::FuncOp func_op_;
+  mlir::Region* region_;
   CoreRuntimeBuilder core_runtime_builder_;
   MlirToRuntimeTranslator::function_defs_t& function_table_;
   std::function<void()> copy_res_fn_;

--- a/cinnrt/host_context/op_executable.cc
+++ b/cinnrt/host_context/op_executable.cc
@@ -75,7 +75,17 @@ MlirFunctionExecutable* OpExecutableBuilder::CreateFunctionExecutable(
   return impl_->mlir_function_executable.get();
 }
 
+MlirFunctionExecutable* OpExecutableBuilder::CreateFunctionExecutable(mlir::Region* region,
+                                                                      mlir::FunctionType func_type,
+                                                                      function_defs_t* function_defs) {
+  CHECK(!impl_->mlir_function_executable);
+  impl_->mlir_function_executable.reset(
+      new MlirFunctionExecutable(region, func_type, impl_->kernel_registry, *function_defs));
+  return impl_->mlir_function_executable.get();
+}
+
 void OpExecutable::Execute() {
+  // std::cout << "OpExecutable::Execute" << std::endl;
 #ifndef NDEBUG
   VLOG(3) << "execute " << name() << " --- frame args: " << impl_->frame.GetNumArgs() << " results "
           << impl_->frame.GetNumResults() << " attributes " << impl_->frame.GetNumAttributes();

--- a/cinnrt/host_context/op_executable.h
+++ b/cinnrt/host_context/op_executable.h
@@ -5,6 +5,9 @@
 #include <string>
 #include <string_view>
 
+#include "mlir/IR/Function.h"
+#include "mlir/IR/Region.h"
+
 namespace mlir {
 class FuncOp;
 }  // namespace mlir
@@ -60,6 +63,10 @@ class OpExecutableBuilder : public OpExecutable {
   void AppendAttribute(Value* value);
 
   MlirFunctionExecutable* CreateFunctionExecutable(mlir::FuncOp op, function_defs_t* function_defs);
+
+  MlirFunctionExecutable* CreateFunctionExecutable(mlir::Region* region,
+                                                   mlir::FunctionType func_type,
+                                                   function_defs_t* function_defs);
 
   //! Get the CoreRuntime instance for function call(used in `cinn.call` op).
   CoreRuntimeBuilder* GetCallRuntimeBuilder();

--- a/cinnrt/host_context/value.h
+++ b/cinnrt/host_context/value.h
@@ -2,6 +2,7 @@
 #include <glog/logging.h>
 #include <llvm/ADT/SmallVector.h>
 
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -24,6 +25,7 @@ using ValueVariantType = cinnrt::Variant<int16_t,
                                          float,
                                          double,
                                          bool,
+                                         std::string,
                                          tensor::TensorShape,
                                          tensor::DenseHostTensor,
                                          MlirFunctionExecutable*,
@@ -49,6 +51,7 @@ class Value : public cinnrt::common::Object {
   explicit Value(float x) : data(x) {}
   explicit Value(double x) : data(x) {}
   explicit Value(bool x) : data(x) {}
+  explicit Value(std::string x) : data(x) {}
   explicit Value(std::vector<int16_t>&& x) : data(x) {}
   explicit Value(std::vector<int32_t>&& x) : data(x) {}
   explicit Value(std::vector<int64_t>&& x) : data(x) {}

--- a/cinnrt/kernel/CMakeLists.txt
+++ b/cinnrt/kernel/CMakeLists.txt
@@ -2,6 +2,7 @@ core_gather_headers()
 
 core_gather_srcs(SRCS
     basic_kernels.cc
+    test_kernels.cc
     tensor_shape_kernels.cc
     tensor_kernels.cc
     control_flow_kernels.cc

--- a/cinnrt/kernel/test_kernels.cc
+++ b/cinnrt/kernel/test_kernels.cc
@@ -1,0 +1,245 @@
+#include "cinnrt/kernel/test_kernels.h"
+
+#include <cassert>
+//#include <chrono>
+//#include <ctime>
+#include <iostream>
+#include <string>
+
+#include "cinnrt/host_context/kernel_registry.h"
+#include "cinnrt/host_context/kernel_utils.h"
+#include "cinnrt/host_context/mlir_function_executable.h"
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+using cinnrt::host_context::Attribute;
+using cinnrt::host_context::MlirFunctionExecutable;
+using cinnrt::host_context::RemainingArguments;
+
+namespace cinnrt::kernel {
+namespace {
+// class BenchmarkStats {
+// public:
+//  BenchmarkStats(llvm::StringRef name, int num_warmup_runs, int max_count,
+//                 std::chrono::microseconds benchmark_duration)
+//      : name_{name},
+//        num_warmup_runs_{num_warmup_runs},
+//        max_count_{max_count},
+//        benchmark_duration_{benchmark_duration} {}
+//
+//  void StartRun() {
+//    ++cur_count_;
+//    // Start recording CPU time.
+//    cur_start_cpu_ = std::clock();
+//    cur_start_walltime_ = std::chrono::steady_clock::now();
+//  }
+//
+//  void StopRun() {
+//    // Do not collect the runtime statistics if we are still in the warm up
+//    // period.
+//    if (cur_count_ <= num_warmup_runs_) return;
+//
+//    // Stop the wall clock timer.
+//    auto cur_stop_walltime_ = std::chrono::steady_clock::now();
+//
+//    // Stop the CPU timer.
+//    std::clock_t cur_stop_cpu_ = std::clock();
+//
+//    // Collect the wall clock duration.
+//    auto duration_walltime_ = cur_stop_walltime_ - cur_start_walltime_;
+//    run_times_walltime_.push_back(duration_walltime_);
+//
+//    // Collect the CPU duration in microseconds.
+//    // First cast to integer that represents microseconds with truncation, as
+//    // does std::chrono::duration_cast. Then cast to std::chrono::microseconds.
+//    std::clock_t duration_cpu_raw = cur_stop_cpu_ - cur_start_cpu_;
+//    auto duration_cpu_ = static_cast<std::chrono::nanoseconds>(
+//        static_cast<int64_t>(1e9 * duration_cpu_raw / CLOCKS_PER_SEC));
+//
+//    run_times_cpu_.push_back(duration_cpu_);
+//
+//    total_duration_walltime_ += duration_walltime_;
+//    total_duration_cpu_ += duration_cpu_;
+//  }
+//  // Return if we should we run more rounds.
+//  bool MoreRun() const {
+//    return cur_count_ < max_count_ + num_warmup_runs_ &&
+//           total_duration_walltime_ < benchmark_duration_;
+//  }
+//
+//  // Summarize the benchmark results.
+//  void Summarize() {
+//    std::sort(run_times_walltime_.begin(), run_times_walltime_.end());
+//    std::sort(run_times_cpu_.begin(), run_times_cpu_.end());
+//
+//    auto percentile =
+//        [](double p, const std::vector<std::chrono::nanoseconds>& run_times) {
+//          assert(p >= 0.0 && p <= 1.0);
+//          return run_times[run_times.size() * p];
+//        };
+//
+//    // BM: prefix is added to make grepping results from lit output easier.
+//    std::string prefix;
+//    llvm::raw_string_ostream(prefix) << "BM:" << name_ << ':';
+//    auto cpu_utilization =
+//        total_duration_cpu_.count() * 100.0 / total_duration_walltime_.count();
+//
+//    llvm::outs() << prefix
+//                 << "Duration(ns): " << total_duration_walltime_.count()
+//                 << '\n';
+//    llvm::outs() << prefix << "Count: " << run_times_walltime_.size() << '\n';
+//    llvm::outs() << prefix
+//                 << "Time Min(ns): " << run_times_walltime_.front().count()
+//                 << '\n';
+//    llvm::outs() << prefix << "Time 50%(ns): "
+//                 << percentile(0.5, run_times_walltime_).count() << '\n';
+//    llvm::outs() << prefix << "Time 95%(ns): "
+//                 << percentile(0.95, run_times_walltime_).count() << '\n';
+//    llvm::outs() << prefix << "Time 99%(ns): "
+//                 << percentile(0.99, run_times_walltime_).count() << '\n';
+//    // Log CPU time statistics.
+//    llvm::outs() << prefix << "CPU Min(ns): " << run_times_cpu_.front().count()
+//                 << '\n';
+//    llvm::outs() << prefix
+//                 << "CPU 50%(ns): " << percentile(0.5, run_times_cpu_).count()
+//                 << '\n';
+//    llvm::outs() << prefix
+//                 << "CPU 95%(ns): " << percentile(0.95, run_times_cpu_).count()
+//                 << '\n';
+//    llvm::outs() << prefix
+//                 << "CPU 99%(ns): " << percentile(0.99, run_times_cpu_).count()
+//                 << '\n';
+//    llvm::outs() << prefix << "CPU utilization(percent): " << cpu_utilization
+//                 << "\n";
+//    llvm::outs().flush();
+//  }
+//
+// private:
+//  const std::string name_;
+//  const int num_warmup_runs_;
+//  const int max_count_;
+//  int cur_count_ = 0;
+//  const std::chrono::nanoseconds benchmark_duration_;
+//  std::chrono::nanoseconds total_duration_walltime_{};
+//  std::chrono::nanoseconds total_duration_cpu_{};
+//  std::chrono::time_point<std::chrono::steady_clock> cur_start_walltime_{};
+//  std::clock_t cur_start_cpu_;
+//  std::vector<std::chrono::nanoseconds> run_times_walltime_;
+//  // CPU run times in microseconds.
+//  std::vector<std::chrono::nanoseconds> run_times_cpu_;
+//};
+//
+// class AsyncBenchmarkRunner {
+// public:
+//  AsyncBenchmarkRunner(BenchmarkStats bm_stats, const Function* func,
+//                       ArrayRef<AsyncValue*> args,
+//                       const ExecutionContext& exec_ctx)
+//      : bm_stats_(std::move(bm_stats)),
+//        func_{FormRef(func)},
+//        args_{args.begin(), args.end()},
+//        exec_ctx_(exec_ctx) {
+//    // AddRef on the arg AsyncValue to take an ownership ref.
+//    for (auto& arg : args_) {
+//      arg->AddRef();
+//    }
+//  }
+//
+//  // Disable copy constructor and assignment.
+//  AsyncBenchmarkRunner(const AsyncBenchmarkRunner&) = delete;
+//  AsyncBenchmarkRunner& operator=(const AsyncBenchmarkRunner&) = delete;
+//
+//  ~AsyncBenchmarkRunner() {
+//    // DropRef on the arg AsyncValue to release the ownership ref.
+//    for (auto& arg : args_) {
+//      arg->DropRef();
+//    }
+//  }
+//
+//  void Start(llvm::unique_function<void()> clean_up) {
+//    clean_up_ = std::move(clean_up);
+//    StartNewRun();
+//  }
+// private:
+//  // Start benchmarking a new function execution.
+//  void StartNewRun() {
+//    bm_stats_.StartRun();
+//    // We need to run the actual work in the work queue to avoid exhausting the
+//    // stack space, otherwise, we will have very deep recursion of
+//    // Function::Execute -> AsyncValue::AndThen -> Function::Execute -> ...
+//    EnqueueWork(exec_ctx_, [this] {
+//      // The benchmarked function should return exactly one value.
+//      assert(func_->result_types().size() == 1);
+//
+//      RCReference<AsyncValue> result;
+//      func_->Execute(exec_ctx_, /*arguments=*/args_, /*results=*/result);
+//
+//      // AndThen() is called when the function execution finishes. We record the
+//      // execution time and start the next run in the AndThen() callback.
+//      // Therefore, each of the function execution is run serially.
+//      auto* result_ptr = result.release();
+//      result_ptr->AndThen([this, result_ptr]() mutable {
+//        bm_stats_.StopRun();
+//        result_ptr->DropRef();
+//
+//        if (bm_stats_.MoreRun()) {
+//          StartNewRun();
+//        } else {
+//          bm_stats_.Summarize();
+//          clean_up_();
+//        }
+//      });
+//    });
+//  }
+//
+//  BenchmarkStats bm_stats_;
+//  RCReference<const Function> func_;
+//  SmallVector<AsyncValue*, 4> args_;
+//  ExecutionContext exec_ctx_;
+//  // Clean up function to run after the end of the benchmark.
+//  llvm::unique_function<void()> clean_up_;
+//};
+}  // namespace
+
+// This op benchmarks the input BEF function by running the function in a loop
+// up to a max count or max time as specified in the function's attributes.
+//
+// Attributes:
+// duration_secs: Benchmark duration in seconds.
+// max_count: Max run count of input function.
+// name: The name used to tag the benchmark results.
+// num_warmup_runs: Number of warm up runs before benchmarking starts.
+// fn_const: The input function to be benchmarked.
+static void benchmark(RemainingArguments args,
+                      host_context::RemainingResults results,
+                      Attribute<int32_t> duration_secs,
+                      Attribute<int32_t> max_count,
+                      Attribute<std::string> name,
+                      Attribute<int32_t> num_warmup_runs,
+                      Attribute<MlirFunctionExecutable *> fn) {
+  std::cout << "benchmark: " << args.size() << " " << results.size() << std::endl;
+  for (int i = 0; i < max_count.get(); ++i) {
+    fn.get()->Execute(args.values(), results.values(), true);
+  }
+
+  // if (fn->result_types().size() != 1) {
+  //  handler.ReportError(
+  //      "Benchmark op requires the input function have exactly one return "
+  //      "value");
+  //  return;
+  //}
+
+  // BenchmarkStats bm_stats{name.str(), *num_warmup_runs, *max_count,
+  //                        std::chrono::seconds(*duration_secs)};
+  // auto benchmark_runner = new AsyncBenchmarkRunner(std::move(bm_stats), fn, args.values(), exec_ctx);
+
+  // benchmark_runner->Start([benchmark_runner, chain = chain.Allocate()] {
+  //  chain.emplace();
+  //  delete benchmark_runner;
+  //});
+}
+
+void RegisterTestKernels(host_context::KernelRegistry *registry) {
+  registry->AddKernel("cinn.benchmark", CINN_KERNEL(benchmark));
+}
+
+}  // namespace cinnrt::kernel

--- a/cinnrt/kernel/test_kernels.cc
+++ b/cinnrt/kernel/test_kernels.cc
@@ -1,8 +1,8 @@
 #include "cinnrt/kernel/test_kernels.h"
 
 #include <cassert>
-//#include <chrono>
-//#include <ctime>
+#include <chrono>
+#include <ctime>
 #include <iostream>
 #include <string>
 
@@ -18,189 +18,101 @@ using cinnrt::host_context::RemainingArguments;
 
 namespace cinnrt::kernel {
 namespace {
-// class BenchmarkStats {
-// public:
-//  BenchmarkStats(llvm::StringRef name, int num_warmup_runs, int max_count,
-//                 std::chrono::microseconds benchmark_duration)
-//      : name_{name},
-//        num_warmup_runs_{num_warmup_runs},
-//        max_count_{max_count},
-//        benchmark_duration_{benchmark_duration} {}
-//
-//  void StartRun() {
-//    ++cur_count_;
-//    // Start recording CPU time.
-//    cur_start_cpu_ = std::clock();
-//    cur_start_walltime_ = std::chrono::steady_clock::now();
-//  }
-//
-//  void StopRun() {
-//    // Do not collect the runtime statistics if we are still in the warm up
-//    // period.
-//    if (cur_count_ <= num_warmup_runs_) return;
-//
-//    // Stop the wall clock timer.
-//    auto cur_stop_walltime_ = std::chrono::steady_clock::now();
-//
-//    // Stop the CPU timer.
-//    std::clock_t cur_stop_cpu_ = std::clock();
-//
-//    // Collect the wall clock duration.
-//    auto duration_walltime_ = cur_stop_walltime_ - cur_start_walltime_;
-//    run_times_walltime_.push_back(duration_walltime_);
-//
-//    // Collect the CPU duration in microseconds.
-//    // First cast to integer that represents microseconds with truncation, as
-//    // does std::chrono::duration_cast. Then cast to std::chrono::microseconds.
-//    std::clock_t duration_cpu_raw = cur_stop_cpu_ - cur_start_cpu_;
-//    auto duration_cpu_ = static_cast<std::chrono::nanoseconds>(
-//        static_cast<int64_t>(1e9 * duration_cpu_raw / CLOCKS_PER_SEC));
-//
-//    run_times_cpu_.push_back(duration_cpu_);
-//
-//    total_duration_walltime_ += duration_walltime_;
-//    total_duration_cpu_ += duration_cpu_;
-//  }
-//  // Return if we should we run more rounds.
-//  bool MoreRun() const {
-//    return cur_count_ < max_count_ + num_warmup_runs_ &&
-//           total_duration_walltime_ < benchmark_duration_;
-//  }
-//
-//  // Summarize the benchmark results.
-//  void Summarize() {
-//    std::sort(run_times_walltime_.begin(), run_times_walltime_.end());
-//    std::sort(run_times_cpu_.begin(), run_times_cpu_.end());
-//
-//    auto percentile =
-//        [](double p, const std::vector<std::chrono::nanoseconds>& run_times) {
-//          assert(p >= 0.0 && p <= 1.0);
-//          return run_times[run_times.size() * p];
-//        };
-//
-//    // BM: prefix is added to make grepping results from lit output easier.
-//    std::string prefix;
-//    llvm::raw_string_ostream(prefix) << "BM:" << name_ << ':';
-//    auto cpu_utilization =
-//        total_duration_cpu_.count() * 100.0 / total_duration_walltime_.count();
-//
-//    llvm::outs() << prefix
-//                 << "Duration(ns): " << total_duration_walltime_.count()
-//                 << '\n';
-//    llvm::outs() << prefix << "Count: " << run_times_walltime_.size() << '\n';
-//    llvm::outs() << prefix
-//                 << "Time Min(ns): " << run_times_walltime_.front().count()
-//                 << '\n';
-//    llvm::outs() << prefix << "Time 50%(ns): "
-//                 << percentile(0.5, run_times_walltime_).count() << '\n';
-//    llvm::outs() << prefix << "Time 95%(ns): "
-//                 << percentile(0.95, run_times_walltime_).count() << '\n';
-//    llvm::outs() << prefix << "Time 99%(ns): "
-//                 << percentile(0.99, run_times_walltime_).count() << '\n';
-//    // Log CPU time statistics.
-//    llvm::outs() << prefix << "CPU Min(ns): " << run_times_cpu_.front().count()
-//                 << '\n';
-//    llvm::outs() << prefix
-//                 << "CPU 50%(ns): " << percentile(0.5, run_times_cpu_).count()
-//                 << '\n';
-//    llvm::outs() << prefix
-//                 << "CPU 95%(ns): " << percentile(0.95, run_times_cpu_).count()
-//                 << '\n';
-//    llvm::outs() << prefix
-//                 << "CPU 99%(ns): " << percentile(0.99, run_times_cpu_).count()
-//                 << '\n';
-//    llvm::outs() << prefix << "CPU utilization(percent): " << cpu_utilization
-//                 << "\n";
-//    llvm::outs().flush();
-//  }
-//
-// private:
-//  const std::string name_;
-//  const int num_warmup_runs_;
-//  const int max_count_;
-//  int cur_count_ = 0;
-//  const std::chrono::nanoseconds benchmark_duration_;
-//  std::chrono::nanoseconds total_duration_walltime_{};
-//  std::chrono::nanoseconds total_duration_cpu_{};
-//  std::chrono::time_point<std::chrono::steady_clock> cur_start_walltime_{};
-//  std::clock_t cur_start_cpu_;
-//  std::vector<std::chrono::nanoseconds> run_times_walltime_;
-//  // CPU run times in microseconds.
-//  std::vector<std::chrono::nanoseconds> run_times_cpu_;
-//};
-//
-// class AsyncBenchmarkRunner {
-// public:
-//  AsyncBenchmarkRunner(BenchmarkStats bm_stats, const Function* func,
-//                       ArrayRef<AsyncValue*> args,
-//                       const ExecutionContext& exec_ctx)
-//      : bm_stats_(std::move(bm_stats)),
-//        func_{FormRef(func)},
-//        args_{args.begin(), args.end()},
-//        exec_ctx_(exec_ctx) {
-//    // AddRef on the arg AsyncValue to take an ownership ref.
-//    for (auto& arg : args_) {
-//      arg->AddRef();
-//    }
-//  }
-//
-//  // Disable copy constructor and assignment.
-//  AsyncBenchmarkRunner(const AsyncBenchmarkRunner&) = delete;
-//  AsyncBenchmarkRunner& operator=(const AsyncBenchmarkRunner&) = delete;
-//
-//  ~AsyncBenchmarkRunner() {
-//    // DropRef on the arg AsyncValue to release the ownership ref.
-//    for (auto& arg : args_) {
-//      arg->DropRef();
-//    }
-//  }
-//
-//  void Start(llvm::unique_function<void()> clean_up) {
-//    clean_up_ = std::move(clean_up);
-//    StartNewRun();
-//  }
-// private:
-//  // Start benchmarking a new function execution.
-//  void StartNewRun() {
-//    bm_stats_.StartRun();
-//    // We need to run the actual work in the work queue to avoid exhausting the
-//    // stack space, otherwise, we will have very deep recursion of
-//    // Function::Execute -> AsyncValue::AndThen -> Function::Execute -> ...
-//    EnqueueWork(exec_ctx_, [this] {
-//      // The benchmarked function should return exactly one value.
-//      assert(func_->result_types().size() == 1);
-//
-//      RCReference<AsyncValue> result;
-//      func_->Execute(exec_ctx_, /*arguments=*/args_, /*results=*/result);
-//
-//      // AndThen() is called when the function execution finishes. We record the
-//      // execution time and start the next run in the AndThen() callback.
-//      // Therefore, each of the function execution is run serially.
-//      auto* result_ptr = result.release();
-//      result_ptr->AndThen([this, result_ptr]() mutable {
-//        bm_stats_.StopRun();
-//        result_ptr->DropRef();
-//
-//        if (bm_stats_.MoreRun()) {
-//          StartNewRun();
-//        } else {
-//          bm_stats_.Summarize();
-//          clean_up_();
-//        }
-//      });
-//    });
-//  }
-//
-//  BenchmarkStats bm_stats_;
-//  RCReference<const Function> func_;
-//  SmallVector<AsyncValue*, 4> args_;
-//  ExecutionContext exec_ctx_;
-//  // Clean up function to run after the end of the benchmark.
-//  llvm::unique_function<void()> clean_up_;
-//};
-}  // namespace
+class BenchmarkStats {
+ public:
+  BenchmarkStats(std::string name, int num_warmup_runs, int max_count, std::chrono::microseconds benchmark_duration)
+      : name_{name},
+        num_warmup_runs_{num_warmup_runs},
+        max_count_{max_count},
+        benchmark_duration_{benchmark_duration} {}
 
-// This op benchmarks the input BEF function by running the function in a loop
+  void StartRun() {
+    ++cur_count_;
+    // Start recording CPU time.
+    cur_start_cpu_      = std::clock();
+    cur_start_walltime_ = std::chrono::steady_clock::now();
+  }
+
+  void StopRun() {
+    // Do not collect the runtime statistics if we are still in the warm up
+    // period.
+    if (cur_count_ <= num_warmup_runs_) return;
+
+    // Stop the wall clock timer.
+    auto cur_stop_walltime_ = std::chrono::steady_clock::now();
+
+    // Stop the CPU timer.
+    std::clock_t cur_stop_cpu_ = std::clock();
+
+    // Collect the wall clock duration.
+    auto duration_walltime_ = cur_stop_walltime_ - cur_start_walltime_;
+    run_times_walltime_.push_back(duration_walltime_);
+
+    // Collect the CPU duration in microseconds.
+    // First cast to integer that represents microseconds with truncation, as
+    // does std::chrono::duration_cast. Then cast to std::chrono::microseconds.
+    std::clock_t duration_cpu_raw = cur_stop_cpu_ - cur_start_cpu_;
+    auto duration_cpu_ =
+        static_cast<std::chrono::nanoseconds>(static_cast<int64_t>(1e9 * duration_cpu_raw / CLOCKS_PER_SEC));
+
+    run_times_cpu_.push_back(duration_cpu_);
+
+    total_duration_walltime_ += duration_walltime_;
+    total_duration_cpu_ += duration_cpu_;
+  }
+  // Return if we should we run more rounds.
+  bool MoreRun() const {
+    return cur_count_ < max_count_ + num_warmup_runs_ && total_duration_walltime_ < benchmark_duration_;
+  }
+
+  // Summarize the benchmark results.
+  void Summarize() {
+    std::sort(run_times_walltime_.begin(), run_times_walltime_.end());
+    std::sort(run_times_cpu_.begin(), run_times_cpu_.end());
+
+    auto percentile = [](double p, const std::vector<std::chrono::nanoseconds> &run_times) {
+      assert(p >= 0.0 && p <= 1.0);
+      return run_times[run_times.size() * p];
+    };
+
+    // BM: prefix is added to make grepping results from lit output easier.
+    std::string prefix;
+    llvm::raw_string_ostream(prefix) << "BM:" << name_ << ':';
+    auto cpu_utilization = total_duration_cpu_.count() * 100.0 / total_duration_walltime_.count();
+
+    llvm::outs() << prefix << "Duration(ns): " << total_duration_walltime_.count() << '\n';
+    llvm::outs() << prefix << "Count: " << run_times_walltime_.size() << '\n';
+    llvm::outs() << prefix << "Time Min(ns): " << run_times_walltime_.front().count() << '\n';
+    llvm::outs() << prefix << "Time 50%(ns): " << percentile(0.5, run_times_walltime_).count() << '\n';
+    llvm::outs() << prefix << "Time 95%(ns): " << percentile(0.95, run_times_walltime_).count() << '\n';
+    llvm::outs() << prefix << "Time 99%(ns): " << percentile(0.99, run_times_walltime_).count() << '\n';
+    // Log CPU time statistics.
+    llvm::outs() << prefix << "CPU Min(ns): " << run_times_cpu_.front().count() << '\n';
+    llvm::outs() << prefix << "CPU 50%(ns): " << percentile(0.5, run_times_cpu_).count() << '\n';
+    llvm::outs() << prefix << "CPU 95%(ns): " << percentile(0.95, run_times_cpu_).count() << '\n';
+    llvm::outs() << prefix << "CPU 99%(ns): " << percentile(0.99, run_times_cpu_).count() << '\n';
+    llvm::outs() << prefix << "CPU utilization(percent): " << cpu_utilization << "\n";
+    llvm::outs().flush();
+  }
+
+ private:
+  const std::string name_;
+  const int num_warmup_runs_;
+  const int max_count_;
+  int cur_count_ = 0;
+  const std::chrono::nanoseconds benchmark_duration_;
+  std::chrono::nanoseconds total_duration_walltime_{};
+  std::chrono::nanoseconds total_duration_cpu_{};
+  std::chrono::time_point<std::chrono::steady_clock> cur_start_walltime_{};
+  std::clock_t cur_start_cpu_;
+  std::vector<std::chrono::nanoseconds> run_times_walltime_;
+  // CPU run times in microseconds.
+  std::vector<std::chrono::nanoseconds> run_times_cpu_;
+};
+
+}  // anonymous namespace
+
+// This op benchmarks the input function by running the function in a loop
 // up to a max count or max time as specified in the function's attributes.
 //
 // Attributes:
@@ -208,7 +120,7 @@ namespace {
 // max_count: Max run count of input function.
 // name: The name used to tag the benchmark results.
 // num_warmup_runs: Number of warm up runs before benchmarking starts.
-// fn_const: The input function to be benchmarked.
+// fn: The input function to be benchmarked.
 static void benchmark(RemainingArguments args,
                       host_context::RemainingResults results,
                       Attribute<int32_t> duration_secs,
@@ -216,26 +128,15 @@ static void benchmark(RemainingArguments args,
                       Attribute<std::string> name,
                       Attribute<int32_t> num_warmup_runs,
                       Attribute<MlirFunctionExecutable *> fn) {
-  std::cout << "benchmark: " << args.size() << " " << results.size() << std::endl;
-  for (int i = 0; i < max_count.get(); ++i) {
+  BenchmarkStats bm_stats{
+      name.get(), num_warmup_runs.get(), max_count.get(), std::chrono::seconds(duration_secs.get())};
+
+  while (bm_stats.MoreRun()) {
+    bm_stats.StartRun();
     fn.get()->Execute(args.values(), results.values(), true);
+    bm_stats.StopRun();
   }
-
-  // if (fn->result_types().size() != 1) {
-  //  handler.ReportError(
-  //      "Benchmark op requires the input function have exactly one return "
-  //      "value");
-  //  return;
-  //}
-
-  // BenchmarkStats bm_stats{name.str(), *num_warmup_runs, *max_count,
-  //                        std::chrono::seconds(*duration_secs)};
-  // auto benchmark_runner = new AsyncBenchmarkRunner(std::move(bm_stats), fn, args.values(), exec_ctx);
-
-  // benchmark_runner->Start([benchmark_runner, chain = chain.Allocate()] {
-  //  chain.emplace();
-  //  delete benchmark_runner;
-  //});
+  bm_stats.Summarize();
 }
 
 void RegisterTestKernels(host_context::KernelRegistry *registry) {

--- a/cinnrt/kernel/test_kernels.h
+++ b/cinnrt/kernel/test_kernels.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <string>
+
+namespace cinnrt::host_context {
+
+struct KernelRegistry;
+
+}  // namespace cinnrt::host_context
+
+namespace cinnrt::kernel {
+
+/**
+ * Register all the test kernels to registry.
+ */
+void RegisterTestKernels(host_context::KernelRegistry* registry);
+
+}  // namespace cinnrt::kernel


### PR DESCRIPTION
1. add benchmark op.
2. support executing region.
3. add BenchmarkStats.

For example:

execute the following command on [benchmark.mlir](https://github.com/PaddlePaddle/CINN/blob/78757cd43e36569a1d35dee20957d5b315f71dd0/cinnrt/dialect/mlir_tests/benchmark.mlir):
`cinn-exec -i cinnrt/dialect/mlir_tests/benchmark.mlir`

will get output looks like:
```text
@benchmark
3
3
3
3
3
3
BM:add.f32:Duration(ns): 47283
BM:add.f32:Count: 3
BM:add.f32:Time Min(ns): 8232
BM:add.f32:Time 50%(ns): 15434
BM:add.f32:Time 95%(ns): 23617
BM:add.f32:Time 99%(ns): 23617
BM:add.f32:CPU Min(ns): 5000
BM:add.f32:CPU 50%(ns): 7000
BM:add.f32:CPU 95%(ns): 9000
BM:add.f32:CPU 99%(ns): 9000
BM:add.f32:CPU utilization(percent): 4.441343e+01
```