### PR TITLE
add decomposer registry

### DIFF
--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -49,6 +49,12 @@ int Target::get_target_bits() const {
   return -1;
 }
 
+size_t Target::Hash::operator()(const Target &key) const {
+  int arch = static_cast<int>(key.arch);
+  std::hash<int> hasher;
+  return hasher(arch);
+}
+
 std::ostream &operator<<(std::ostream &os, const Target &target) {
   os << "Target<";
   switch (target.os) {

--- a/cinn/common/target.h
+++ b/cinn/common/target.h
@@ -69,6 +69,10 @@ struct Target {
 
   std::vector<Lib> get_target_libs() const;
 
+  struct Hash {
+    size_t operator()(const Target& key) const;
+  };
+
   bool operator==(const Target& other) const;
   bool operator!=(const Target& other) const { return !(*this == other); }
   friend std::ostream& operator<<(std::ostream& os, const Target& target);

--- a/cinn/frontend/CMakeLists.txt
+++ b/cinn/frontend/CMakeLists.txt
@@ -3,6 +3,7 @@ core_gather_srcs(SRCS
     syntax.cc
     paddle_model_to_program.cc
     interpreter.cc
+    decomposer_registry.cc
     )
 
 if(NOT WITH_CUDA)
@@ -13,6 +14,9 @@ if(NOT WITH_CUDA)
   cc_test(test_frontend_interpreter
           ARGS --model_dir=${THIRD_PARTY_PATH}/naive_mul_model
           SRCS interpreter_test.cc DEPS cinncore)
+
+  cc_test(test_decomposer_registry
+          SRCS decomposer_registry_test.cc DEPS cinncore)
 else()
   nv_test(test_frontend_syntax
           ARGS "--model_dir=${THIRD_PARTY_PATH}/naive_mul_model"

--- a/cinn/frontend/decomposer_registry.cc
+++ b/cinn/frontend/decomposer_registry.cc
@@ -1,0 +1,13 @@
+#include "cinn/frontend/decomposer_registry.h"
+
+namespace cinn {
+namespace frontend {
+
+void InstrDecomposerRegistry::RegisterDecomposer(const std::string& op_type,
+                                                 const common::Target& target,
+                                                 Decomposer func) {
+  InstrDecomposerMap::Instance().Insert(op_type, target, func);
+}
+
+}  // namespace frontend
+}  // namespace cinn

--- a/cinn/frontend/decomposer_registry.h
+++ b/cinn/frontend/decomposer_registry.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "cinn/common/target.h"
+#include "cinn/frontend/syntax.h"
+
+namespace cinn {
+namespace frontend {
+
+using Decomposer = std::function<void(
+    const Instruction& instr, frontend::Program* progam, std::unordered_map<std::string, Variable>* outs_map)>;
+
+using TargetMap = std::unordered_map<common::Target, Decomposer, common::Target::Hash>;
+
+class InstrDecomposerMap {
+ public:
+  static InstrDecomposerMap& Instance() {
+    static InstrDecomposerMap g_instr_decomposer_map;
+    return g_instr_decomposer_map;
+  }
+
+  bool Has(const std::string& op_type, const common::Target& target) const {
+    return map_.find(op_type) != map_.end() && map_.at(op_type).find(target) != map_.at(op_type).end();
+  }
+
+  void Insert(const std::string& op_type, const common::Target& target, Decomposer func) {
+    map_[op_type][target] = func;
+  }
+
+  const Decomposer& Get(const std::string& op_type, const common::Target& target) const {
+    auto decomposer_ptr = GetNullable(op_type, target);
+    CHECK(decomposer_ptr) << "The decomposer for [" << op_type << ", " << target << "] "
+                          << " is not registered.";
+    return *decomposer_ptr;
+  }
+
+  const Decomposer* GetNullable(const std::string& op_type, const common::Target& target) const {
+    auto it_target = map_.find(op_type);
+    if (it_target == map_.end()) {
+      return nullptr;
+    } else {
+      auto it_decomposer = map_.at(op_type).find(target);
+      if (it_decomposer == map_.at(op_type).end()) {
+        return nullptr;
+      } else {
+        return &it_decomposer->second;
+      }
+    }
+  }
+
+ private:
+  std::unordered_map<std::string, TargetMap> map_;
+};
+
+class InstrDecomposerRegistry final {
+ public:
+  static void RegisterDecomposer(const std::string& op_type, const common::Target& target, Decomposer func);
+};
+
+#define REGISTER_INSTR_DECOMPOSER(op_type, target, decomposer) \
+  InstrDecomposerRegistry::RegisterDecomposer(op_type, target, decomposer)
+
+}  // namespace frontend
+}  // namespace cinn

--- a/cinn/frontend/decomposer_registry_test.cc
+++ b/cinn/frontend/decomposer_registry_test.cc
@@ -1,0 +1,20 @@
+#include "cinn/frontend/decomposer_registry.h"
+
+#include <gtest/gtest.h>
+
+namespace cinn::frontend {
+
+TEST(InstrDecomposerRegistry, basic) {
+  common::Target target;
+  auto decomposer =
+      [](const Instruction& instr, Program* program, std::unordered_map<std::string, Variable>* outs_map) {
+        auto var           = frontend::Variable("var");
+        (*outs_map)["var"] = var;
+      };
+  REGISTER_INSTR_DECOMPOSER("test", target, decomposer);
+
+  ASSERT_EQ(InstrDecomposerMap::Instance().Has("test", target), true);
+  InstrDecomposerMap::Instance().Get("test", target);
+}
+
+}  // namespace cinn::frontend


### PR DESCRIPTION
背景：CINN需要将粗粒度算子拆解为元算子实现，需要为每个op_type注册拆解函数。

实现方式：
- 使用一个全局的map保存所有拆解函数，其key为op_type，value为对应的拆解函数表
- 每个op_type的拆解函数也是一个map，其key为target，value为拆解函数

结合pass的机制：输入一个原始program，返回一个将所有粗粒度算子替换为元算子的新program。

目前对拆解函数的构思如下，本PR未做实现
- 输入：待拆解指令，新建的program
- 输出：一个保存输出映射关系的map，作为函数参数传入，原因如下

原始program：
```python
out1 = conv(a, b)
out2 = bn(out1)
out3 = conv(out2, d)
out4 = bn(out3)
out5 = pool(out4)
out6 = add(out2, out5)
```

bn拆解函数：
```python
res1 = op1(out1)
res2 = op2(res1)
```

假设需要对out2 = bn(out1) 这里的bn进行拆解
- 需要建立一个输出映射表
- 当pass中遍历到bn时，由于拆解后，bn的拆解算子产生的输出是res2，为了能正确被下游算子使用，添加到输出映射表中 map[out2.id] = res2
- 处理add算子时，需要将它的输入out2替换为新的variable res2，通过检查它的每个输入是否在这个输出映射表中，为add算子建立正确的输入


