### PR TITLE
rewrite SimplifySumRec and SimplifyProductRec using top-down mergesort

### DIFF
--- a/cinn/common/cas.h
+++ b/cinn/common/cas.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -96,9 +97,14 @@ struct CasSimplifyMutator {
   Expr SimplifySpecificSum(Expr u);
 
  private:
-  std::vector<Expr> MergeProduct(const std::vector<Expr>& _p, const std::vector<Expr>& _q);
+  std::vector<Expr> SimplifyBinaryProduct(Expr left, Expr right);
+  std::vector<Expr> MergeProduct(const std::vector<Expr>& p, const std::vector<Expr>& q);
 
-  std::vector<Expr> MergeSum(const std::vector<Expr>& _p, const std::vector<Expr>& _q);
+  std::vector<Expr> SimplifyBinarySum(Expr left, Expr right);
+  std::vector<Expr> MergeSum(const std::vector<Expr>& p, const std::vector<Expr>& q);
+  std::vector<Expr> MergeExprs(const std::vector<Expr>& p,
+                               const std::vector<Expr>& q,
+                               const std::function<std::vector<Expr>(Expr, Expr)>& binary_merge);
 
   const std::unordered_map<std::string, CasInterval> var_intervals;
 


### PR DESCRIPTION
According to performance profiler, we know the CasSimplify occupies most of the compile time. With further analysis, I found that SimplifySumRec(similar to SimlifyProduct) exists duplicate simplification on every its operands, and the time complexity is O(n3logn). The process of them just like simplifing every binary Expr of sum(or product) and then merge of the results, so I modify them refering to top-down method mergesort where its time complexity is O(nlogn)

I verify the effect of this modification on test_cinn_real_resnet18 and other tests, it can pass all test and cut off  80% of the complication time.