### PR TITLE
Add transformer from paddle's Desc to CINN's Desc

### DIFF
--- a/cinn/frontend/paddle/compatible_paddle_pb.cc
+++ b/cinn/frontend/paddle/compatible_paddle_pb.cc
@@ -1,0 +1,317 @@
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cinn/frontend/paddle/compatible_pb.h"
+#include "paddle/fluid/framework/block_desc.h"
+#include "paddle/fluid/framework/op_desc.h"
+#include "paddle/fluid/framework/program_desc.h"
+#include "paddle/fluid/framework/var_desc.h"
+
+namespace cinn::frontend::paddle {
+namespace pb    = ::paddle::framework;
+using PbVarType = pb::proto::VarType;
+
+namespace utils {
+
+cpp::VarDescAPI::Type TransformVarTypePbToCpp(const PbVarType::Type &type) {
+#define SET_TYPE_CASE_ITEM(type__)        \
+  case PbVarType::type__:                 \
+    return cpp::VarDescAPI::Type::type__; \
+    break;
+
+  switch (type) {
+    SET_TYPE_CASE_ITEM(LOD_TENSOR);
+    SET_TYPE_CASE_ITEM(LOD_TENSOR_ARRAY);
+    SET_TYPE_CASE_ITEM(LOD_RANK_TABLE);
+    SET_TYPE_CASE_ITEM(SELECTED_ROWS);
+    SET_TYPE_CASE_ITEM(FEED_MINIBATCH);
+    SET_TYPE_CASE_ITEM(FETCH_LIST);
+    SET_TYPE_CASE_ITEM(STEP_SCOPES);
+    SET_TYPE_CASE_ITEM(PLACE_LIST);
+    SET_TYPE_CASE_ITEM(READER);
+    default:
+      LOG(FATAL) << "Unknown var type";
+  }
+#undef SET_TYPE_CASE_ITEM
+}
+
+PbVarType::Type TransformVarTypeCppToPb(const cpp::VarDescAPI::Type &type) {
+#define SET_TYPE_CASE_ITEM(type__)    \
+  case cpp::VarDescAPI::Type::type__: \
+    return PbVarType::type__;         \
+    break;
+
+  switch (type) {
+    SET_TYPE_CASE_ITEM(LOD_TENSOR);
+    SET_TYPE_CASE_ITEM(LOD_TENSOR_ARRAY);
+    SET_TYPE_CASE_ITEM(LOD_RANK_TABLE);
+    SET_TYPE_CASE_ITEM(SELECTED_ROWS);
+    SET_TYPE_CASE_ITEM(FEED_MINIBATCH);
+    SET_TYPE_CASE_ITEM(FETCH_LIST);
+    SET_TYPE_CASE_ITEM(STEP_SCOPES);
+    SET_TYPE_CASE_ITEM(PLACE_LIST);
+    SET_TYPE_CASE_ITEM(READER);
+    default:
+      LOG(FATAL) << "Unknown var type";
+  }
+#undef SET_TYPE_CASE_ITEM
+}
+
+cpp::VarDescAPI::Type TransformVarDataTypePbToCpp(const PbVarType::Type &type) {
+#define SET_DATA_TYPE_CASE_ITEM(type__)   \
+  case PbVarType::type__:                 \
+    return cpp::VarDescAPI::Type::type__; \
+    break;
+
+  switch (type) {
+    SET_DATA_TYPE_CASE_ITEM(BOOL);
+    SET_DATA_TYPE_CASE_ITEM(SIZE_T);
+    SET_DATA_TYPE_CASE_ITEM(UINT8);
+    SET_DATA_TYPE_CASE_ITEM(INT8);
+    SET_DATA_TYPE_CASE_ITEM(INT16);
+    SET_DATA_TYPE_CASE_ITEM(INT32);
+    SET_DATA_TYPE_CASE_ITEM(INT64);
+    SET_DATA_TYPE_CASE_ITEM(FP16);
+    SET_DATA_TYPE_CASE_ITEM(FP32);
+    SET_DATA_TYPE_CASE_ITEM(FP64);
+    default:
+      LOG(FATAL) << "Unknown var data type";
+  }
+#undef SET_DATA_TYPE_CASE_ITEM
+}
+
+PbVarType::Type TransformVarDataTypeCppToPb(const cpp::VarDescAPI::Type &type) {
+#define SET_DATA_TYPE_CASE_ITEM(type__) \
+  case cpp::VarDescAPI::Type::type__:   \
+    return PbVarType::type__;           \
+    break;
+
+  switch (type) {
+    SET_DATA_TYPE_CASE_ITEM(BOOL);
+    SET_DATA_TYPE_CASE_ITEM(SIZE_T);
+    SET_DATA_TYPE_CASE_ITEM(UINT8);
+    SET_DATA_TYPE_CASE_ITEM(INT8);
+    SET_DATA_TYPE_CASE_ITEM(INT16);
+    SET_DATA_TYPE_CASE_ITEM(INT32);
+    SET_DATA_TYPE_CASE_ITEM(INT64);
+    SET_DATA_TYPE_CASE_ITEM(FP16);
+    SET_DATA_TYPE_CASE_ITEM(FP32);
+    SET_DATA_TYPE_CASE_ITEM(FP64);
+    default:
+      LOG(FATAL) << "Unknown var data type";
+  }
+#undef SET_DATA_TYPE_CASE_ITEM
+}
+}  // namespace utils
+
+template <>
+void TransformVarDescAnyToCpp<pb::VarDesc>(pb::VarDesc *pb_desc, cpp::VarDesc *cpp_desc) {
+  cpp_desc->SetName(pb_desc->Name());
+  cpp_desc->SetType(utils::TransformVarTypePbToCpp(pb_desc->GetType()));
+  cpp_desc->SetPersistable(pb_desc->Persistable());
+  if (pb_desc->Name() != "feed" && pb_desc->Name() != "fetch") {
+    cpp_desc->SetDataType(utils::TransformVarDataTypePbToCpp(pb_desc->GetDataType()));
+    cpp_desc->SetShape(pb_desc->GetShape());
+  }
+}
+
+template <>
+void TransformVarDescCppToAny<pb::VarDesc>(const cpp::VarDesc &cpp_desc, pb::VarDesc *pb_desc) {
+  pb_desc->SetName(cpp_desc.Name());
+  pb_desc->SetType(utils::TransformVarTypeCppToPb(cpp_desc.GetType()));
+  pb_desc->SetPersistable(cpp_desc.Persistable());
+  if (cpp_desc.Name() != "feed" && cpp_desc.Name() != "fetch") {
+    pb_desc->SetShape(cpp_desc.GetShape());
+    pb_desc->SetDataType(utils::TransformVarDataTypeCppToPb(cpp_desc.GetDataType()));
+  }
+}
+
+/// For OpDesc transform
+void OpInputsPbToCpp(pb::OpDesc *pb_desc, cpp::OpDesc *cpp_desc) {
+  for (const std::string &param : pb_desc->InputArgumentNames()) {
+    cpp_desc->SetInput(param, pb_desc->Input(param));
+  }
+}
+
+void OpInputsCppToPb(const cpp::OpDesc &cpp_desc, pb::OpDesc *pb_desc) {
+  for (const std::string &param : cpp_desc.InputArgumentNames()) {
+    pb_desc->SetInput(param, cpp_desc.Input(param));
+  }
+}
+
+void OpOutputsPbToCpp(pb::OpDesc *pb_desc, cpp::OpDesc *cpp_desc) {
+  for (const std::string &param : pb_desc->OutputArgumentNames()) {
+    cpp_desc->SetOutput(param, pb_desc->Output(param));
+  }
+}
+
+void OpOutputsCppToPb(const cpp::OpDesc &cpp_desc, pb::OpDesc *pb_desc) {
+  for (const std::string &param : cpp_desc.OutputArgumentNames()) {
+    pb_desc->SetOutput(param, cpp_desc.Output(param));
+  }
+}
+
+void OpAttrsPbToCpp(pb::OpDesc *pb_desc, cpp::OpDesc *cpp_desc) {
+  using AttrType = pb::proto::AttrType;
+  auto set_attr  = [&](const std::string &name, AttrType type) {
+    switch (type) {
+#define IMPL_ONE(type__, T)                                        \
+  case AttrType::type__:                                           \
+    cpp_desc->SetAttr<T>(name, pb_desc->GetAttrIfExists<T>(name)); \
+    break;
+      IMPL_ONE(INT, int32_t);
+      IMPL_ONE(FLOAT, float);
+      IMPL_ONE(STRING, std::string);
+      IMPL_ONE(STRINGS, std::vector<std::string>);
+      IMPL_ONE(FLOATS, std::vector<float>);
+      IMPL_ONE(INTS, std::vector<int>);
+      IMPL_ONE(BOOLEAN, bool);
+      IMPL_ONE(LONG, int64_t);
+      IMPL_ONE(LONGS, std::vector<int64_t>);
+      case AttrType::BLOCK: {
+        auto i = pb_desc->GetAttrIfExists<int16_t>(name);
+        cpp_desc->SetAttr<int32_t>(name, i);
+        break;
+      }
+      default:
+        LOG(FATAL) << "Unsupported attr type found " << static_cast<int>(type);
+    }
+  };
+#undef IMPL_ONE
+
+  for (const auto &attr_name : pb_desc->AttrNames()) {
+    auto type = pb_desc->GetAttrType(attr_name);
+    set_attr(attr_name, type);
+  }
+}
+
+void OpAttrsCppToPb(const cpp::OpDesc &cpp_desc, pb::OpDesc *pb_desc) {
+  using AttrType = cpp::OpDescAPI::AttrType;
+  auto set_attr  = [&](const std::string &name, AttrType type) {
+    switch (type) {
+#define IMPL_ONE(type__, T)                            \
+  case AttrType::type__:                               \
+    pb_desc->SetAttr(name, cpp_desc.GetAttr<T>(name)); \
+    break;
+      IMPL_ONE(INT, int32_t);
+      IMPL_ONE(FLOAT, float);
+      IMPL_ONE(STRING, std::string);
+      IMPL_ONE(STRINGS, std::vector<std::string>);
+      IMPL_ONE(FLOATS, std::vector<float>);
+      IMPL_ONE(INTS, std::vector<int>);
+      IMPL_ONE(BOOLEAN, bool);
+      IMPL_ONE(LONG, int64_t);
+      IMPL_ONE(LONGS, std::vector<int64_t>);
+      default:
+        LOG(FATAL) << "Unsupported attr type found: " << static_cast<int>(type);
+    }
+  };
+#undef IMPL_ONE
+
+  for (const auto &attr_name : cpp_desc.AttrNames()) {
+    auto type = cpp_desc.GetAttrType(attr_name);
+    set_attr(attr_name, type);
+  }
+}
+
+template <>
+void TransformOpDescAnyToCpp<pb::OpDesc>(pb::OpDesc *pb_desc, cpp::OpDesc *cpp_desc) {
+  cpp_desc->SetType(pb_desc->Type());
+  OpInputsPbToCpp(pb_desc, cpp_desc);
+  OpOutputsPbToCpp(pb_desc, cpp_desc);
+  OpAttrsPbToCpp(pb_desc, cpp_desc);
+}
+
+template <>
+void TransformOpDescCppToAny<pb::OpDesc>(const cpp::OpDesc &cpp_desc, pb::OpDesc *pb_desc) {
+  pb_desc->SetType(cpp_desc.Type());
+  OpInputsCppToPb(cpp_desc, pb_desc);
+  OpOutputsCppToPb(cpp_desc, pb_desc);
+  OpAttrsCppToPb(cpp_desc, pb_desc);
+}
+
+/// For BlockDesc transform
+template <>
+void TransformBlockDescAnyToCpp<pb::BlockDesc>(pb::BlockDesc *pb_desc, cpp::BlockDesc *cpp_desc) {
+  cpp_desc->SetIdx(pb_desc->ID());
+  cpp_desc->SetParentIdx(pb_desc->Parent());
+  cpp_desc->SetForwardBlockIdx(pb_desc->ForwardBlockID());
+
+  cpp_desc->ClearOps();
+  const auto &all_ops = pb_desc->AllOps();
+  for (const auto &op : all_ops) {
+    auto *cpp_op_desc = cpp_desc->AddOp<cpp::OpDesc>();
+    TransformOpDescAnyToCpp(*op, cpp_op_desc);
+  }
+
+  cpp_desc->ClearVars();
+  const auto &all_vars = pb_desc->AllVars();
+  for (const auto &var : all_vars) {
+    auto *cpp_var_desc = cpp_desc->AddVar<cpp::VarDesc>();
+    TransformVarDescAnyToCpp(var, cpp_var_desc);
+  }
+}
+
+template <>
+void TransformBlockDescCppToAny<pb::BlockDesc>(const cpp::BlockDesc &cpp_desc, pb::BlockDesc *pb_desc) {
+  pb_desc->Proto()->Clear();
+
+  pb_desc->Proto()->set_idx(cpp_desc.Idx());
+  pb_desc->Proto()->set_parent_idx(cpp_desc.ParentIdx());
+  pb_desc->Proto()->set_forward_block_idx(cpp_desc.ForwardBlockIdx());
+
+  for (size_t i = 0; i < cpp_desc.OpsSize(); ++i) {
+    const auto &cpp_op_desc = cpp_desc.template GetConstOp<cpp::OpDesc>(static_cast<int32_t>(i));
+    auto *pb_op_desc        = pb_desc->AppendOp();
+    TransformOpDescCppToAny(cpp_op_desc, pb_op_desc);
+  }
+
+  for (size_t i = 0; i < cpp_desc.VarsSize(); ++i) {
+    const auto &cpp_var_desc = cpp_desc.template GetConstVar<cpp::VarDesc>(static_cast<int32_t>(i));
+    auto *pb_var_desc        = pb_desc->Var(cpp_var_desc.Name());
+    TransformVarDescCppToAny(cpp_var_desc, pb_var_desc);
+  }
+}
+
+/// For ProgramDesc transform
+template <>
+void TransformProgramDescAnyToCpp<pb::ProgramDesc>(pb::ProgramDesc *pb_desc, cpp::ProgramDesc *cpp_desc) {
+  if (pb_desc->Proto()->version().has_version()) {
+    cpp_desc->SetVersion(pb_desc->Version());
+  }
+
+  cpp_desc->ClearBlocks();
+  for (size_t i = 0; i < pb_desc->Size(); ++i) {
+    const auto &pb_block_desc = pb_desc->Block(i);
+    auto *cpp_block_desc      = cpp_desc->AddBlock<cpp::BlockDesc>();
+    TransformBlockDescAnyToCpp(pb_block_desc, cpp_block_desc);
+  }
+}
+
+template <>
+void TransformProgramDescCppToAny<pb::ProgramDesc>(const cpp::ProgramDesc &cpp_desc, pb::ProgramDesc *pb_desc) {
+  pb_desc->Proto()->Clear();
+
+  if (cpp_desc.HasVersion()) {
+    pb_desc->SetVersion(cpp_desc.Version());
+  }
+
+  // For paddle proto program, the only way to add block is invoke AppendBlock(),
+  // the AppendBlock need one necessary parameter: const BlockDesc &parent,
+  // but the only function of parent is set the block's parent_idx value.
+  // That's why here we create a fake block and only set it's id zero;
+  pb::ProgramDesc fake_prog;
+  pb::BlockDesc fake_block(&fake_prog, fake_prog.Proto()->add_blocks());
+  // In fact, the is is not important, because in TransformBlockDescCppToAny,
+  // the parent_idx will reset, so here all is fake.
+  fake_block.Proto()->set_idx(0);
+
+  for (size_t i = 0; i < cpp_desc.BlocksSize(); ++i) {
+    const auto &cpp_block_desc = cpp_desc.GetConstBlock<cpp::BlockDesc>(i);
+    auto pb_block_desc         = pb_desc->AppendBlock(fake_block);
+    TransformBlockDescCppToAny(cpp_block_desc, &pb_block_desc);
+  }
+}
+
+}  // namespace cinn::frontend::paddle

--- a/cinn/frontend/paddle/compatible_paddle_pb_test.cc
+++ b/cinn/frontend/paddle/compatible_paddle_pb_test.cc
@@ -1,0 +1,218 @@
+#include <unordered_map>
+
+#include "cinn/frontend/paddle/compatible_pb.h"
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/block_desc.h"
+#include "paddle/fluid/framework/op_desc.h"
+#include "paddle/fluid/framework/program_desc.h"
+#include "paddle/fluid/framework/var_desc.h"
+
+namespace cinn::frontend::paddle {
+
+namespace pb    = ::paddle::framework;
+using PbVarType = pb::proto::VarType;
+
+// check VarDesc
+cpp::VarDesc CreateCppVarDesc() {
+  cpp::VarDesc var("test");
+  var.SetType(cpp::VarDescAPI::Type::LOD_TENSOR);
+  var.SetPersistable(true);
+  var.SetDataType(cpp::VarDescAPI::Type::FP32);
+  var.SetShape({100, 200, 300});
+  return var;
+}
+
+pb::VarDesc CreatePbVarDesc() {
+  pb::VarDesc var("test");
+  var.SetType(PbVarType::LOD_TENSOR);
+  var.SetPersistable(true);
+  var.SetDataType(PbVarType::FP32);
+  var.SetShape({100, 200, 300});
+  return var;
+}
+
+TEST(TransformVarDesc, cpp2pb) {
+  auto cpp_var = CreateCppVarDesc();
+  pb::VarDesc pb_var("init");
+  TransformVarDescCppToAny(cpp_var, &pb_var);
+
+  auto correct_var = CreatePbVarDesc();
+  ASSERT_EQ(pb_var.Name(), correct_var.Name());
+  ASSERT_EQ(pb_var.GetType(), correct_var.GetType());
+  ASSERT_EQ(pb_var.Persistable(), correct_var.Persistable());
+  ASSERT_EQ(pb_var.GetDataType(), correct_var.GetDataType());
+  ASSERT_EQ(pb_var.GetShape(), correct_var.GetShape());
+}
+
+TEST(TransformVarDesc, pb2cpp) {
+  auto pb_var = CreatePbVarDesc();
+  cpp::VarDesc cpp_var;
+  TransformVarDescAnyToCpp(&pb_var, &cpp_var);
+
+  auto correct_var = CreateCppVarDesc();
+  ASSERT_EQ(cpp_var.Name(), correct_var.Name());
+  ASSERT_EQ(cpp_var.GetType(), correct_var.GetType());
+  ASSERT_EQ(cpp_var.Persistable(), correct_var.Persistable());
+  ASSERT_EQ(cpp_var.GetDataType(), correct_var.GetDataType());
+  ASSERT_EQ(cpp_var.GetShape(), correct_var.GetShape());
+}
+
+// check OpDesc
+cpp::OpDesc CreateCppOpDesc() {
+  cpp::OpDesc op;
+  op.SetType("test");
+  op.SetInput("X", {"x1"});
+  op.SetInput("Y", {"y1", "y2"});
+  op.SetOutput("Out", {"out1"});
+  op.SetAttr<float>("attr_f", 0.1f);
+  op.SetAttr<std::string>("attr_str", "test_attr");
+  return op;
+}
+
+pb::OpDesc CreatePbOpDesc() {
+  pb::OpDesc op;
+  op.SetType("test");
+  op.SetInput("X", {"x1"});
+  op.SetInput("Y", {"y1", "y2"});
+  op.SetOutput("Out", {"out1"});
+  op.SetAttr("attr_f", 0.1f);
+  op.SetAttr("attr_str", std::string("test_attr"));
+  return op;
+}
+
+TEST(TransformOpDesc, cpp2pb) {
+  auto cpp_op = CreateCppOpDesc();
+  pb::OpDesc pb_op;
+  TransformOpDescCppToAny(cpp_op, &pb_op);
+
+  auto correct_op = CreatePbOpDesc();
+  ASSERT_EQ(pb_op.Type(), correct_op.Type());
+  ASSERT_EQ(pb_op.Inputs(), correct_op.Inputs());
+  ASSERT_EQ(pb_op.Outputs(), correct_op.Outputs());
+  ASSERT_EQ(pb_op.AttrNames(), correct_op.AttrNames());
+
+  for (const auto &attr_name : pb_op.AttrNames()) {
+    ASSERT_EQ(pb_op.GetAttrType(attr_name), correct_op.GetAttrType(attr_name));
+  }
+  ASSERT_EQ(pb_op.GetAttrIfExists<float>("attr_f"), correct_op.GetAttrIfExists<float>("attr_f"));
+  ASSERT_EQ(pb_op.GetAttrIfExists<std::string>("attr_str"), correct_op.GetAttrIfExists<std::string>("attr_str"));
+}
+
+TEST(TransformOpDesc, pb2cpp) {
+  auto pb_op = CreatePbOpDesc();
+  cpp::OpDesc cpp_op;
+  TransformOpDescAnyToCpp(&pb_op, &cpp_op);
+
+  auto correct_op = CreateCppOpDesc();
+  ASSERT_EQ(cpp_op.Type(), correct_op.Type());
+  ASSERT_EQ(cpp_op.inputs(), correct_op.inputs());
+  ASSERT_EQ(cpp_op.outputs(), correct_op.outputs());
+  ASSERT_EQ(cpp_op.AttrNames(), correct_op.AttrNames());
+  ASSERT_EQ(cpp_op.attr_types(), correct_op.attr_types());
+
+  ASSERT_EQ(cpp_op.GetAttr<float>("attr_f"), correct_op.GetAttr<float>("attr_f"));
+  ASSERT_EQ(cpp_op.GetAttr<std::string>("attr_str"), correct_op.GetAttr<std::string>("attr_str"));
+}
+
+// check BlockDesc
+// pb::BlockDesc is DISABLE_COPY_AND_ASSIGN, so can not return
+void CreateCppBlockDesc(cpp::BlockDesc *block) {
+  block->SetIdx(42);
+  block->SetParentIdx(4);
+  block->SetForwardBlockIdx(32);
+
+  auto *op = block->AddOp<cpp::OpDesc>();
+  *op      = CreateCppOpDesc();
+
+  auto *var = block->AddVar<cpp::VarDesc>();
+  *var      = CreateCppVarDesc();
+}
+
+void CreatePbBlockDesc(pb::BlockDesc *block) {
+  block->Proto()->set_idx(42);
+  block->Proto()->set_parent_idx(4);
+  block->Proto()->set_forward_block_idx(32);
+
+  auto *op = block->AppendOp();
+  *op      = CreatePbOpDesc();
+
+  auto *var = block->Var("init");
+  *var      = CreatePbVarDesc();
+}
+
+TEST(TransformBlockDesc, cpp2pb) {
+  cpp::BlockDesc cpp_block;
+  CreateCppBlockDesc(&cpp_block);
+
+  pb::ProgramDesc pb_prog;
+  auto *pb_block = pb_prog.MutableBlock(0);
+  TransformBlockDescCppToAny(cpp_block, pb_block);
+
+  pb::ProgramDesc correct_prog;
+  auto *correct_block = correct_prog.MutableBlock(0);
+  CreatePbBlockDesc(correct_block);
+  ASSERT_EQ(pb_block->ID(), correct_block->ID());
+  ASSERT_EQ(pb_block->Parent(), correct_block->Parent());
+  ASSERT_EQ(pb_block->ForwardBlockID(), correct_block->ForwardBlockID());
+  ASSERT_EQ(pb_block->OpSize(), correct_block->OpSize());
+  ASSERT_EQ(pb_block->AllVars().size(), correct_block->AllVars().size());
+}
+
+TEST(TransformBlockDesc, pb2cpp) {
+  pb::ProgramDesc pb_prog;
+  auto *pb_block = pb_prog.MutableBlock(0);
+  CreatePbBlockDesc(pb_block);
+
+  cpp::BlockDesc cpp_block;
+  TransformBlockDescAnyToCpp(pb_block, &cpp_block);
+
+  cpp::BlockDesc correct_block;
+  CreateCppBlockDesc(&correct_block);
+  ASSERT_EQ(cpp_block.Idx(), correct_block.Idx());
+  ASSERT_EQ(cpp_block.ParentIdx(), correct_block.ParentIdx());
+  ASSERT_EQ(cpp_block.ForwardBlockIdx(), correct_block.ForwardBlockIdx());
+  ASSERT_EQ(cpp_block.OpsSize(), correct_block.OpsSize());
+  ASSERT_EQ(cpp_block.VarsSize(), correct_block.VarsSize());
+}
+
+// check ProgramDesc
+cpp::ProgramDesc CreateCppProgramDesc() {
+  cpp::ProgramDesc prog;
+  prog.SetVersion(22);
+
+  auto *block = prog.AddBlock<cpp::BlockDesc>();
+  CreateCppBlockDesc(block);
+
+  return prog;
+}
+
+pb::ProgramDesc CreatePbProgramDesc() {
+  pb::ProgramDesc prog;
+  prog.SetVersion(22);
+
+  auto *block = prog.MutableBlock(0);
+  CreatePbBlockDesc(block);
+  return prog;
+}
+
+TEST(TransformProgramDesc, cpp2pb) {
+  auto cpp_prog = CreateCppProgramDesc();
+  pb::ProgramDesc pb_prog;
+  TransformProgramDescCppToAny(cpp_prog, &pb_prog);
+
+  auto correct_prog = CreatePbProgramDesc();
+  ASSERT_EQ(pb_prog.Version(), correct_prog.Version());
+  ASSERT_EQ(pb_prog.Size(), correct_prog.Size());
+}
+
+TEST(TransformProgramDesc, pb2cpp) {
+  auto pb_prog = CreatePbProgramDesc();
+  cpp::ProgramDesc cpp_prog;
+  TransformProgramDescAnyToCpp(&pb_prog, &cpp_prog);
+
+  auto correct_prog = CreateCppProgramDesc();
+  ASSERT_EQ(cpp_prog.Version(), correct_prog.Version());
+  ASSERT_EQ(cpp_prog.BlocksSize(), correct_prog.BlocksSize());
+}
+
+}  // namespace cinn::frontend::paddle

--- a/cinn/frontend/paddle/compatible_pb.h
+++ b/cinn/frontend/paddle/compatible_pb.h
@@ -11,6 +11,9 @@ namespace cinn::frontend::paddle {
 template <typename VarDescType>
 void TransformVarDescAnyToCpp(const VarDescType& any_desc, cpp::VarDesc* cpp_desc);
 
+template <typename VarDescType>
+void TransformVarDescAnyToCpp(VarDescType* any_desc, cpp::VarDesc* cpp_desc);
+
 /// Transform an VarDesc from cpp to VarDescType format.
 template <typename VarDescType>
 void TransformVarDescCppToAny(const cpp::VarDesc& cpp_desc, VarDescType* any_desc);
@@ -18,6 +21,9 @@ void TransformVarDescCppToAny(const cpp::VarDesc& cpp_desc, VarDescType* any_des
 /// Transform an OpDesc from OpDescType to cpp format.
 template <typename OpDescType>
 void TransformOpDescAnyToCpp(const OpDescType& any_desc, cpp::OpDesc* cpp_desc);
+
+template <typename OpDescType>
+void TransformOpDescAnyToCpp(OpDescType* any_desc, cpp::OpDesc* cpp_desc);
 
 /// Transform an OpDesc from cpp to OpDescType format.
 template <typename OpDescType>
@@ -27,6 +33,9 @@ void TransformOpDescCppToAny(const cpp::OpDesc& cpp_desc, OpDescType* any_desc);
 template <typename BlockDescType>
 void TransformBlockDescAnyToCpp(const BlockDescType& any_desc, cpp::BlockDesc* cpp_desc);
 
+template <typename BlockDescType>
+void TransformBlockDescAnyToCpp(BlockDescType* any_desc, cpp::BlockDesc* cpp_desc);
+
 /// Transform an BlockDesc from cpp to BlockDescType format.
 template <typename BlockDescType>
 void TransformBlockDescCppToAny(const cpp::BlockDesc& cpp_desc, BlockDescType* any_desc);
@@ -34,6 +43,9 @@ void TransformBlockDescCppToAny(const cpp::BlockDesc& cpp_desc, BlockDescType* a
 /// Transform an ProgramDesc from ProgramDescType to cpp format.
 template <typename ProgramDescType>
 void TransformProgramDescAnyToCpp(const ProgramDescType& any_desc, cpp::ProgramDesc* cpp_desc);
+
+template <typename ProgramDescType>
+void TransformProgramDescAnyToCpp(ProgramDescType* any_desc, cpp::ProgramDesc* cpp_desc);
 
 /// Transform an ProgramDesc from cpp to ProgramDescType format.
 template <typename ProgramDescType>

--- a/cinn/frontend/paddle/cpp/block_desc.cc
+++ b/cinn/frontend/paddle/cpp/block_desc.cc
@@ -4,8 +4,14 @@ namespace cinn::frontend::paddle::cpp {
 
 template <>
 VarDesc* BlockDesc::GetVar<VarDesc>(int32_t idx) {
-  CHECK_LT(idx, VarsSize()) << "idx >= vars.size()";
+  CHECK_LT(idx, static_cast<int32_t>(VarsSize())) << "idx >= vars.size()";
   return &vars_[idx];
+}
+
+template <>
+const VarDesc& BlockDesc::GetConstVar<VarDesc>(int32_t idx) const {
+  CHECK_LT(idx, static_cast<int32_t>(VarsSize())) << "idx >= vars.size()";
+  return vars_[idx];
 }
 
 template <>
@@ -16,8 +22,14 @@ VarDesc* BlockDesc::AddVar<VarDesc>() {
 
 template <>
 OpDesc* BlockDesc::GetOp<OpDesc>(int32_t idx) {
-  CHECK_LT(idx, OpsSize()) << "idx >= ops.size()";
+  CHECK_LT(idx, static_cast<int32_t>(OpsSize())) << "idx >= ops.size()";
   return &ops_[idx];
+}
+
+template <>
+const OpDesc& BlockDesc::GetConstOp<OpDesc>(int32_t idx) const {
+  CHECK_LT(idx, static_cast<int32_t>(OpsSize())) << "idx >= ops.size()";
+  return ops_[idx];
 }
 
 template <>

--- a/cinn/frontend/paddle/cpp/block_desc.h
+++ b/cinn/frontend/paddle/cpp/block_desc.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <vector>
+
 #include "cinn/frontend/paddle/cpp/desc_api.h"
 #include "cinn/frontend/paddle/cpp/op_desc.h"
 #include "cinn/frontend/paddle/cpp/var_desc.h"
@@ -29,6 +32,9 @@ class BlockDesc : public BlockDescAPI {
   T* GetVar(int32_t idx);
 
   template <typename T>
+  const T& GetConstVar(int32_t idx) const;
+
+  template <typename T>
   T* AddVar();
 
   size_t OpsSize() const override { return ops_.size(); }
@@ -37,6 +43,9 @@ class BlockDesc : public BlockDescAPI {
 
   template <typename T>
   T* GetOp(int32_t idx);
+
+  template <typename T>
+  const T& GetConstOp(int32_t idx) const;
 
   template <typename T>
   T* AddOp();

--- a/cinn/frontend/paddle/cpp/program_desc.cc
+++ b/cinn/frontend/paddle/cpp/program_desc.cc
@@ -1,12 +1,17 @@
 #include "cinn/frontend/paddle/cpp/program_desc.h"
 
 namespace cinn::frontend::paddle::cpp {
-namespace framework_proto = ::paddle::framework::proto;
 
 template <>
 BlockDesc* ProgramDesc::GetBlock<BlockDesc>(int32_t idx) {
-  CHECK_LT(idx, BlocksSize()) << "idx >= blocks.size()";
+  CHECK_LT(idx, static_cast<int32_t>(BlocksSize())) << "idx >= blocks.size()";
   return &blocks_[idx];
+}
+
+template <>
+const BlockDesc& ProgramDesc::GetConstBlock<BlockDesc>(int32_t idx) const {
+  CHECK_LT(idx, static_cast<int32_t>(BlocksSize())) << "idx >= blocks.size()";
+  return blocks_[idx];
 }
 
 template <>

--- a/cinn/frontend/paddle/cpp/program_desc.h
+++ b/cinn/frontend/paddle/cpp/program_desc.h
@@ -24,6 +24,9 @@ class ProgramDesc : public ProgramDescAPI {
   T* GetBlock(int32_t idx);
 
   template <typename T>
+  const T& GetConstBlock(int32_t idx) const;
+
+  template <typename T>
   T* AddBlock();
 
   // Just return default versoin

--- a/cinn/frontend/paddle/vartype_utils.h
+++ b/cinn/frontend/paddle/vartype_utils.h
@@ -1,0 +1,101 @@
+#pragma once
+#include "cinn/frontend/paddle/cpp/desc_api.h"
+#include "glog/logging.h"
+#include "paddle/fluid/framework/framework.pb.h"
+
+namespace cinn::frontend::paddle::utils {
+
+cpp::VarDescAPI::Type TransformVarTypePbToCpp(const ::paddle::framework::proto::VarType::Type& type) {
+#define SET_TYPE_CASE_ITEM(type__)                  \
+  case ::paddle::framework::proto::VarType::type__: \
+    return cpp::VarDescAPI::Type::type__;           \
+    break;
+
+  switch (type) {
+    SET_TYPE_CASE_ITEM(LOD_TENSOR);
+    SET_TYPE_CASE_ITEM(LOD_TENSOR_ARRAY);
+    SET_TYPE_CASE_ITEM(LOD_RANK_TABLE);
+    SET_TYPE_CASE_ITEM(SELECTED_ROWS);
+    SET_TYPE_CASE_ITEM(FEED_MINIBATCH);
+    SET_TYPE_CASE_ITEM(FETCH_LIST);
+    SET_TYPE_CASE_ITEM(STEP_SCOPES);
+    SET_TYPE_CASE_ITEM(PLACE_LIST);
+    SET_TYPE_CASE_ITEM(READER);
+    default:
+      LOG(FATAL) << "Unknown var type";
+      return cpp::VarDescAPI::Type::RAW;
+  }
+#undef SET_TYPE_CASE_ITEM
+}
+
+::paddle::framework::proto::VarType::Type TransformVarTypeCppToPb(const cpp::VarDescAPI::Type& type) {
+#define SET_TYPE_CASE_ITEM(type__)                      \
+  case cpp::VarDescAPI::Type::type__:                   \
+    return ::paddle::framework::proto::VarType::type__; \
+    break;
+
+  switch (type) {
+    SET_TYPE_CASE_ITEM(LOD_TENSOR);
+    SET_TYPE_CASE_ITEM(LOD_TENSOR_ARRAY);
+    SET_TYPE_CASE_ITEM(LOD_RANK_TABLE);
+    SET_TYPE_CASE_ITEM(SELECTED_ROWS);
+    SET_TYPE_CASE_ITEM(FEED_MINIBATCH);
+    SET_TYPE_CASE_ITEM(FETCH_LIST);
+    SET_TYPE_CASE_ITEM(STEP_SCOPES);
+    SET_TYPE_CASE_ITEM(PLACE_LIST);
+    SET_TYPE_CASE_ITEM(READER);
+    default:
+      LOG(FATAL) << "Unknown var type";
+      return ::paddle::framework::proto::VarType::RAW;
+  }
+#undef SET_TYPE_CASE_ITEM
+}
+
+cpp::VarDescAPI::Type TransformVarDataTypePbToCpp(const ::paddle::framework::proto::VarType::Type& type) {
+#define SET_DATA_TYPE_CASE_ITEM(type__)             \
+  case ::paddle::framework::proto::VarType::type__: \
+    return cpp::VarDescAPI::Type::type__;           \
+    break;
+
+  switch (type) {
+    SET_DATA_TYPE_CASE_ITEM(BOOL);
+    SET_DATA_TYPE_CASE_ITEM(SIZE_T);
+    SET_DATA_TYPE_CASE_ITEM(UINT8);
+    SET_DATA_TYPE_CASE_ITEM(INT8);
+    SET_DATA_TYPE_CASE_ITEM(INT16);
+    SET_DATA_TYPE_CASE_ITEM(INT32);
+    SET_DATA_TYPE_CASE_ITEM(INT64);
+    SET_DATA_TYPE_CASE_ITEM(FP16);
+    SET_DATA_TYPE_CASE_ITEM(FP32);
+    SET_DATA_TYPE_CASE_ITEM(FP64);
+    default:
+      LOG(FATAL) << "Unknown var data type";
+      return cpp::VarDescAPI::Type::RAW;
+  }
+#undef SET_DATA_TYPE_CASE_ITEM
+}
+
+::paddle::framework::proto::VarType::Type TransformVarDataTypeCppToPb(const cpp::VarDescAPI::Type& type) {
+#define SET_DATA_TYPE_CASE_ITEM(type__)                 \
+  case cpp::VarDescAPI::Type::type__:                   \
+    return ::paddle::framework::proto::VarType::type__; \
+    break;
+
+  switch (type) {
+    SET_DATA_TYPE_CASE_ITEM(BOOL);
+    SET_DATA_TYPE_CASE_ITEM(SIZE_T);
+    SET_DATA_TYPE_CASE_ITEM(UINT8);
+    SET_DATA_TYPE_CASE_ITEM(INT8);
+    SET_DATA_TYPE_CASE_ITEM(INT16);
+    SET_DATA_TYPE_CASE_ITEM(INT32);
+    SET_DATA_TYPE_CASE_ITEM(INT64);
+    SET_DATA_TYPE_CASE_ITEM(FP16);
+    SET_DATA_TYPE_CASE_ITEM(FP32);
+    SET_DATA_TYPE_CASE_ITEM(FP64);
+    default:
+      LOG(FATAL) << "Unknown var data type";
+      return ::paddle::framework::proto::VarType::RAW;
+  }
+#undef SET_DATA_TYPE_CASE_ITEM
+}
+}  // namespace cinn::frontend::paddle::utils


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
**[WIP] Need co-compilation of paddle and cinn!!**
As title. Add the instantiation of `Transform*DescAnyToCpp` and `Transform*DescCppToAny` of `paddle::framework::*Desc`, and add some interface of CINN Desc for Transform.