### PR TITLE
Two layers fc mlir

### DIFF
--- a/cinnrt/dialect/mlir_tests/benchmark.mlir
+++ b/cinnrt/dialect/mlir_tests/benchmark.mlir
@@ -1,7 +1,7 @@
 // CHECK-LABEL: @benchmark
 func @benchmark() {
-  // CHECK-LABEL: BM:add.f32:Duration(ns)
   // CHECK-LABEL: BM:add.f32:Count: 3
+  // CHECK-LABEL: BM:add.f32:Duration(ns)
   // CHECK-LABEL: BM:add.f32:Time Min(ns)
   // CHECK-LABEL: BM:add.f32:Time 50%(ns)
   // CHECK-LABEL: BM:add.f32:Time 95%(ns)

--- a/cinnrt/external_kernels/fc.mlir
+++ b/cinnrt/external_kernels/fc.mlir
@@ -1,41 +1,40 @@
 // CHECK-LABEL: @fc
 func @fc(%input : !cinn.tensor<X86, NCHW, F32>,
-        %w : !cinn.tensor<X86, NCHW, F32>,
-        %bias : !cinn.tensor<X86, NCHW, F32>) -> !cinn.tensor<X86, NCHW, F32>
+         %w : !cinn.tensor<X86, NCHW, F32>,
+         %bias : !cinn.tensor<X86, NCHW, F32>) -> !cinn.tensor<X86, NCHW, F32>
 {
-  %out = dt.create_uninit_tensor.f32 [3, 4] -> !cinn.tensor<X86, NCHW, F32>
-  dt.fill_tensor_with_constant.f32 (%out : !cinn.tensor<X86, NCHW, F32>) {value=0.0:f32}
+  %out = dt.create_uninit_tensor.f32 [30, 50] -> !cinn.tensor<X86, NCHW, F32>
+  // dt.fill_tensor_with_constant.f32 (%out : !cinn.tensor<X86, NCHW, F32>) {value=0.0:f32}
 
-  // test external.matmul
+  // fc1
   "external.matmul"(%input, %w, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
-  // CHECK: tensor: shape=shape[3,4], values=[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
-  //dt.print_tensor (%out : !cinn.tensor<X86, NCHW, F32>)
-
-  // test external.elementwise_add
   "external.elementwise_add"(%out, %bias, %out) {axis = -1}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
-  // CHECK: tensor: shape=shape[3,4], values=[13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13]
-  //dt.print_tensor (%out : !cinn.tensor<X86, NCHW, F32>)
-
-  // test external.sigmoid
   "external.sigmoid"(%out, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
-  // CHECK: tensor: shape=shape[3,4], values=[0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998, 0.999998]
-  //dt.print_tensor (%out : !cinn.tensor<X86, NCHW, F32>)
+
+  // fc2
+  "external.matmul"(%out, %w, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
+  "external.elementwise_add"(%out, %bias, %out) {axis = -1}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
+  "external.sigmoid"(%out, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
 
   cinn.return %out : !cinn.tensor<X86, NCHW, F32>
 }
 
 // CHECK-LABEL: @benchmark
 func @benchmark() {
-  %input = dt.create_uninit_tensor.f32 [3, 5] -> !cinn.tensor<X86, NCHW, F32>
+  %input = dt.create_uninit_tensor.f32 [30, 50] -> !cinn.tensor<X86, NCHW, F32>
   dt.fill_tensor_with_constant.f32 (%input : !cinn.tensor<X86, NCHW, F32>) {value=1.0:f32}
 
-  %w = dt.create_uninit_tensor.f32 [5, 4] -> !cinn.tensor<X86, NCHW, F32>
+  %w = dt.create_uninit_tensor.f32 [50, 50] -> !cinn.tensor<X86, NCHW, F32>
   dt.fill_tensor_with_constant.f32 (%w : !cinn.tensor<X86, NCHW, F32>) {value=2.0:f32}
 
-  %bias = dt.create_uninit_tensor.f32 [3, 4] -> !cinn.tensor<X86, NCHW, F32>
+  %bias = dt.create_uninit_tensor.f32 [30, 50] -> !cinn.tensor<X86, NCHW, F32>
   dt.fill_tensor_with_constant.f32 (%bias : !cinn.tensor<X86, NCHW, F32>) {value=3.0:f32}
 
-  cinn.benchmark "add.f32"(%input:!cinn.tensor<X86, NCHW, F32>, %w:!cinn.tensor<X86, NCHW, F32>, %bias:!cinn.tensor<X86, NCHW, F32>) duration_secs = 100, max_count = 300000, num_warmup_runs = 3
+  cinn.benchmark "add.f32"(
+          %input:!cinn.tensor<X86, NCHW, F32>,
+          %w:!cinn.tensor<X86, NCHW, F32>,
+          %bias:!cinn.tensor<X86, NCHW, F32>)
+          duration_secs = 100, max_count = 300000, num_warmup_runs = 3
   {
     %res = cinn.call @fc(%input, %w, %bias) : (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> (!cinn.tensor<X86, NCHW, F32>)
     cinn.return %res : !cinn.tensor<X86, NCHW, F32>

--- a/cinnrt/external_kernels/fc.mlir
+++ b/cinnrt/external_kernels/fc.mlir
@@ -1,14 +1,8 @@
 // CHECK-LABEL: @fc
-func @fc() -> !cinn.tensor<X86, NCHW, F32> {
-  %input = dt.create_uninit_tensor.f32 [3, 5] -> !cinn.tensor<X86, NCHW, F32>
-  dt.fill_tensor_with_constant.f32 (%input : !cinn.tensor<X86, NCHW, F32>) {value=1.0:f32}
-
-  %w = dt.create_uninit_tensor.f32 [5, 4] -> !cinn.tensor<X86, NCHW, F32>
-  dt.fill_tensor_with_constant.f32 (%w : !cinn.tensor<X86, NCHW, F32>) {value=2.0:f32}
-
-  %bias = dt.create_uninit_tensor.f32 [3, 4] -> !cinn.tensor<X86, NCHW, F32>
-  dt.fill_tensor_with_constant.f32 (%bias : !cinn.tensor<X86, NCHW, F32>) {value=3.0:f32}
-
+func @fc(%input : !cinn.tensor<X86, NCHW, F32>,
+        %w : !cinn.tensor<X86, NCHW, F32>,
+        %bias : !cinn.tensor<X86, NCHW, F32>) -> !cinn.tensor<X86, NCHW, F32>
+{
   %out = dt.create_uninit_tensor.f32 [3, 4] -> !cinn.tensor<X86, NCHW, F32>
   dt.fill_tensor_with_constant.f32 (%out : !cinn.tensor<X86, NCHW, F32>) {value=0.0:f32}
 
@@ -32,9 +26,18 @@ func @fc() -> !cinn.tensor<X86, NCHW, F32> {
 
 // CHECK-LABEL: @benchmark
 func @benchmark() {
-  cinn.benchmark "add.f32"() duration_secs = 100, max_count = 300000, num_warmup_runs = 3
+  %input = dt.create_uninit_tensor.f32 [3, 5] -> !cinn.tensor<X86, NCHW, F32>
+  dt.fill_tensor_with_constant.f32 (%input : !cinn.tensor<X86, NCHW, F32>) {value=1.0:f32}
+
+  %w = dt.create_uninit_tensor.f32 [5, 4] -> !cinn.tensor<X86, NCHW, F32>
+  dt.fill_tensor_with_constant.f32 (%w : !cinn.tensor<X86, NCHW, F32>) {value=2.0:f32}
+
+  %bias = dt.create_uninit_tensor.f32 [3, 4] -> !cinn.tensor<X86, NCHW, F32>
+  dt.fill_tensor_with_constant.f32 (%bias : !cinn.tensor<X86, NCHW, F32>) {value=3.0:f32}
+
+  cinn.benchmark "add.f32"(%input:!cinn.tensor<X86, NCHW, F32>, %w:!cinn.tensor<X86, NCHW, F32>, %bias:!cinn.tensor<X86, NCHW, F32>) duration_secs = 100, max_count = 300000, num_warmup_runs = 3
   {
-    %res = cinn.call @fc() : () -> (!cinn.tensor<X86, NCHW, F32>)
+    %res = cinn.call @fc(%input, %w, %bias) : (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> (!cinn.tensor<X86, NCHW, F32>)
     cinn.return %res : !cinn.tensor<X86, NCHW, F32>
   }
   cinn.return

--- a/cinnrt/kernel/test_kernels.cc
+++ b/cinnrt/kernel/test_kernels.cc
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <chrono>
 #include <ctime>
+#include <iomanip>
 #include <iostream>
 #include <string>
 
@@ -29,8 +30,8 @@ class BenchmarkStats {
   void StartRun() {
     ++cur_count_;
     // Start recording CPU time.
-    cur_start_cpu_      = std::clock();
     cur_start_walltime_ = std::chrono::steady_clock::now();
+    cur_start_cpu_      = std::clock();
   }
 
   void StopRun() {
@@ -38,11 +39,11 @@ class BenchmarkStats {
     // period.
     if (cur_count_ <= num_warmup_runs_) return;
 
-    // Stop the wall clock timer.
-    auto cur_stop_walltime_ = std::chrono::steady_clock::now();
-
     // Stop the CPU timer.
     std::clock_t cur_stop_cpu_ = std::clock();
+
+    // Stop the wall clock timer.
+    auto cur_stop_walltime_ = std::chrono::steady_clock::now();
 
     // Collect the wall clock duration.
     auto duration_walltime_ = cur_stop_walltime_ - cur_start_walltime_;
@@ -80,14 +81,17 @@ class BenchmarkStats {
     llvm::raw_string_ostream(prefix) << "BM:" << name_ << ':';
     auto cpu_utilization = total_duration_cpu_.count() * 100.0 / total_duration_walltime_.count();
 
-    llvm::outs() << prefix << "Duration(ns): " << total_duration_walltime_.count() << '\n';
     llvm::outs() << prefix << "Count: " << run_times_walltime_.size() << '\n';
+    llvm::outs() << prefix << "Duration(ns): " << total_duration_walltime_.count() << '\n';
     llvm::outs() << prefix << "Time Min(ns): " << run_times_walltime_.front().count() << '\n';
+    llvm::outs() << prefix << "Time Max(ns): " << run_times_walltime_.back().count() << '\n';
     llvm::outs() << prefix << "Time 50%(ns): " << percentile(0.5, run_times_walltime_).count() << '\n';
     llvm::outs() << prefix << "Time 95%(ns): " << percentile(0.95, run_times_walltime_).count() << '\n';
     llvm::outs() << prefix << "Time 99%(ns): " << percentile(0.99, run_times_walltime_).count() << '\n';
     // Log CPU time statistics.
+    llvm::outs() << prefix << "CPU Duration(ns): " << total_duration_cpu_.count() << '\n';
     llvm::outs() << prefix << "CPU Min(ns): " << run_times_cpu_.front().count() << '\n';
+    llvm::outs() << prefix << "CPU Max(ns): " << run_times_cpu_.back().count() << '\n';
     llvm::outs() << prefix << "CPU 50%(ns): " << percentile(0.5, run_times_cpu_).count() << '\n';
     llvm::outs() << prefix << "CPU 95%(ns): " << percentile(0.95, run_times_cpu_).count() << '\n';
     llvm::outs() << prefix << "CPU 99%(ns): " << percentile(0.99, run_times_cpu_).count() << '\n';


### PR DESCRIPTION
1. add two layers fc.mlir, and it's easy to extend.
2. we calculate (30, 50) X (50, 50) + (30, 50).
3. init input and weight only once, and pass them to fc as arguments.

how to run:

```bash
cinn-exec -i ../cinnrt/external_kernels/fc.mlir --shared_libs=../paddle/libexternal_kernels.so
```

output looks like:

```text
@fc
@benchmark
BM:add.f32:Count: 300000
BM:add.f32:Duration(ns): 11905908734
BM:add.f32:Time Min(ns): 35099
BM:add.f32:Time Max(ns): 1300744
BM:add.f32:Time 50%(ns): 39078
BM:add.f32:Time 95%(ns): 44012
BM:add.f32:Time 99%(ns): 50146
BM:add.f32:CPU Duration(ns): 11499420000
BM:add.f32:CPU Min(ns): 33000
BM:add.f32:CPU Max(ns): 1299000
BM:add.f32:CPU 50%(ns): 38000
BM:add.f32:CPU 95%(ns): 43000
BM:add.f32:CPU 99%(ns): 49000
BM:add.f32:CPU utilization(percent): 9.658582e+01
```