### PR TITLE
Add `GetConst` API for blockdesc and programdesc

### DIFF
--- a/cinn/frontend/paddle/cpp/block_desc.cc
+++ b/cinn/frontend/paddle/cpp/block_desc.cc
@@ -9,6 +9,12 @@ VarDesc* BlockDesc::GetVar<VarDesc>(int32_t idx) {
 }
 
 template <>
+const VarDesc& BlockDesc::GetConstVar<VarDesc>(int32_t idx) const {
+  CHECK_LT(idx, static_cast<int32_t>(VarsSize())) << "idx >= vars.size()";
+  return vars_[idx];
+}
+
+template <>
 VarDesc* BlockDesc::AddVar<VarDesc>() {
   vars_.emplace_back();
   return &vars_.back();
@@ -18,6 +24,12 @@ template <>
 OpDesc* BlockDesc::GetOp<OpDesc>(int32_t idx) {
   CHECK_LT(idx, OpsSize()) << "idx >= ops.size()";
   return &ops_[idx];
+}
+
+template <>
+const OpDesc& BlockDesc::GetConstOp<OpDesc>(int32_t idx) const {
+  CHECK_LT(idx, static_cast<int32_t>(OpsSize())) << "idx >= ops.size()";
+  return ops_[idx];
 }
 
 template <>

--- a/cinn/frontend/paddle/cpp/block_desc.h
+++ b/cinn/frontend/paddle/cpp/block_desc.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <vector>
+
 #include "cinn/frontend/paddle/cpp/desc_api.h"
 #include "cinn/frontend/paddle/cpp/op_desc.h"
 #include "cinn/frontend/paddle/cpp/var_desc.h"
@@ -29,6 +32,9 @@ class BlockDesc : public BlockDescAPI {
   T* GetVar(int32_t idx);
 
   template <typename T>
+  const T& GetConstVar(int32_t idx) const;
+
+  template <typename T>
   T* AddVar();
 
   size_t OpsSize() const override { return ops_.size(); }
@@ -37,6 +43,9 @@ class BlockDesc : public BlockDescAPI {
 
   template <typename T>
   T* GetOp(int32_t idx);
+
+  template <typename T>
+  const T& GetConstOp(int32_t idx) const;
 
   template <typename T>
   T* AddOp();

--- a/cinn/frontend/paddle/cpp/program_desc.cc
+++ b/cinn/frontend/paddle/cpp/program_desc.cc
@@ -1,12 +1,17 @@
 #include "cinn/frontend/paddle/cpp/program_desc.h"
 
 namespace cinn::frontend::paddle::cpp {
-namespace framework_proto = ::paddle::framework::proto;
 
 template <>
 BlockDesc* ProgramDesc::GetBlock<BlockDesc>(int32_t idx) {
   CHECK_LT(idx, BlocksSize()) << "idx >= blocks.size()";
   return &blocks_[idx];
+}
+
+template <>
+const BlockDesc& ProgramDesc::GetConstBlock<BlockDesc>(int32_t idx) const {
+  CHECK_LT(idx, static_cast<int32_t>(BlocksSize())) << "idx >= blocks.size()";
+  return blocks_[idx];
 }
 
 template <>

--- a/cinn/frontend/paddle/cpp/program_desc.h
+++ b/cinn/frontend/paddle/cpp/program_desc.h
@@ -24,6 +24,9 @@ class ProgramDesc : public ProgramDescAPI {
   T* GetBlock(int32_t idx);
 
   template <typename T>
+  const T& GetConstBlock(int32_t idx) const;
+
+  template <typename T>
   T* AddBlock();
 
   // Just return default versoin


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
Add `GetConstOp` and `GetConstVar` api of cpp::desc, they are used for paddle desc and cinn desc transformer https://github.com/PaddlePaddle/Paddle/pull/36100 .