### PR TITLE
optimize depthwise_conv2d

### DIFF
--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -181,11 +181,10 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions() {
           } else {
             instr->attrs.push_back(instr->attrs[1]);
           }
-          for (auto& out_node : node->outlinks_in_order()) {
-            std::string out_id = out_node->sink()->safe_as<NodeData>()->id();
-            auto out_shape     = shape_dict.at(out_id);
-            instr->attrs.insert(instr->attrs.end(), out_shape.begin(), out_shape.end());
-          }
+          auto& out_node     = node->outlinks_in_order().front();
+          std::string out_id = out_node->sink()->safe_as<NodeData>()->id();
+          auto out_shape     = shape_dict.at(out_id);
+          instr->attrs.insert(instr->attrs.end(), out_shape.begin(), out_shape.end());
           CHECK_EQ(instr->attrs.size(), 19UL);
         } else if (node->op()->name == "pool2d") {
           auto& shape_dict = graph_->GetAttrs<std::unordered_map<std::string, shape_t>>("infershape");

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -79,6 +79,14 @@ void Conv2d_NCHWc_1X1_Schedule_CPU_Nofuse(poly::StageMap stages,
                                           const ir::Tensor &data,
                                           const common::Target &target);
 
+void Depthwise_Conv2d_NCHWc_Schedule_CPU_Nofuse(poly::StageMap stages,
+                                                const ir::Tensor &res,
+                                                ir::Tensor &packed_out,
+                                                const ir::Tensor &input_pad,
+                                                const ir::Tensor &weights_dilation,
+                                                const ir::Tensor &data,
+                                                const common::Target &target);
+
 void CudaScheduleMul(poly::StageMap stages,
                      ir::Tensor output,
                      const std::vector<int> &output_shape,

--- a/python/tests/test_op_nn.py
+++ b/python/tests/test_op_nn.py
@@ -227,7 +227,7 @@ class OpTest_depthwise_conv2d_nchw(SingleOpTester):
         self.input_size = [2, 8, 10, 10]
         self.groups = self.input_size[1]
         assert np.mod(self.input_size[1], self.groups) == 0
-        channel_multiplier = 4
+        channel_multiplier = 1
         self.filter_size = [self.input_size[1], channel_multiplier, 7, 7]
         self.data_format = "NCHW"
         self.attrs = framework.NodeAttr()

--- a/tests/benchmark/test_all_ops_default.cc
+++ b/tests/benchmark/test_all_ops_default.cc
@@ -184,7 +184,7 @@ std::vector<int> dilation_depthwise_conv2d                            = {1, 1};
 std::unordered_map<std::string, AttrType> attr_store_depthwise_conv2d = {{"padding", padding_depthwise_conv2d},
                                                                          {"stride", stride_depthwise_conv2d},
                                                                          {"dilation", dilation_depthwise_conv2d}};
-TEST_DEFAULT1(depthwise_conv2d, depthwise_conv2d_nchw, type1, type, attr_store_depthwise_conv2d)
+TEST_DEFAULT1(depthwise_conv2d, depthwise_conv2d_nchw, type1, type7, attr_store_depthwise_conv2d)
 
 // pool2d
 hlir::framework::NodeAttr attrs;


### PR DESCRIPTION
optimize depthwise_conv2d：refactor compute and add schedule
for shape: [1, 3, 112, 112], [32, 1, 3, 3], it can be optimized from 2.46ms to 0.627ms.