### PR TITLE
fix isl for1 problems

### DIFF
--- a/cinn/backends/codegen_c_test.cc
+++ b/cinn/backends/codegen_c_test.cc
@@ -287,7 +287,7 @@ void main(void* _args, int32_t num_args)
   const float* A = ((const float*)(_A->memory));
   const float* B = ((const float*)(_B->memory));
   float* C = ((float*)(_C->memory));
-  for (int32_t i = 0; i < 1; i += 1) {
+  {
     cinn_pod_value_t _pod_val_;
     buffer_p_to_cinn_pod_value(_A, &_pod_val_);
     cinn_pod_value_t _pod_val__0;

--- a/cinn/lang/lower_impl.h
+++ b/cinn/lang/lower_impl.h
@@ -200,6 +200,7 @@ struct MarkVectorizeMutator : public ir::IRMutator<Expr*> {
     CHECK(tensor_n);
     auto it = vectorizes.find(tensor_n->name);
     if (it != vectorizes.end()) {
+      CHECK_LT(it->second.level, forloop_stack.size());
       forloop_stack[it->second.level]->set_vectorize_info(it->second);
       CHECK(it->second.valid());
     }

--- a/cinn/poly/ast_gen.cc
+++ b/cinn/poly/ast_gen.cc
@@ -157,11 +157,9 @@ isl::ast_node AstGen::Build() {
 
   ast_build = ast_build.set_at_each_domain(collect);
 
-  isl::union_set new_domain = TransIdentityExtentToContextId(impl_->domain());
-
   isl::union_map transformed_schedule = impl_->transform().apply_range(schedule);
   VLOG(4) << "transformed_schedule: " << transformed_schedule;
-  auto schedule_domain = transformed_schedule.intersect_domain(new_domain);
+  auto schedule_domain = transformed_schedule.intersect_domain(impl_->domain());
   VLOG(4) << "domain: " << impl_->domain();
   VLOG(4) << "transform schedule " << impl_->stages()[0]->transform();
   VLOG(4) << "schedule: " << schedule;

--- a/cinn/poly/isl_utils.cc
+++ b/cinn/poly/isl_utils.cc
@@ -154,7 +154,7 @@ int isl_get_precending_removed_axes_counts(isl_set __isl_keep *a, int level) {
   return removed_axes_counts;
 }
 
-bool is_isl_removed_axis(isl_set __isl_keep *a, int level) {
+bool isl_is_removed_axis(isl_set __isl_keep *a, int level) {
   std::vector<std::tuple<int, int>> iden_dim_offsets;
   if (isl_set_axis_has_noparam_constant_bound(a, level)) {
     auto [minv, maxv] = isl_set_get_axis_range(a, level);

--- a/cinn/poly/isl_utils.cc
+++ b/cinn/poly/isl_utils.cc
@@ -138,6 +138,35 @@ isl_set *isl_get_precending_aixs(isl_set *set, int level, bool with_tuple_name) 
   return isl_set_apply(set, transform.release());
 }
 
+int isl_get_precending_removed_axes_counts(isl_set __isl_keep *a, int level) {
+  int removed_axes_counts = 0;
+  std::vector<std::tuple<int, int>> iden_dim_offsets;
+  for (int i = 0; i < level; i++) {
+    if (isl_set_axis_has_noparam_constant_bound(a, i)) {
+      auto [minv, maxv] = isl_set_get_axis_range(a, i);
+      int min_iv        = minv.get_num_si();
+      int max_iv        = maxv.get_num_si();
+      if (max_iv == min_iv) {
+        removed_axes_counts++;
+      }
+    }
+  }
+  return removed_axes_counts;
+}
+
+bool is_isl_removed_axis(isl_set __isl_keep *a, int level) {
+  std::vector<std::tuple<int, int>> iden_dim_offsets;
+  if (isl_set_axis_has_noparam_constant_bound(a, level)) {
+    auto [minv, maxv] = isl_set_get_axis_range(a, level);
+    int min_iv        = minv.get_num_si();
+    int max_iv        = maxv.get_num_si();
+    if (max_iv == min_iv) {
+      return true;
+    }
+  }
+  return false;
+}
+
 int isl_max_level_compatible(isl_set *a, isl_set *b) {
   int an = isl_set_dim(a, isl_dim_set);
   int bn = isl_set_dim(b, isl_dim_set);

--- a/cinn/poly/isl_utils.h
+++ b/cinn/poly/isl_utils.h
@@ -4,6 +4,7 @@
 #include <llvm/ADT/ArrayRef.h>
 
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace cinn {
@@ -33,6 +34,14 @@ isl::union_set isl_sets_to_union_set(const std::vector<isl::set>& sets);
 std::string isl_map_get_statement_repr(__isl_keep isl_map* map, isl_dim_type type);
 
 isl_set* __isl_give isl_get_precending_aixs(isl_set* set, int level, bool with_tuple_name);
+
+//! If the min and max bounds of the axis are same, isl will remove this axis after ast_build. Counts the removed axes
+//! before the given axis.
+int isl_get_precending_removed_axes_counts(isl_set __isl_keep* a, int level);
+
+//! If the min and max bounds of the axis are same, isl will remove this axis after ast_build. Judge whether or not the
+//! axis will be removed by isl.
+bool is_isl_removed_axis(isl_set __isl_keep* a, int level);
 
 //! Get the maximum level of axis that is has the same domain.
 int isl_max_level_compatible(isl_set* __isl_keep a, isl_set* __isl_keep b);

--- a/cinn/poly/isl_utils.h
+++ b/cinn/poly/isl_utils.h
@@ -41,7 +41,7 @@ int isl_get_precending_removed_axes_counts(isl_set __isl_keep* a, int level);
 
 //! If the min and max bounds of the axis are same, isl will remove this axis after ast_build. Judge whether or not the
 //! axis will be removed by isl.
-bool is_isl_removed_axis(isl_set __isl_keep* a, int level);
+bool isl_is_removed_axis(isl_set __isl_keep* a, int level);
 
 //! Get the maximum level of axis that is has the same domain.
 int isl_max_level_compatible(isl_set* __isl_keep a, isl_set* __isl_keep b);

--- a/cinn/poly/stage.cc
+++ b/cinn/poly/stage.cc
@@ -676,7 +676,7 @@ void Stage::Vectorize(int level, int factor) {
     return;
   }
   auto transformed_domain = this->transformed_domain();
-  if (is_isl_removed_axis(transformed_domain.get(), level)) {
+  if (isl_is_removed_axis(transformed_domain.get(), level)) {
     LOG(INFO) << "Vectorizing for-1 has no sense, skip it";
     return;
   }
@@ -699,7 +699,7 @@ void Stage::Parallel(int level) {
   AssertAxisIsNotLocked(level);
   auto transformed_domain = this->transformed_domain();
   LOG(INFO) << "transformed_domain" << transformed_domain;
-  if (is_isl_removed_axis(transformed_domain.get(), level)) {
+  if (isl_is_removed_axis(transformed_domain.get(), level)) {
     LOG(INFO) << "Paralleling for-1 has no sense, skip it";
     return;
   }
@@ -712,7 +712,7 @@ void Stage::Unroll(int level) {
   CHECK_GE(level, 0);
   AssertAxisIsNotLocked(level);
   auto transformed_domain = this->transformed_domain();
-  if (is_isl_removed_axis(transformed_domain.get(), level)) {
+  if (isl_is_removed_axis(transformed_domain.get(), level)) {
     LOG(INFO) << "Unrolling for-1 has no sense, skip it";
     return;
   }
@@ -1065,7 +1065,7 @@ void Stage::AddForloopInfo(int level, const StageForloopInfo &info) {
   CHECK_GE(level, 0);
   CHECK_LT(level, num_levels);
   auto transformed_domain = this->transformed_domain();
-  if (is_isl_removed_axis(transformed_domain.get(), level)) {
+  if (isl_is_removed_axis(transformed_domain.get(), level)) {
     LOG(INFO) << "for-1 has no sense, skip it";
     return;
   }
@@ -1189,7 +1189,7 @@ void Stage::CopyLoopInfo(std::map<int, StageForloopInfo> target_forloop_infos, c
   int removed_axes_counts                 = 0;
   for (int i = 0; i < this_dim_names.size(); i++) {
     auto transformed_domain = this->transformed_domain();
-    if (is_isl_removed_axis(transformed_domain.get(), i)) {
+    if (isl_is_removed_axis(transformed_domain.get(), i)) {
       LOG(INFO) << "for-1 has no sense, skip it";
       removed_axes_counts++;
       continue;


### PR DESCRIPTION
Isl ast_build will eliminate forloop axis if its' range is 1, which will cause the forloop's level go wrong in the process of CINN ir lowering after ast_build.
So we adapt the forloop's level recorded in the forloopInfo which will be used in the CINN ir lowering after ast_build correspondingly by eliminating for-1 axes in the transformed_domain.
Additionally, we remove the const_0 solution for generated complicated poly ir hard to simplify.