### PR TITLE
Enhance cinnrt predictor

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,20 +80,21 @@ function cmake_ {
     sed -i 's/0git/0/g' $build_dir/cinn/backends/llvm/cinn_runtime_llvm_ir.h
 }
 
+function _download_and_untar {
+    local tar_file=$1
+    if [[ ! -f "ResNet18.tar" ]]; then
+        wget http://paddle-inference-dist.bj.bcebos.com/CINN/$tar_file
+        tar -xvf $tar_file
+    fi
+}
+
 function prepare_model {
     cd $build_dir/thirds
-    if [[ ! -f "ResNet18.tar" ]]; then
-        wget http://paddle-inference-dist.bj.bcebos.com/CINN/ResNet18.tar
-        tar -xvf ResNet18.tar
-    fi
-    if [[ ! -f "MobileNetV2.tar" ]]; then
-        wget http://paddle-inference-dist.bj.bcebos.com/CINN/MobileNetV2.tar
-        tar -xvf MobileNetV2.tar
-    fi
-    if [[ ! -f "EfficientNet.tar" ]]; then
-        wget http://paddle-inference-dist.bj.bcebos.com/CINN/EfficientNet.tar
-        tar -xvf EfficientNet.tar
-    fi
+
+    _download_and_untar ResNet18.tar
+    _download_and_untar MobileNetV2.tar
+    _download_and_untar EfficientNet.tar
+
     mkdir -p $build_dir/paddle
     cd $build_dir/paddle
     if [[ ! -f "libexternal_kernels.so.tgz" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ function cmake_ {
 
 function _download_and_untar {
     local tar_file=$1
-    if [[ ! -f "ResNet18.tar" ]]; then
+    if [[ ! -f $tar_file ]]; then
         wget http://paddle-inference-dist.bj.bcebos.com/CINN/$tar_file
         tar -xvf $tar_file
     fi

--- a/cinn/CMakeLists.txt
+++ b/cinn/CMakeLists.txt
@@ -13,6 +13,6 @@ add_subdirectory(pybind)
 add_subdirectory(frontend)
 
 # Download a model
-#download_and_uncompress("${DOWNLOAD_MODEL_DIR}" "${PADDLE_RESOURCE_URL}" "lite_naive_model.tar.gz")
+download_and_uncompress("${DOWNLOAD_MODEL_DIR}" "${PADDLE_RESOURCE_URL}" "lite_naive_model.tar.gz")
 
 core_gather_headers()

--- a/cinn/CMakeLists.txt
+++ b/cinn/CMakeLists.txt
@@ -13,6 +13,6 @@ add_subdirectory(pybind)
 add_subdirectory(frontend)
 
 # Download a model
-download_and_uncompress("${DOWNLOAD_MODEL_DIR}" "${PADDLE_RESOURCE_URL}" "lite_naive_model.tar.gz")
+#download_and_uncompress("${DOWNLOAD_MODEL_DIR}" "${PADDLE_RESOURCE_URL}" "lite_naive_model.tar.gz")
 
 core_gather_headers()

--- a/cinnrt/api/CMakeLists.txt
+++ b/cinnrt/api/CMakeLists.txt
@@ -4,4 +4,4 @@ core_gather_srcs(SRCS
     cinnrt_api.cc
     )
 
-cc_test(test_cinnrt_predictor SRCS cinnrt_api_test.cc DEPS cinncore ${MLIR_IR_LIBS})
+cc_test(test_cinnrt_api SRCS cinnrt_api_test.cc DEPS cinncore ${MLIR_IR_LIBS})

--- a/cinnrt/api/cinnrt_api_test.cc
+++ b/cinnrt/api/cinnrt_api_test.cc
@@ -30,8 +30,6 @@ TEST(CinnRtPredictor, predictor) {
 
   std::shared_ptr<CinnRtPredictor> predictor = CreateCinnRtPredictor(config);
 
-  // std::cout << "input num: " << predictor->GetInputNum() << std::endl;
-  // std::cout << "output num: " << predictor->GetOutputNum() << std::endl;
   auto* input                = predictor->GetInput(0);
   std::vector<int64_t> shape = {3, 3};
   input->Init(shape, cinnrt::GetDType<float>());

--- a/cinnrt/dialect/CMakeLists.txt
+++ b/cinnrt/dialect/CMakeLists.txt
@@ -35,10 +35,10 @@ add_dependencies(print-ir pd_ops_inc)
 
 # MLIR opt tests
 # %{
-add_test(test_mlir_opt_on_basic ${CMAKE_BINARY_DIR}/cinnrt/dialect/cinn-opt
-        ${CMAKE_SOURCE_DIR}/cinnrt/dialect/mlir_tests/basic.mlir)
-
 set(cinn_opt_path ${CMAKE_BINARY_DIR}/cinnrt/dialect/cinn-opt)
+
+add_test(test_mlir_opt_on_basic ${cinn_opt_path}
+        ${CMAKE_SOURCE_DIR}/cinnrt/dialect/mlir_tests/basic.mlir)
 add_test(test_mlir_opt_on_tensor_shape ${cinn_opt_path}
         ${CMAKE_SOURCE_DIR}/cinnrt/dialect/mlir_tests/tensor_shape.mlir)
 add_test(test_mlir_opt_on_paddle_ops
@@ -52,3 +52,8 @@ cc_test(test_mlir_loader SRCS mlir_loader_test.cc DEPS cinncore ${MLIR_IR_LIBS})
 cinn_exec_check(run_and_check_tensor_type mlir_tests/tensor_type.mlir)
 cinn_exec_check(run_and_check_basic mlir_tests/basic.mlir)
 cinn_exec_check(run_and_check_benchmark mlir_tests/benchmark.mlir)
+#cinn_exec_check(run_and_check_dense_tensor mlir_tests/dense_tensor.mlir)
+add_test(test_mlir_dense_tensor
+        ${CMAKE_BINARY_DIR}/cinnrt/host_context/cinn-exec
+        -i
+        ${CMAKE_CURRENT_SOURCE_DIR}/mlir_tests/dense_tensor.mlir)

--- a/cinnrt/dialect/dense_tensor.td
+++ b/cinnrt/dialect/dense_tensor.td
@@ -35,7 +35,7 @@ class CreateUninitTensorOp<string dtype>
 }
 
 
-def ShadowCopyTensorOp
+def ShallowCopyTensorOp
       : DT_Op<"shallow_copy_tensor", [NoSideEffect]> {
   let summary = "dt.shallow_copy_tensor operation";
 

--- a/cinnrt/dialect/dense_tensor.td
+++ b/cinnrt/dialect/dense_tensor.td
@@ -34,6 +34,22 @@ class CreateUninitTensorOp<string dtype>
   let printer = [{ return cinnrt::dt::printCreateUninitTensorOp(p, *this); }];
 }
 
+
+def ShadowCopyTensorOp
+      : DT_Op<"shallow_copy_tensor", [NoSideEffect]> {
+  let summary = "dt.shallow_copy_tensor operation";
+
+  let description = [{
+      An operation that copy a tensor shallowly.
+  }];
+
+  let arguments = (ins TensorType:$input);
+  let results = (outs TensorType:$output);
+
+  let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
+}
+
+
 class FillTensorWithConstantOp<string dtype> :
       DT_Op<"fill_tensor_with_constant." # dtype> {
   let summary = "dt.fill_tensor_with_constant operation";

--- a/cinnrt/dialect/mlir_tests/dense_tensor.mlir
+++ b/cinnrt/dialect/mlir_tests/dense_tensor.mlir
@@ -1,7 +1,22 @@
 func @dense_shape0() {
   %shape = ts.build_shape [1:i64, 57:i64]
-  %a = dt.create_uninit_tensor.f32.2 [12:i64, 23:i64]
-  dt.fill_tensor_with_constant.f32 %a 0.1:f32
+  %a = dt.create_uninit_tensor.f32 [12:i64, 23:i64] -> !cinn.tensor<X86, NCHW, F32>
 
+  cinn.return
+}
+
+func @predict(%a: !cinn.tensor<X86, NCHW, F32>, %b: !cinn.tensor<X86, NCHW, F32>) -> (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) {
+  %a0 = dt.shallow_copy_tensor %a : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>
+  %b0 = dt.shallow_copy_tensor %b : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>
+
+  cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
+}
+
+
+func @main() {
+  %shape = ts.build_shape [1:i64, 57:i64]
+  %a = dt.create_uninit_tensor.f32 [12:i64, 23:i64] -> !cinn.tensor<X86, NCHW, F32>
+
+  %b, %c = cinn.call @predict(%a, %a) : (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) -> (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>)
   cinn.return
 }

--- a/cinnrt/host_context/CMakeLists.txt
+++ b/cinnrt/host_context/CMakeLists.txt
@@ -11,6 +11,7 @@ core_gather_srcs(SRCS
     mlir_to_runtime_translate.cc
     function.cc
     mlir_function_executable.cc
+    mlir_program_executor.cc
     )
 
 cc_test(test_host_context_value SRCS value_test.cc DEPS cinncore ${MLIR_IR_LIBS})

--- a/cinnrt/host_context/core_runtime.cc
+++ b/cinnrt/host_context/core_runtime.cc
@@ -31,13 +31,15 @@ void CoreRuntime::Execute() {
   }
 }
 
+KernelRegistry* CoreRuntime::kernel_registry() const { return impl_->kernel_registry; }
+
 size_t CoreRuntime::num_ops() const { return impl_->op_executables.size(); }
 
 CoreRuntimeBuilder::CoreRuntimeBuilder(KernelRegistry* kernel_registry) : CoreRuntime(new Impl) {
   impl_->kernel_registry = kernel_registry ? kernel_registry : GetCpuKernelRegistry();
 }
 
-OpExecutableBuilder* CoreRuntimeBuilder::NewOpExecutable(std::string_view op_name, const std::string& fn_name) {
+OpExecutableBuilder* CoreRuntimeBuilder::NewOpExecutable(std::string_view op_name) {
   CHECK(impl_.get());
   impl_->op_executables.emplace_back(op_name, symbol_table(), impl_->kernel_registry);
   return &impl_->op_executables.back();

--- a/cinnrt/host_context/core_runtime.h
+++ b/cinnrt/host_context/core_runtime.h
@@ -30,9 +30,11 @@ class CoreRuntime : public std::enable_shared_from_this<CoreRuntime> {
   llvm::SmallVector<ValueRef, 4>  //
   GetResults(llvm::ArrayRef<std::string_view> arg_names);
 
-  ~CoreRuntime();
-
   std::shared_ptr<CoreRuntime> getptr() { return std::shared_ptr<CoreRuntime>(this); }
+
+  KernelRegistry* kernel_registry() const;
+
+  ~CoreRuntime();
 
  protected:
   //! Get the symbol table.
@@ -59,7 +61,7 @@ class CoreRuntimeBuilder : public CoreRuntime {
 
   llvm::ArrayRef<std::string_view> attr_names() const;
 
-  OpExecutableBuilder* NewOpExecutable(std::string_view op_name, const std::string& fn_name);
+  OpExecutableBuilder* NewOpExecutable(std::string_view op_name);
 };
 
 }  // namespace cinnrt::host_context

--- a/cinnrt/host_context/core_runtime_test.cc
+++ b/cinnrt/host_context/core_runtime_test.cc
@@ -25,13 +25,13 @@ TEST(CoreRuntime, basic) {
   table->Register("d", 4);
 
   // c = a + b
-  auto* op0 = builder.NewOpExecutable("cinn.test.addi32", "main");
+  auto* op0 = builder.NewOpExecutable("cinn.test.addi32");
   op0->AppendArgument("a");
   op0->AppendArgument("b");
   op0->SetResults({"c"});
 
   // e = c - d
-  auto* op1 = builder.NewOpExecutable("cinn.test.subi32", "main");
+  auto* op1 = builder.NewOpExecutable("cinn.test.subi32");
   op1->AppendArgument("c");
   op1->AppendArgument("d");
   op1->SetResults({"e"});
@@ -64,7 +64,7 @@ TEST(CoreRuntime, function) {
   ASSERT_EQ(table->Get<int>("b"), 2);
   ASSERT_EQ(table->size(), 2UL);
 
-  auto* op = builder.NewOpExecutable("cinn.test.addi32", "main");
+  auto* op = builder.NewOpExecutable("cinn.test.addi32");
   op->AppendArgument("a");
   op->AppendArgument("b");
   op->SetResults({"c"});

--- a/cinnrt/host_context/kernel_registry.cc
+++ b/cinnrt/host_context/kernel_registry.cc
@@ -40,6 +40,8 @@ std::vector<std::string> KernelRegistry::GetKernelList() const {
 
 KernelRegistry::~KernelRegistry() {}
 
+size_t KernelRegistry::size() const { return impl_->data.size(); }
+
 KernelRegistry *GetCpuKernelRegistry() {
   static auto registry = std::make_unique<KernelRegistry>();
   return registry.get();

--- a/cinnrt/host_context/kernel_registry.h
+++ b/cinnrt/host_context/kernel_registry.h
@@ -24,6 +24,8 @@ class KernelRegistry {
   KernelImplementation GetKernel(const std::string &key) const;
   std::vector<std::string> GetKernelList() const;
 
+  size_t size() const;
+
   ~KernelRegistry();
 
  private:

--- a/cinnrt/host_context/mlir_function_executable.h
+++ b/cinnrt/host_context/mlir_function_executable.h
@@ -45,7 +45,7 @@ class MlirFunctionExecutable : public Function, public MlirToRuntimeTranslator {
   void BuildExecutables(llvm::ArrayRef<Value*> arguments, llvm::MutableArrayRef<ValueRef> results, bool is_region);
 
  private:
-  mlir::Region* region_;
+  mlir::Region* region_{};
   CoreRuntimeBuilder core_runtime_builder_;
   MlirToRuntimeTranslator::function_defs_t& function_table_;
   std::function<void()> copy_res_fn_;

--- a/cinnrt/host_context/mlir_program_executor.cc
+++ b/cinnrt/host_context/mlir_program_executor.cc
@@ -1,0 +1,5 @@
+#include "cinnrt/host_context/mlir_program_executor.h"
+
+namespace cinnrt {
+namespace host_context {}  // namespace host_context
+}  // namespace cinnrt

--- a/cinnrt/host_context/mlir_program_executor.h
+++ b/cinnrt/host_context/mlir_program_executor.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <mlir/Dialect/StandardOps/IR/Ops.h>
+#include <mlir/IR/Diagnostics.h>
+#include <mlir/IR/Function.h>
+#include <mlir/IR/Module.h>
+#include <mlir/IR/OperationSupport.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "cinnrt/host_context/core_runtime.h"
+#include "cinnrt/host_context/kernel_registry.h"
+#include "cinnrt/host_context/mlir_function_executable.h"
+#include "cinnrt/host_context/mlir_to_runtime_translate.h"
+#include "cinnrt/host_context/op_executable.h"
+
+namespace cinnrt {
+namespace host_context {
+
+/**
+ * This get a MLIR program as input, it compiles it into runtime program, and one can retrieve the function and execute
+ * it by passing the input arguments.
+ */
+class MlirProgramExecutor : public MlirToRuntimeTranslator {
+ public:
+  CoreRuntimeBuilder runtime_builder;
+  mlir::ModuleOp module;
+  function_defs_t function_defs;
+
+  MlirProgramExecutor(mlir::ModuleOp module, KernelRegistry* registry)
+      : runtime_builder(registry), MlirToRuntimeTranslator(module, &runtime_builder), module(module) {}
+
+  // Build functions and generate executables.
+  void BuildFunctions() { EmitFunctions(); }
+
+  void EmitFunction(mlir::FuncOp op) override {
+    LOG(INFO) << "Emit function: " << op.getName().str();
+    function_defs[op.getName().str()] = op;
+
+    func_executables_.emplace(op.getName().str(),
+                              new MlirFunctionExecutable(op, runtime_builder.kernel_registry(), function_defs));
+  }
+
+  MlirFunctionExecutable* LookupFunc(const std::string& name) {
+    auto it = func_executables_.find(name);
+    if (it != func_executables_.end()) {
+      return it->second.get();
+    }
+    return nullptr;
+  }
+
+ private:
+  std::unordered_map<std::string, std::unique_ptr<MlirFunctionExecutable>> func_executables_;
+};
+
+}  // namespace host_context
+}  // namespace cinnrt

--- a/cinnrt/host_context/mlir_to_runtime_translate.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate.cc
@@ -415,7 +415,7 @@ void MlirToRuntimeTranslate(mlir::ModuleOp module, CoreRuntimeBuilder* runtime) 
 }
 
 /**
- * Execute the mlir program in test mode -- print some debug infomation to stdout.
+ * Execute the mlir program in test mode -- print some debug information to stdout.
  */
 class MlirProgramTestExecutor : public MlirToRuntimeTranslator {
  public:
@@ -476,6 +476,19 @@ class MlirProgramTestExecutor : public MlirToRuntimeTranslator {
 
  private:
   KernelRegistry* registry{};
+};
+
+class MlirProgramExecutor : public MlirToRuntimeTranslator {
+ public:
+  CoreRuntimeBuilder runtime_builder;
+  mlir::ModuleOp module;
+
+  MlirProgramExecutor(mlir::ModuleOp module, KernelRegistry* registry) : runtime_builder(registry), module(module) {}
+
+  // Build functions and generate executables.
+  void BuildFunctions();
+
+  MlirFunctionExecutable*  LookupFunc(const std::string& name);
 };
 
 void TestMlir(mlir::ModuleOp module, KernelRegistry* registry) {

--- a/cinnrt/host_context/mlir_to_runtime_translate.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate.cc
@@ -189,7 +189,7 @@ static bool IsReturn(mlir::Operation* op) { return op->getName().getStringRef() 
 bool MlirToRuntimeTranslator::EmitGeneralOp(mlir::Operation* op) {
   auto loc = op->getLoc();
   CHECK(impl_->runtime);
-  impl_->cur_op = impl_->runtime->NewOpExecutable(op->getName().getStringRef().str(), impl_->cur_func_name);
+  impl_->cur_op = impl_->runtime->NewOpExecutable(op->getName().getStringRef().str());
 
   VLOG(3) << "processing general op : " << op->getName().getStringRef().str();
 
@@ -359,7 +359,7 @@ bool MlirToRuntimeTranslator::EmitCallOp(mlir::Operation* op, function_defs_t* f
   CHECK(function_table);
   if (op->getName().getStringRef() != "cinn.call") return false;
 
-  impl_->cur_op = impl_->runtime->NewOpExecutable(op->getName().getStringRef().str(), impl_->cur_func_name);
+  impl_->cur_op = impl_->runtime->NewOpExecutable(op->getName().getStringRef().str());
 
   auto callee      = op->getAttr("callee");
   auto callee_name = callee.dyn_cast<mlir::FlatSymbolRefAttr>();
@@ -476,19 +476,6 @@ class MlirProgramTestExecutor : public MlirToRuntimeTranslator {
 
  private:
   KernelRegistry* registry{};
-};
-
-class MlirProgramExecutor : public MlirToRuntimeTranslator {
- public:
-  CoreRuntimeBuilder runtime_builder;
-  mlir::ModuleOp module;
-
-  MlirProgramExecutor(mlir::ModuleOp module, KernelRegistry* registry) : runtime_builder(registry), module(module) {}
-
-  // Build functions and generate executables.
-  void BuildFunctions();
-
-  MlirFunctionExecutable*  LookupFunc(const std::string& name);
 };
 
 void TestMlir(mlir::ModuleOp module, KernelRegistry* registry) {

--- a/cinnrt/host_context/mlir_to_runtime_translate_test.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate_test.cc
@@ -2,11 +2,16 @@
 
 #include <gtest/gtest.h>
 
+#include "cinnrt/common/global.h"
 #include "cinnrt/dialect/mlir_loader.h"
 #include "cinnrt/host_context/core_runtime.h"
 #include "cinnrt/host_context/kernel_registry.h"
 #include "cinnrt/host_context/kernel_utils.h"
 #include "cinnrt/kernel/basic_kernels.h"
+#include "cinnrt/kernel/control_flow_kernels.h"
+#include "cinnrt/kernel/tensor_kernels.h"
+#include "cinnrt/kernel/tensor_shape_kernels.h"
+#include "cinnrt/kernel/test_kernels.h"
 
 namespace cinnrt::host_context {
 
@@ -60,6 +65,33 @@ func @main() -> () {
   kernel::RegisterIntBasicKernels(&registry);
 
   TestMlir(module.get(), &registry);
+}
+
+TEST(TestMlir, shadow_copy_tensor_profile) {
+  mlir::MLIRContext* context = cinnrt::Global::getMLIRContext();
+
+  auto source = R"ROC(
+func @predict(%a: !cinn.tensor<X86, NCHW, F32>, %b: !cinn.tensor<X86, NCHW, F32>) -> (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) {
+  %a0 = dt.shallow_copy_tensor %a : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>
+  %b0 = dt.shallow_copy_tensor %b : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>
+
+  cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
+}
+  )ROC";
+
+  auto module = dialect::LoadMlirSource(context, source);
+  module->verify();
+
+  host_context::KernelRegistry registry;
+
+  kernel::RegisterBasicKernels(&registry);
+  kernel::RegisterTestKernels(&registry);
+  kernel::RegisterTensorShapeKernels(&registry);
+  kernel::RegisterTensorKernels(&registry);
+  kernel::RegisterControlFlowKernels(&registry);
+
+
+
 }
 
 }  // namespace cinnrt::host_context

--- a/cinnrt/host_context/mlir_to_runtime_translate_test.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate_test.cc
@@ -1,12 +1,15 @@
 #include "cinnrt/host_context/mlir_to_runtime_translate.h"
 
 #include <gtest/gtest.h>
+#include <llvm/Support/FormatVariadic.h>
 
 #include "cinnrt/common/global.h"
+#include "cinn/utils/string.h"
 #include "cinnrt/dialect/mlir_loader.h"
 #include "cinnrt/host_context/core_runtime.h"
 #include "cinnrt/host_context/kernel_registry.h"
 #include "cinnrt/host_context/kernel_utils.h"
+#include "cinnrt/host_context/mlir_program_executor.h"
 #include "cinnrt/kernel/basic_kernels.h"
 #include "cinnrt/kernel/control_flow_kernels.h"
 #include "cinnrt/kernel/tensor_kernels.h"
@@ -70,16 +73,31 @@ func @main() -> () {
 TEST(TestMlir, shadow_copy_tensor_profile) {
   mlir::MLIRContext* context = cinnrt::Global::getMLIRContext();
 
-  auto source = R"ROC(
+  auto head = R"ROC(
 func @predict(%a: !cinn.tensor<X86, NCHW, F32>, %b: !cinn.tensor<X86, NCHW, F32>) -> (!cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>) {
-  %a0 = dt.shallow_copy_tensor %a : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>
-  %b0 = dt.shallow_copy_tensor %b : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>
+)ROC";
 
-  cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
+  auto tpl0 = "%a{0} = dt.shallow_copy_tensor %a : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>";
+  auto tpl1 = "%b{0} = dt.shallow_copy_tensor %b : !cinn.tensor<X86, NCHW, F32> -> !cinn.tensor<X86, NCHW, F32>";
+
+  auto end = R"ROC(
+cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
 }
   )ROC";
 
-  auto module = dialect::LoadMlirSource(context, source);
+  std::stringstream ss;
+  ss << head;
+  for (int i = 0; i < 200; i++) {
+    ss << llvm::formatv(tpl0, i).str() << "\n";
+    ss << llvm::formatv(tpl1, i).str() << "\n";
+  }
+  ss << end;
+
+  auto content = ss.str();
+
+  // LOG(INFO) << "content: " << content << std::endl;
+
+  auto module = dialect::LoadMlirSource(context, content);
   module->verify();
 
   host_context::KernelRegistry registry;
@@ -90,8 +108,32 @@ func @predict(%a: !cinn.tensor<X86, NCHW, F32>, %b: !cinn.tensor<X86, NCHW, F32>
   kernel::RegisterTensorKernels(&registry);
   kernel::RegisterControlFlowKernels(&registry);
 
+  MlirProgramExecutor executor(*module, &registry);
+  executor.BuildFunctions();
 
+  auto* func = executor.LookupFunc("predict");
+  ASSERT_TRUE(func);
 
+  std::vector<Value*> in_args;
+  std::vector<ValueRef> out_args(
+      {ValueRef(new Value(tensor::DenseHostTensor())), ValueRef(new Value(tensor::DenseHostTensor()))});
+
+  auto create_tensor = [] {
+    tensor::DenseHostTensor a(tensor::TensorShape{{2, 3}}, DType(DType::Kind::F32));
+    auto* data = reinterpret_cast<float*>(a.raw_data());
+    for (int i = 0; i < a.shape().GetNumElements(); i++) {
+      data[i] = i;
+    }
+    return a;
+  };
+
+  std::vector<ValueRef> inputs({ValueRef(new Value(create_tensor())), ValueRef(new Value(create_tensor()))});
+  in_args.assign({inputs[0].get(), inputs[1].get()});
+
+  for (int i = 0; i < 1000; i++) {
+    func->Execute(llvm::ArrayRef(in_args.data(), in_args.size()),
+                  llvm::MutableArrayRef(out_args.data(), out_args.size()));
+  }
 }
 
 }  // namespace cinnrt::host_context

--- a/cinnrt/host_context/mlir_to_runtime_translate_test.cc
+++ b/cinnrt/host_context/mlir_to_runtime_translate_test.cc
@@ -3,8 +3,8 @@
 #include <gtest/gtest.h>
 #include <llvm/Support/FormatVariadic.h>
 
-#include "cinnrt/common/global.h"
 #include "cinn/utils/string.h"
+#include "cinnrt/common/global.h"
 #include "cinnrt/dialect/mlir_loader.h"
 #include "cinnrt/host_context/core_runtime.h"
 #include "cinnrt/host_context/kernel_registry.h"
@@ -87,7 +87,7 @@ cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
 
   std::stringstream ss;
   ss << head;
-  for (int i = 0; i < 200; i++) {
+  for (int i = 0; i < 2000; i++) {
     ss << llvm::formatv(tpl0, i).str() << "\n";
     ss << llvm::formatv(tpl1, i).str() << "\n";
   }
@@ -119,7 +119,7 @@ cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
       {ValueRef(new Value(tensor::DenseHostTensor())), ValueRef(new Value(tensor::DenseHostTensor()))});
 
   auto create_tensor = [] {
-    tensor::DenseHostTensor a(tensor::TensorShape{{2, 3}}, DType(DType::Kind::F32));
+    tensor::DenseHostTensor a(tensor::TensorShape{{200, 3000}}, DType(DType::Kind::F32));
     auto* data = reinterpret_cast<float*>(a.raw_data());
     for (int i = 0; i < a.shape().GetNumElements(); i++) {
       data[i] = i;
@@ -130,7 +130,7 @@ cinn.return %a0, %b0: !cinn.tensor<X86, NCHW, F32>, !cinn.tensor<X86, NCHW, F32>
   std::vector<ValueRef> inputs({ValueRef(new Value(create_tensor())), ValueRef(new Value(create_tensor()))});
   in_args.assign({inputs[0].get(), inputs[1].get()});
 
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 500; i++) {
     func->Execute(llvm::ArrayRef(in_args.data(), in_args.size()),
                   llvm::MutableArrayRef(out_args.data(), out_args.size()));
   }

--- a/cinnrt/host_context/op_executable.cc
+++ b/cinnrt/host_context/op_executable.cc
@@ -17,6 +17,9 @@ struct OpExecutable::Impl {
     CHECK(kernel_registry);
   }
 
+  inline bool to_execute() const { return !run_once || run_once && !has_executed; }
+  inline void MarkRun() { has_executed = true; }
+
   std::string name;
   SymbolTable* symbol_table{};
   KernelFrameBuilder frame;
@@ -25,6 +28,11 @@ struct OpExecutable::Impl {
   std::unique_ptr<MlirFunctionExecutable> mlir_function_executable;
 
   KernelImplementation kernel_impl{};
+
+  //! Tell whether this Op should be executed only once.
+  bool run_once{};
+  //! Tell whether this op has been executed.
+  bool has_executed{};
 };
 
 OpExecutable::OpExecutable(OpExecutable::Impl* impl) : impl_(impl) {}
@@ -36,10 +44,14 @@ OpExecutableBuilder::OpExecutableBuilder(std::string_view op_name,
                                          KernelRegistry* kernel_registry)
     : OpExecutable(new Impl(op_name, symbol_table, kernel_registry)) {
   CHECK(impl_);
-  // Cpu kernel registry is the default KernelRegistry.
+  // CPU kernel registry is the default KernelRegistry.
   impl_->kernel_impl = impl_->kernel_registry->GetKernel(std::string(op_name.data(), op_name.size()));
   // TODO(Superjomn) support other device other than CPU.
   CHECK(impl_->kernel_impl) << "No CPU kernel called " << op_name;
+
+  if (op_name == "dt.get_param") {
+    impl_->run_once = true;
+  }
 }
 
 void OpExecutableBuilder::AppendArgument(std::string_view name) {
@@ -88,7 +100,6 @@ MlirFunctionExecutable* OpExecutableBuilder::CreateFunctionExecutable(mlir::Regi
 }
 
 void OpExecutable::Execute() {
-  // std::cout << "OpExecutable::Execute" << std::endl;
 #ifndef NDEBUG
   VLOG(3) << "execute " << name() << " --- frame args: " << impl_->frame.GetNumArgs() << " results "
           << impl_->frame.GetNumResults() << " attributes " << impl_->frame.GetNumAttributes();
@@ -100,7 +111,10 @@ void OpExecutable::Execute() {
   }
 #endif
 
-  impl_->kernel_impl(&impl_->frame);
+  if (impl_->to_execute()) {
+    impl_->kernel_impl(&impl_->frame);
+    impl_->MarkRun();
+  }
 }
 
 OpExecutable::~OpExecutable() {}

--- a/cinnrt/host_context/op_executable.cc
+++ b/cinnrt/host_context/op_executable.cc
@@ -13,7 +13,9 @@ struct OpExecutable::Impl {
   Impl(std::string_view op_name, SymbolTable* symbol_table, KernelRegistry* kernel_registry)
       : name(op_name),
         symbol_table(symbol_table),
-        kernel_registry(kernel_registry ? kernel_registry : GetCpuKernelRegistry()) {}
+        kernel_registry(kernel_registry ? kernel_registry : GetCpuKernelRegistry()) {
+    CHECK(kernel_registry);
+  }
 
   std::string name;
   SymbolTable* symbol_table{};
@@ -33,6 +35,7 @@ OpExecutableBuilder::OpExecutableBuilder(std::string_view op_name,
                                          SymbolTable* symbol_table,
                                          KernelRegistry* kernel_registry)
     : OpExecutable(new Impl(op_name, symbol_table, kernel_registry)) {
+  CHECK(impl_);
   // Cpu kernel registry is the default KernelRegistry.
   impl_->kernel_impl = impl_->kernel_registry->GetKernel(std::string(op_name.data(), op_name.size()));
   // TODO(Superjomn) support other device other than CPU.

--- a/cinnrt/kernel/tensor_kernels.cc
+++ b/cinnrt/kernel/tensor_kernels.cc
@@ -39,6 +39,10 @@ DenseHostTensor GetParam(TensorMap map, Attribute<std::string> nameAttr) {
   return *(map[name]);
 }
 
+DenseHostTensor ShallowCopyTensor(DenseHostTensor v) {
+  return v;
+}
+
 /// ===== Kernel end ====
 
 void RegisterTensorKernels(host_context::KernelRegistry *registry) {
@@ -49,6 +53,7 @@ void RegisterTensorKernels(host_context::KernelRegistry *registry) {
   registry->AddKernel("dt.fill_tensor_with_constant.f64", CINN_KERNEL(FillTensorWithConstant<double>));
   registry->AddKernel("dt.load_params", CINN_KERNEL(LoadParams));
   registry->AddKernel("dt.get_param", CINN_KERNEL(GetParam));
+  registry->AddKernel("dt.shallow_copy_tensor", CINN_KERNEL(ShallowCopyTensor));
 }
 
 }  // namespace cinnrt::kernel

--- a/cinnrt/kernel/tensor_kernels.cc
+++ b/cinnrt/kernel/tensor_kernels.cc
@@ -39,9 +39,7 @@ DenseHostTensor GetParam(TensorMap map, Attribute<std::string> nameAttr) {
   return *(map[name]);
 }
 
-DenseHostTensor ShallowCopyTensor(DenseHostTensor v) {
-  return v;
-}
+DenseHostTensor ShallowCopyTensor(DenseHostTensor v) { return v; }
 
 /// ===== Kernel end ====
 

--- a/cinnrt/kernel/test_kernels.cc
+++ b/cinnrt/kernel/test_kernels.cc
@@ -1,5 +1,8 @@
 #include "cinnrt/kernel/test_kernels.h"
 
+#include <llvm/ADT/FunctionExtras.h>
+#include <llvm/Support/raw_ostream.h>
+
 #include <cassert>
 #include <chrono>
 #include <ctime>
@@ -10,8 +13,7 @@
 #include "cinnrt/host_context/kernel_registry.h"
 #include "cinnrt/host_context/kernel_utils.h"
 #include "cinnrt/host_context/mlir_function_executable.h"
-#include "llvm/ADT/FunctionExtras.h"
-#include "llvm/Support/raw_ostream.h"
+#include "cinnrt/tensor/dense_host_tensor.h"
 
 using cinnrt::host_context::Attribute;
 using cinnrt::host_context::MlirFunctionExecutable;
@@ -143,8 +145,12 @@ static void benchmark(RemainingArguments args,
   bm_stats.Summarize();
 }
 
+// Just copy the input to the result.
+tensor::DenseHostTensor ShadowCopyTensor(tensor::DenseHostTensor src) { return src; }
+
 void RegisterTestKernels(host_context::KernelRegistry *registry) {
   registry->AddKernel("cinn.benchmark", CINN_KERNEL(benchmark));
+  registry->AddKernel("cinn.test.shadow_copy_tensor", CINN_KERNEL(ShadowCopyTensor));
 }
 
 }  // namespace cinnrt::kernel

--- a/cinnrt/tensor/tensor_map.h
+++ b/cinnrt/tensor/tensor_map.h
@@ -4,9 +4,11 @@
 #include "cinnrt/tensor/dense_host_tensor.h"
 
 namespace cinnrt {
-namespace tensor {  // namespace tensor
+namespace tensor {
+
 using TensorMap = std::unordered_map<std::string, tensor::DenseHostTensor*>;
 
 TensorMap* LoadParams(const std::string& path);
+
 }  // namespace tensor
 }  // namespace cinnrt


### PR DESCRIPTION
This PR optimizes the CINNRT predictor performance by making load_param op only run once.

The original hotspots:
![Screenshot from 2021-05-07 13-25-05](https://user-images.githubusercontent.com/328693/117401731-b3d3db00-af37-11eb-8a4f-6d9803bb6c7f.png)

The `unordered_map` consumes considerable lantency.

The result of the optimized:
![Screenshot from 2021-05-07 13-22-26](https://user-images.githubusercontent.com/328693/117401725-b2a2ae00-af37-11eb-8bc5-f2d6e835a488.png)
