### PR TITLE
can load_tensors from param file into TensorMap, and get_tensor from TensorMap

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ function prepare {
 
 function prepare_llvm {
     cd $workspace
-    clang++ -mavx2 -masm=intel -S -emit-llvm cinn/runtime/cinn_runtime.cc -I$PWD
+    #clang++ -mavx2 -masm=intel -S -emit-llvm cinn/runtime/cinn_runtime.cc -I$PWD
     cd -
 
     export runtime_include_dir=$workspace/cinn/runtime/cuda

--- a/cinn/frontend/paddle/model_parser.h
+++ b/cinn/frontend/paddle/model_parser.h
@@ -28,6 +28,8 @@ void LoadModelPb(const std::string& model_dir,
 // Read a __model__ file.
 std::unique_ptr<framework_proto::ProgramDesc> LoadProgram(const std::string& path, bool program_from_memory = false);
 
+void LoadLoDTensor(std::istream& is, hlir::framework::Variable* var, const common::Target& target);
+
 // Read a single file containing all the parameters.
 void LoadParams(const std::string& path);
 

--- a/cinnrt/common/global.cc
+++ b/cinnrt/common/global.cc
@@ -5,12 +5,20 @@ namespace cinnrt {
 Global::Global() {}
 
 mlir::MLIRContext* Global::context = nullptr;
+TensorMap* Global::tensorMap       = nullptr;
 
 mlir::MLIRContext* Global::getMLIRContext() {
   if (nullptr == context) {
     context = new mlir::MLIRContext();
   }
   return context;
+}
+
+TensorMap* Global::getTensorMap() {
+  if (nullptr == tensorMap) {
+    tensorMap = new TensorMap();
+  }
+  return tensorMap;
 }
 
 }  // namespace cinnrt

--- a/cinnrt/common/global.cc
+++ b/cinnrt/common/global.cc
@@ -5,20 +5,12 @@ namespace cinnrt {
 Global::Global() {}
 
 mlir::MLIRContext* Global::context = nullptr;
-TensorMap* Global::tensorMap       = nullptr;
 
 mlir::MLIRContext* Global::getMLIRContext() {
   if (nullptr == context) {
     context = new mlir::MLIRContext();
   }
   return context;
-}
-
-TensorMap* Global::getTensorMap() {
-  if (nullptr == tensorMap) {
-    tensorMap = new TensorMap();
-  }
-  return tensorMap;
 }
 
 }  // namespace cinnrt

--- a/cinnrt/common/global.h
+++ b/cinnrt/common/global.h
@@ -3,20 +3,16 @@
 #include "cinnrt/tensor/dense_host_tensor.h"
 #include "mlir/IR/MLIRContext.h"
 
-using TensorMap = std::unordered_map<std::string, cinnrt::tensor::DenseHostTensor *>;
-
 namespace cinnrt {
 
 // global variables
 class Global {
  private:
   static mlir::MLIRContext *context;
-  static TensorMap *tensorMap;
   Global();
 
  public:
   static mlir::MLIRContext *getMLIRContext();
-  static TensorMap *getTensorMap();
 };  // class Global
 
 }  // namespace cinnrt

--- a/cinnrt/common/global.h
+++ b/cinnrt/common/global.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "cinnrt/tensor/dense_host_tensor.h"
 #include "mlir/IR/MLIRContext.h"
+
+using TensorMap = std::unordered_map<std::string, cinnrt::tensor::DenseHostTensor *>;
 
 namespace cinnrt {
 
@@ -8,10 +11,12 @@ namespace cinnrt {
 class Global {
  private:
   static mlir::MLIRContext *context;
+  static TensorMap *tensorMap;
   Global();
 
  public:
   static mlir::MLIRContext *getMLIRContext();
+  static TensorMap *getTensorMap();
 };  // class Global
 
 }  // namespace cinnrt

--- a/cinnrt/dialect/basic_kernels.cc
+++ b/cinnrt/dialect/basic_kernels.cc
@@ -11,6 +11,8 @@
 #include <mlir/IR/TypeUtilities.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include "cinnrt/dialect/dense_tensor.h"
+
 namespace cinnrt::dialect {
 using namespace mlir;
 

--- a/cinnrt/dialect/basic_kernels.td
+++ b/cinnrt/dialect/basic_kernels.td
@@ -112,4 +112,28 @@ class PrintOp<string suffix, Type type> : CINN_Op<"print." # suffix> {
 def PrintF32Op : PrintOp<"f32", F32>;
 //def PrintF64Op : PrintOp<"f64", F64>;
 
+def GetStringOp : CINN_Op<"get_string"> {
+  let summary = "cinn.get_string";
+  let description = [{
+    Get a !cinn.string value from the given string attribute.
+  }];
+
+  let arguments = (ins StrAttr:$value);
+  let results = (outs StringType);
+  let assemblyFormat = "`(` $value `)` attr-dict";
+  let verifier = ?;
+}
+
+def PrintStringOp : CINN_Op<"print_string"> {
+  let summary = "cinn.print_string";
+  let description = [{
+      An operation that prints a string.
+  }];
+
+  let arguments = (ins StringType:$input);
+  let results = (outs);
+  let assemblyFormat = "`(` $input `)` attr-dict";
+  let verifier = ?;
+}
+
 #endif  // basic kernels

--- a/cinnrt/dialect/cinn_base.cc
+++ b/cinnrt/dialect/cinn_base.cc
@@ -11,7 +11,9 @@ void CINNDialect::initialize() {
   allowUnknownTypes();
   allowUnknownOperations();
 
+  addTypes<cinnrt::dt::StringType>();
   addTypes<cinnrt::dt::TensorType>();
+  addTypes<cinnrt::dt::TensorMapType>();
 
   addOperations<
 #define GET_OP_LIST
@@ -67,6 +69,15 @@ mlir::Type CINNDialect::parseType(mlir::DialectAsmParser &parser) const {
 
     return cinnrt::dt::TensorType::get(*targetType, *layoutType, *precisionType);
   }
+  // parse TensorMapType, for example: !cinn.tensor_map
+  if (keyword == "tensor_map") {
+    return cinnrt::dt::TensorMapType::get();
+  }
+  // parse StringType, for example: !cinn.string
+  if (keyword == "string") {
+    return cinnrt::dt::StringType::get();
+  }
+
   parser.emitError(parser.getCurrentLocation(), "unknown cinn type: ") << keyword;
   return mlir::Type();
 }
@@ -76,6 +87,16 @@ void CINNDialect::printType(mlir::Type type, mlir::DialectAsmPrinter &printer) c
   if (type.isa<cinnrt::dt::TensorType>()) {
     auto tensorType = type.cast<cinnrt::dt::TensorType>();
     printer << "tensor<" << tensorType.target() << ", " << tensorType.layout() << ", " << tensorType.precision() << ">";
+    return;
+  }
+  // print TensorMapType, for example: !cinn.tensor_map
+  if (type.isa<cinnrt::dt::TensorMapType>()) {
+    printer << "tensor_map";
+    return;
+  }
+  // print StringType, for example: !cinn.string
+  if (type.isa<cinnrt::dt::StringType>()) {
+    printer << "string";
     return;
   }
   llvm_unreachable("unknown cinn type.");

--- a/cinnrt/dialect/cinn_base.td
+++ b/cinnrt/dialect/cinn_base.td
@@ -15,10 +15,16 @@ def CINN_Dialect : Dialect {
 }
 
 // Type definitions
-def StringType : OpaqueType<"cinn", "string", "!cinn.string type">;
+def StringType :
+    Type<CPred<"$_self.isa<::cinnrt::dt::StringType>()">, "!tfrt.string type">,
+    BuildableType<"$_builder.getType<::cinnrt::dt::StringType>()">;
 
 def TensorType :
     Type<CPred<"$_self.isa<::cinnrt::dt::TensorType>()">, "!cinn.tensor type">;
+
+def TensorMapType :
+    Type<CPred<"$_self.isa<::cinnrt::dt::TensorMapType>()">, "!cinn.tensor_map type">,
+    BuildableType<"$_builder.getType<::cinnrt::dt::TensorMapType>()">;
 
 def BufferType : OpaqueType<"b", "buffer", "buffer">;
 

--- a/cinnrt/dialect/dense_tensor.cc
+++ b/cinnrt/dialect/dense_tensor.cc
@@ -216,7 +216,7 @@ static ParseResult parseSetTensorOp(OpAsmParser &parser, OperationState &result)
                  parser.parseAttribute(value_attr, "values", result.attributes));
 }
 
-// static ParseResult parseLoadTensorsOp(OpAsmParser &parser, OperationState &result) {
+// static ParseResult parseLoadParamsOp(OpAsmParser &parser, OperationState &result) {
 //  SmallVector<OpAsmParser::OperandType, 1> operands;
 //  if (parser.parseOperandList(operands, 1)) return failure();
 //

--- a/cinnrt/dialect/dense_tensor.cc
+++ b/cinnrt/dialect/dense_tensor.cc
@@ -91,6 +91,14 @@ raw_ostream &operator<<(raw_ostream &os, TensorType tensorType) {
   return os;
 }
 
+TensorMapType TensorMapType::get() { return Base::get(::cinnrt::Global::getMLIRContext()); }
+
+TensorMapType TensorMapType::get(mlir::MLIRContext *context) { return Base::get(context); }
+
+StringType StringType::get() { return Base::get(::cinnrt::Global::getMLIRContext()); }
+
+StringType StringType::get(mlir::MLIRContext *context) { return Base::get(context); }
+
 raw_ostream &operator<<(raw_ostream &os, TargetType type) {
   switch (type) {
     case (TargetType::X86):
@@ -207,6 +215,17 @@ static ParseResult parseSetTensorOp(OpAsmParser &parser, OperationState &result)
   return failure(parser.resolveOperand(operands[0], tensor_type, result.operands) ||
                  parser.parseAttribute(value_attr, "values", result.attributes));
 }
+
+// static ParseResult parseLoadTensorsOp(OpAsmParser &parser, OperationState &result) {
+//  SmallVector<OpAsmParser::OperandType, 1> operands;
+//  if (parser.parseOperandList(operands, 1)) return failure();
+//
+//  auto tensor_type = getTensorType(result.getContext());
+//
+//  Attribute value_attr;
+//  return failure(parser.resolveOperand(operands[0], tensor_type, result.operands) ||
+//                 parser.parseAttribute(value_attr, "values", result.attributes));
+//}
 
 template <typename SetTensorOp>
 static void printSetTensorOp(OpAsmPrinter &p, SetTensorOp op) {

--- a/cinnrt/dialect/dense_tensor.h
+++ b/cinnrt/dialect/dense_tensor.h
@@ -36,6 +36,20 @@ class TensorType : public mlir::Type::TypeBase<TensorType, mlir::Type, detail::T
 
 raw_ostream &operator<<(raw_ostream &os, TensorType tensorType);
 
+class TensorMapType : public mlir::Type::TypeBase<TensorMapType, mlir::Type, mlir::TypeStorage> {
+ public:
+  using Base::Base;
+  static TensorMapType get();
+  static TensorMapType get(mlir::MLIRContext *context);
+};
+
+class StringType : public mlir::Type::TypeBase<StringType, mlir::Type, mlir::TypeStorage> {
+ public:
+  using Base::Base;
+  static StringType get();
+  static StringType get(mlir::MLIRContext *context);
+};
+
 #include "cinnrt/dialect/dense_tensor_dialect.hpp.inc"
 
 #define GET_OP_CLASSES

--- a/cinnrt/dialect/dense_tensor.td
+++ b/cinnrt/dialect/dense_tensor.td
@@ -81,6 +81,35 @@ class SetTensorOp<string dtype> :
   let printer = [{ return cinnrt::dt::printSetTensorOp(p, *this); }];
 }
 
+def LoadTensorsOp : DT_Op<"load_tensors", [NoSideEffect]> {
+  let summary = "dt.load_tensors operation";
+
+  let description = [{
+    An operation that can load tensors to TensorMap.
+  }];
+
+  // input path of model params.
+  let arguments = (ins StringType:$path);
+  let results = (outs TensorMapType);
+
+  let assemblyFormat = "`(` operands `)` attr-dict";
+  let verifier = ?;
+}
+
+def GetTensorOp : DT_Op<"get_tensor", [NoSideEffect]> {
+  let summary = "dt.get_tensor operation";
+
+  let description = [{
+    An operation that can get a tensor from TensorMap.
+  }];
+
+  // input path of model params.
+  let arguments = (ins StrAttr:$name);
+  let results = (outs TensorType:$output);
+  let assemblyFormat = "`(` $name `)` attr-dict `->` type($output)";
+  let verifier = ?;
+}
+
 def GetTensorShapeOp : DT_Op<"get_tensor_shape", [NoSideEffect]> {
   let summary = "dt.get_tensor_shape operation";
 

--- a/cinnrt/dialect/dense_tensor.td
+++ b/cinnrt/dialect/dense_tensor.td
@@ -81,8 +81,8 @@ class SetTensorOp<string dtype> :
   let printer = [{ return cinnrt::dt::printSetTensorOp(p, *this); }];
 }
 
-def LoadTensorsOp : DT_Op<"load_tensors", [NoSideEffect]> {
-  let summary = "dt.load_tensors operation";
+def LoadParamsOp : DT_Op<"load_params", [NoSideEffect]> {
+  let summary = "dt.load_params operation";
 
   let description = [{
     An operation that can load tensors to TensorMap.
@@ -96,17 +96,20 @@ def LoadTensorsOp : DT_Op<"load_tensors", [NoSideEffect]> {
   let verifier = ?;
 }
 
-def GetTensorOp : DT_Op<"get_tensor", [NoSideEffect]> {
-  let summary = "dt.get_tensor operation";
+def GetParamOp : DT_Op<"get_param", [NoSideEffect]> {
+  let summary = "dt.get_param operation";
 
   let description = [{
     An operation that can get a tensor from TensorMap.
   }];
 
   // input path of model params.
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins
+          TensorMapType:$map,
+          StrAttr:$name
+          );
   let results = (outs TensorType:$output);
-  let assemblyFormat = "`(` $name `)` attr-dict `->` type($output)";
+  let assemblyFormat = "`(` $map `,` $name `)` attr-dict `->` type($output)";
   let verifier = ?;
 }
 

--- a/cinnrt/dialect/mlir_tests/basic.mlir
+++ b/cinnrt/dialect/mlir_tests/basic.mlir
@@ -30,3 +30,11 @@ func @caller.add.f32() -> f32 {
   cinn.return %z : f32
 }
 /// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// CHECK-LABEL: @string_test
+func @string_test() {
+  %path = cinn.get_string("this is get_string op.")
+  // CHECK-LABEL: string = this is get_string op.
+  cinn.print_string(%path)
+  cinn.return
+}

--- a/cinnrt/dialect/mlir_tests/tensor_map.mlir
+++ b/cinnrt/dialect/mlir_tests/tensor_map.mlir
@@ -1,16 +1,6 @@
-// CHECK-LABEL: test_tensor_type
-func @test_tensor_type() -> !cinn.tensor_map {
-  %path = cinn.get_string("/cinn/benchmark/paddle-inference/Paddle-Inference-Demo/c++/fc/fc_1.8")
-  %map = dt.load_tensors(%path)
-  cinn.return %map : !cinn.tensor_map
-}
-
-func @predict() {
-  %input = dt.create_uninit_tensor.f32 [3, 3] -> !cinn.tensor<X86, NCHW, F32>
-  dt.fill_tensor_with_constant.f32 (%input : !cinn.tensor<X86, NCHW, F32>) {value=1.0:f32}
-
-  %w = dt.get_tensor("create_parameter_0.w_0") -> !cinn.tensor<X86, NCHW, F32>
-  %bias = dt.get_tensor("create_parameter_1.w_0") -> !cinn.tensor<X86, NCHW, F32>
+func @predict(%input:!cinn.tensor<X86, NCHW, F32>, %map: !cinn.tensor_map) -> (!cinn.tensor<X86, NCHW, F32>) {
+  %w = dt.get_param(%map, "create_parameter_0.w_0") -> !cinn.tensor<X86, NCHW, F32>
+  %bias = dt.get_param(%map, "create_parameter_1.w_0") -> !cinn.tensor<X86, NCHW, F32>
 
   %out = dt.create_uninit_tensor.f32 [3, 3] -> !cinn.tensor<X86, NCHW, F32>
 
@@ -19,6 +9,18 @@ func @predict() {
   "external.elementwise_add"(%out, %bias, %out) {axis = -1}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
   "external.sigmoid"(%out, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
 
+  cinn.return %out : !cinn.tensor<X86, NCHW, F32>
+}
+
+// CHECK-LABEL: main
+func @main() {
+  %input = dt.create_uninit_tensor.f32 [3, 3] -> !cinn.tensor<X86, NCHW, F32>
+  dt.fill_tensor_with_constant.f32 (%input : !cinn.tensor<X86, NCHW, F32>) {value=1.0:f32}
+
+  %path = cinn.get_string("/cinn/benchmark/paddle-inference/Paddle-Inference-Demo/c++/fc/fc_1.8")
+  %map = dt.load_params(%path)
+
+  %out = cinn.call @predict(%input, %map): (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor_map) -> (!cinn.tensor<X86, NCHW, F32>)
   dt.print_tensor (%out : !cinn.tensor<X86, NCHW, F32>)
 
   cinn.return

--- a/cinnrt/dialect/mlir_tests/tensor_map.mlir
+++ b/cinnrt/dialect/mlir_tests/tensor_map.mlir
@@ -1,0 +1,25 @@
+// CHECK-LABEL: test_tensor_type
+func @test_tensor_type() -> !cinn.tensor_map {
+  %path = cinn.get_string("/cinn/benchmark/paddle-inference/Paddle-Inference-Demo/c++/fc/fc_1.8")
+  %map = dt.load_tensors(%path)
+  cinn.return %map : !cinn.tensor_map
+}
+
+func @predict() {
+  %input = dt.create_uninit_tensor.f32 [3, 3] -> !cinn.tensor<X86, NCHW, F32>
+  dt.fill_tensor_with_constant.f32 (%input : !cinn.tensor<X86, NCHW, F32>) {value=1.0:f32}
+
+  %w = dt.get_tensor("create_parameter_0.w_0") -> !cinn.tensor<X86, NCHW, F32>
+  %bias = dt.get_tensor("create_parameter_1.w_0") -> !cinn.tensor<X86, NCHW, F32>
+
+  %out = dt.create_uninit_tensor.f32 [3, 3] -> !cinn.tensor<X86, NCHW, F32>
+
+  // fc
+  "external.matmul"(%input, %w, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
+  "external.elementwise_add"(%out, %bias, %out) {axis = -1}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
+  "external.sigmoid"(%out, %out) {}: (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> ()
+
+  dt.print_tensor (%out : !cinn.tensor<X86, NCHW, F32>)
+
+  cinn.return
+}

--- a/cinnrt/host_context/value.cc
+++ b/cinnrt/host_context/value.cc
@@ -43,6 +43,8 @@ void CopyTo(const Value& from, Value* to) {
           to->data = arg;
         else if constexpr (std::is_same_v<T, std::vector<int64_t>>)
           to->data = arg;
+        else if constexpr (std::is_same_v<T, TensorMap>)
+          to->data = arg;
         else
           LOG(FATAL) << "Not supported Value copy: " << typeid(T).name();
       },

--- a/cinnrt/host_context/value.h
+++ b/cinnrt/host_context/value.h
@@ -3,6 +3,7 @@
 #include <llvm/ADT/SmallVector.h>
 
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -17,6 +18,8 @@
 namespace cinnrt {
 namespace host_context {
 
+using TensorMap = std::unordered_map<std::string, tensor::DenseHostTensor*>;
+
 struct MlirFunctionExecutable;
 
 using ValueVariantType = cinnrt::Variant<int16_t,
@@ -29,6 +32,7 @@ using ValueVariantType = cinnrt::Variant<int16_t,
                                          tensor::TensorShape,
                                          tensor::DenseHostTensor,
                                          MlirFunctionExecutable*,
+                                         TensorMap,
                                          std::vector<int16_t>,
                                          std::vector<int32_t>,
                                          std::vector<int64_t>,
@@ -52,6 +56,7 @@ class Value : public cinnrt::common::Object {
   explicit Value(double x) : data(x) {}
   explicit Value(bool x) : data(x) {}
   explicit Value(std::string x) : data(x) {}
+  explicit Value(TensorMap&& x) : data(x) {}
   explicit Value(std::vector<int16_t>&& x) : data(x) {}
   explicit Value(std::vector<int32_t>&& x) : data(x) {}
   explicit Value(std::vector<int64_t>&& x) : data(x) {}

--- a/cinnrt/kernel/basic_kernels.cc
+++ b/cinnrt/kernel/basic_kernels.cc
@@ -1,9 +1,13 @@
 #include "cinnrt/kernel/basic_kernels.h"
 
 #include <iostream>
+#include <string>
 
 #include "cinnrt/host_context/kernel_registry.h"
 #include "cinnrt/host_context/kernel_utils.h"
+#include "llvm/Support/raw_ostream.h"
+
+using cinnrt::host_context::Attribute;
 
 namespace cinnrt::kernel {
 
@@ -32,9 +36,18 @@ void print(T a) {
   std::cout << a << std::endl;
 }
 
+static std::string GetString(Attribute<std::string> value) { return value.get(); }
+
+static void PrintString(const std::string &str) {
+  llvm::outs() << "string = " << str << '\n';
+  llvm::outs().flush();
+}
+
 void RegisterBasicKernels(host_context::KernelRegistry *registry) {
   RegisterIntBasicKernels(registry);
   RegisterFloatBasicKernels(registry);
+  registry->AddKernel("cinn.get_string", CINN_KERNEL(GetString));
+  registry->AddKernel("cinn.print_string", CINN_KERNEL(PrintString));
 }
 
 void RegisterIntBasicKernels(host_context::KernelRegistry *registry) {

--- a/cinnrt/kernel/tensor_kernels.cc
+++ b/cinnrt/kernel/tensor_kernels.cc
@@ -1,13 +1,21 @@
 #include "cinnrt/kernel/tensor_kernels.h"
 
+#include <fstream>
 #include <iostream>
 #include <vector>
 
+#include "cinn/frontend/paddle/compatible_pb.h"
+#include "cinn/frontend/paddle/model_parser.h"
+#include "cinnrt/common/global.h"
 #include "cinnrt/host_context/kernel_registry.h"
 #include "cinnrt/host_context/kernel_utils.h"
 #include "cinnrt/tensor/dense_host_tensor.h"
 #include "cinnrt/tensor/dense_tensor_view.h"
 #include "cinnrt/tensor/tensor_shape.h"
+
+using Scope       = cinn::hlir::framework::Scope;
+using ProgramDesc = cinn::frontend::paddle::cpp::ProgramDesc;
+using Target      = cinn::common::Target;
 
 namespace cinnrt::kernel {
 using namespace host_context;  // NOLINT
@@ -17,27 +25,100 @@ using namespace tensor;        // NOLINT
 
 template <typename T>
 DenseHostTensor CreateUninitTensor(Attribute<std::vector<int64_t>> shape) {
-  const auto& shape_data = shape.get();
+  const auto &shape_data = shape.get();
   auto array             = llvm::ArrayRef<int64_t>(shape_data.data(), shape_data.size());
   auto type              = GetDType<T>();
   return DenseHostTensor(TensorShape(array), type);
 }
 
-void PrintTensor(const DenseHostTensor& tensor) { std::cout << tensor << std::endl; }
+void PrintTensor(const DenseHostTensor &tensor) { std::cout << tensor << std::endl; }
 
 template <typename T>
-void FillTensorWithConstant(DenseHostTensor* tensor, Attribute<T> v) {
+void FillTensorWithConstant(DenseHostTensor *tensor, Attribute<T> v) {
   MutableDTArrayView<T>(tensor).Fill(v.get());
+}
+
+cinnrt::DType _CinnType2DType(cinn::common::Type type) {
+  if (type.is_bool()) return GetDType<bool>();
+  if (type.is_int(8)) return GetDType<int8_t>();
+  if (type.is_int(16)) return GetDType<int16_t>();
+  if (type.is_int(32)) return GetDType<int32_t>();
+  if (type.is_int(64)) return GetDType<int64_t>();
+  if (type.is_uint(8)) return GetDType<uint8_t>();
+  if (type.is_uint(16)) return GetDType<uint16_t>();
+  if (type.is_uint(32)) return GetDType<uint32_t>();
+  if (type.is_uint(64)) return GetDType<uint64_t>();
+  if (type.is_float(32)) return GetDType<float>();
+  if (type.is_float(64)) return GetDType<double>();
+  if (type.is_string()) return GetDType<std::string>();
+  return cinnrt::DType(cinnrt::DType::Kind::Unk);
+}
+
+void _LoadParams(const std::string &path, Scope *scope, ProgramDesc *cpp_prog, const Target &target, TensorMap &map) {
+  std::string model_path                              = path + "/__model__";
+  paddle::framework::proto::ProgramDesc pb_proto_prog = *cinn::frontend::paddle::LoadProgram(model_path);
+  // cinn::frontend::paddle::pb::ProgramDesc pb_prog_desc(&pb_proto_prog);
+  // cinn::frontend::paddle::TransformProgramDescAnyToCpp(pb_prog_desc, cpp_prog);
+  auto main_block = pb_proto_prog.blocks(0);
+  for (auto &var : main_block.vars()) {
+    if (var.name() == "feed" || var.name() == "fetch" || !var.persistable()) continue;
+    std::string param_path = path + "/" + var.name();
+    std::ifstream param_file(param_path, std::ios::binary);
+    switch (var.type().type()) {
+      case paddle::framework::proto::VarType_Type_LOD_TENSOR: {
+        using CinnTensor = cinn::hlir::framework::Tensor;
+        using namespace cinn::utils;
+        auto var_name = TransValidVarName(var.name());
+        // std::cout << "var name: " << var.name() << " " << var_name << std::endl;
+        auto *_var = scope->Var<CinnTensor>(var_name);
+        cinn::frontend::paddle::LoadLoDTensor(param_file, _var, target);
+        auto tensor     = scope->GetTensor(var_name);
+        auto *src_data  = tensor->data<float>();
+        auto &cinn_type = tensor->type();
+        std::vector<int64_t> shape;
+        for (int dim : tensor->shape().data()) shape.push_back(dim);
+        auto shape_array = llvm::ArrayRef<int64_t>(shape.data(), shape.size());
+        auto dtype       = _CinnType2DType(cinn_type);
+        auto *dht        = new DenseHostTensor(TensorShape(shape_array), dtype);
+        int num_elements = dht->shape().GetNumElements();
+        auto *dst_data   = reinterpret_cast<float *>(dht->raw_data());
+        for (int i = 0; i < num_elements; ++i) dst_data[i] = src_data[i];
+        map[var.name()] = dht;
+        break;
+      }
+      default:
+        std::cout << "unknown weight type" << std::endl;
+        break;
+    }
+  }
+}
+
+TensorMap LoadTensors(const std::string &path) {
+  auto &map = *Global::getTensorMap();
+  std::cout << "loading params from: " << path << std::endl;
+  Scope scope;
+  ProgramDesc cpp_prog;
+  const Target &target = cinn::common::DefaultHostTarget();
+  _LoadParams(path, &scope, &cpp_prog, target, map);
+  return map;
+}
+
+DenseHostTensor GetTensor(Attribute<std::string> nameAttr) {
+  auto &name = nameAttr.get();
+  auto &map  = *Global::getTensorMap();
+  return *map[name];
 }
 
 /// ===== Kernel end ====
 
-void RegisterTensorKernels(host_context::KernelRegistry* registry) {
+void RegisterTensorKernels(host_context::KernelRegistry *registry) {
   registry->AddKernel("dt.create_uninit_tensor.f32", CINN_KERNEL(CreateUninitTensor<float>));
   registry->AddKernelAttrNameList("dt.create_uninit_tensor.f32", {"shape"});
   registry->AddKernel("dt.print_tensor", CINN_KERNEL(PrintTensor));
   registry->AddKernel("dt.fill_tensor_with_constant.f32", CINN_KERNEL(FillTensorWithConstant<float>));
   registry->AddKernel("dt.fill_tensor_with_constant.f64", CINN_KERNEL(FillTensorWithConstant<double>));
+  registry->AddKernel("dt.load_tensors", CINN_KERNEL(LoadTensors));
+  registry->AddKernel("dt.get_tensor", CINN_KERNEL(GetTensor));
 }
 
 }  // namespace cinnrt::kernel

--- a/cinnrt/kernel/tensor_kernels.cc
+++ b/cinnrt/kernel/tensor_kernels.cc
@@ -94,19 +94,18 @@ void _LoadParams(const std::string &path, Scope *scope, ProgramDesc *cpp_prog, c
 }
 
 TensorMap LoadParams(const std::string &path) {
-  auto &map = *Global::getTensorMap();
+  TensorMap *map = new TensorMap();
   std::cout << "loading params from: " << path << std::endl;
   Scope scope;
   ProgramDesc cpp_prog;
   const Target &target = cinn::common::DefaultHostTarget();
-  _LoadParams(path, &scope, &cpp_prog, target, map);
-  return map;
+  _LoadParams(path, &scope, &cpp_prog, target, *map);
+  return *map;
 }
 
-DenseHostTensor GetParam(Attribute<std::string> nameAttr) {
+DenseHostTensor GetParam(TensorMap map, Attribute<std::string> nameAttr) {
   auto &name = nameAttr.get();
-  auto &map  = *Global::getTensorMap();
-  return *map[name];
+  return *(map[name]);
 }
 
 /// ===== Kernel end ====

--- a/cinnrt/kernel/tensor_kernels.cc
+++ b/cinnrt/kernel/tensor_kernels.cc
@@ -93,7 +93,7 @@ void _LoadParams(const std::string &path, Scope *scope, ProgramDesc *cpp_prog, c
   }
 }
 
-TensorMap LoadTensors(const std::string &path) {
+TensorMap LoadParams(const std::string &path) {
   auto &map = *Global::getTensorMap();
   std::cout << "loading params from: " << path << std::endl;
   Scope scope;
@@ -103,7 +103,7 @@ TensorMap LoadTensors(const std::string &path) {
   return map;
 }
 
-DenseHostTensor GetTensor(Attribute<std::string> nameAttr) {
+DenseHostTensor GetParam(Attribute<std::string> nameAttr) {
   auto &name = nameAttr.get();
   auto &map  = *Global::getTensorMap();
   return *map[name];
@@ -117,8 +117,8 @@ void RegisterTensorKernels(host_context::KernelRegistry *registry) {
   registry->AddKernel("dt.print_tensor", CINN_KERNEL(PrintTensor));
   registry->AddKernel("dt.fill_tensor_with_constant.f32", CINN_KERNEL(FillTensorWithConstant<float>));
   registry->AddKernel("dt.fill_tensor_with_constant.f64", CINN_KERNEL(FillTensorWithConstant<double>));
-  registry->AddKernel("dt.load_tensors", CINN_KERNEL(LoadTensors));
-  registry->AddKernel("dt.get_tensor", CINN_KERNEL(GetTensor));
+  registry->AddKernel("dt.load_params", CINN_KERNEL(LoadParams));
+  registry->AddKernel("dt.get_param", CINN_KERNEL(GetParam));
 }
 
 }  // namespace cinnrt::kernel


### PR DESCRIPTION
1. 从指定的文件加载模型参数，保存在一个全局的TensorMap中，目前不支持combined 格式的参数文件。
2. 执行predict的时候，从TensorMap中获取参数。

测试命令：
```bash
cd build
cinn-exec -i ../cinnrt/dialect/mlir_tests/tensor_map.mlir --shared_libs=/path/to/libexternal_kernels.so
```