### PR TITLE
fix temp buffer codegen

### DIFF
--- a/cinn/backends/codegen_c_test.cc
+++ b/cinn/backends/codegen_c_test.cc
@@ -55,7 +55,6 @@ TEST(CodeGenC, module) {
   auto func   = Lower("add1", stages, {A, B, C});
 
   builder.AddFunction(func);
-  builder.AddBuffer(C_buf.buffer());
 
   {
     CodeGenC codegen(target);
@@ -67,7 +66,6 @@ TEST(CodeGenC, module) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 20 }, 32/*align*/);
 void add1(void* _args, int32_t num_args)
 {
   const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
@@ -161,7 +159,6 @@ TEST(CodeGenC, module_with_transform) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 20 }, 32/*align*/);
 void add1(void* _args, int32_t num_args)
 {
   const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
@@ -248,7 +245,6 @@ TEST(CodeGenC, matmul) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 50 });
 void matmul(void* _args, int32_t num_args)
 {
   const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
@@ -354,7 +350,6 @@ TEST(CodeGenC, matmul_tile) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 500 }, 32/*align*/);
 void matmul(void* _args, int32_t num_args)
 {
   const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
@@ -434,8 +429,6 @@ TEST(CodeGenC, matmul_packed) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _C = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 100, 500 }, 32/*align*/);
-cinn_buffer_t* _PackedB = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 15, 200, 32 }, 32/*align*/);
 void matmul_with_packing(void* _args, int32_t num_args)
 {
   const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));

--- a/cinn/backends/llvm/codegen_llvm.h
+++ b/cinn/backends/llvm/codegen_llvm.h
@@ -119,6 +119,7 @@ class CodeGenLLVM : public LLVMIRVisitor, public IrBuilderMixin<CodeGenLLVM> {
   // Common methods to get a constant
   // @{
   inline llvm::Constant *ll_const_int32(int v) const { return llvm::ConstantInt::get(b_->getInt32Ty(), v); }
+  inline llvm::Constant *ll_const_int64(int v) const { return llvm::ConstantInt::get(b_->getInt64Ty(), v); }
   // @}
 
   //! Get the bound LLVM module.

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -395,8 +395,6 @@ void IrPrinter::Visit(const intrinsics::PodValueToX *x) {
   os() << ")";
 }
 void IrPrinter::Visit(const intrinsics::BufferCreate *x) {
-  Print(x->buffer);
-  os() << " = ";
   os() << runtime::intrisic::buffer_create;
   os() << "()";
 }

--- a/cinn/ir/lowered_func.h
+++ b/cinn/ir/lowered_func.h
@@ -156,8 +156,10 @@ struct _LoweredFunc_ : ExprNode<_LoweredFunc_> {
 
   static const IrNodeTy _node_type_ = IrNodeTy::_LoweredFunc_;
 
+  std::vector<Expr> PrepareCreateTempBufferExprs() const;
   //! Prepare the expressions for `alloc_tmp_buffer_exprs`.
   std::vector<Expr> PrepareAllocTempBufferExprs() const;
+  std::vector<Expr> PrepareDeallocTempBufferExprs() const;
   std::vector<Expr> CudaPrepareAllocTempBufferExprs() const;
   std::vector<Expr> CudaAliasVarExprs() const;
 

--- a/cinn/ir/tensor_test.cc
+++ b/cinn/ir/tensor_test.cc
@@ -135,11 +135,11 @@ TEST(Tensor, ReshapeCopied) {
 #include <cinn_runtime.h>
 #include <stdio.h>
 
-cinn_buffer_t* _A_copied_reshape = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 10, 10, 100 }, 32/*align*/);
 void fn(void* _args, int32_t num_args)
 {
   const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
   cinn_buffer_t* _tensor = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[1]));
+  cinn_buffer_t* _A_copied_reshape = cinn_buffer_t::new_((cinn_device_kind_t)(0)/*target*/, cinn_float32_t(), { 10, 10, 100 }, 32/*align*/);
   cinn_buffer_malloc((void*)(0), _tensor);
   cinn_buffer_malloc((void*)(0), _A_copied_reshape);
   const float* A = ((const float*)(_A->memory));
@@ -158,6 +158,7 @@ void fn(void* _args, int32_t num_args)
       };
     };
   };
+  cinn_buffer_free((void*)(0), _A_copied_reshape);
   cinn_buffer_free((void*)(0), _tensor);
 }
 )ROC";

--- a/cinn/runtime/cinn_runtime.cc
+++ b/cinn/runtime/cinn_runtime.cc
@@ -73,6 +73,31 @@ void* cinn_buffer_get_data_const_handle(const struct cinn_buffer_t* buf) {
   return buf->memory;
 }
 
+cinn_buffer_t* cinn_buffer_new_default(int target, uint64_t memory_size, int align) {
+  struct cinn_buffer_t* buf = (struct cinn_buffer_t*)malloc(sizeof(struct cinn_buffer_t));
+  buf->type                 = cinn_float32_t();
+  buf->device               = (cinn_device_kind_t)target;
+  buf->memory               = nullptr;
+  buf->memory_size          = memory_size;
+  buf->align                = align;
+  buf->lazy                 = true;
+  // NOTE set device_interface for each buffer.
+  switch (buf->device) {
+    case cinn_x86_device:
+      buf->device_interface = cinn_x86_device_interface();
+      break;
+    case cinn_unk_device:
+      fprintf(stderr, "Device type of buffer should be set, found Unk");
+      abort();
+      break;
+    default:
+      fprintf(stderr, "Not supported device type");
+      abort();
+  }
+  cinn_buffer_malloc((void*)(0), buf);
+  return buf;
+}
+
 cinn_type_t cinn_unk_t() { return cinn_type_t(cinn_type_unk, 0); }
 cinn_type_t cinn_bool_t(int num_asterisks) { return cinn_type_t(cinn_type_int, 8, num_asterisks); }
 cinn_type_t cinn_int8_t(int num_asterisks) { return cinn_type_t(cinn_type_int, 8, num_asterisks); }

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -146,6 +146,9 @@ extern int cinn_buffer_free(void* context, struct cinn_buffer_t* buf);
 extern void* cinn_buffer_get_data_handle(struct cinn_buffer_t* buf);
 extern void* cinn_buffer_get_data_const_handle(const struct cinn_buffer_t* buf);
 
+//! Create a new default cinn_buffer.
+extern cinn_buffer_t* cinn_buffer_new_default(int target, uint64_t memory_size, int align = 32);
+
 //! The raw representation of a buffer,used in the generated code/lib.
 #define CINN_BUFFER_MAX_DIMS 8
 typedef struct cinn_buffer_t {

--- a/cinn/runtime/cinn_x86_device_impl.cc
+++ b/cinn/runtime/cinn_x86_device_impl.cc
@@ -5,9 +5,16 @@
 int cinn_x86_malloc(void* context, cinn_buffer_t* buf) {
   // ASSERT_NOT_NULL(context)
   ASSERT_NOT_NULL(buf)
-  uint64_t memory_size = buf->num_elements() * buf->type.bytes();
+  uint64_t memory_size;
+  bool need_malloc = false;
+  if (buf->memory_size > 0 && !buf->memory) {
+    memory_size = buf->memory_size;
+    need_malloc = true;
+  } else {
+    memory_size = buf->num_elements() * buf->type.bytes();
+  }
   CINN_CHECK(memory_size > 0);
-  if (buf->memory_size < memory_size) {
+  if (buf->memory_size < memory_size || need_malloc) {
     if (buf->memory) {
       free(buf->memory);
     }


### PR DESCRIPTION
fix temp buffer codegen：
之前所有的temp buffer都要从函数入参构造传参，比较麻烦。现在可以不用传参，直接自动识别temp buffer生成buffer的let和new，codegen使能。