### PR TITLE
enable tensor.mutable_data on compile-time with an option

### DIFF
--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -334,7 +334,7 @@ void GraphCompiler::ProcessFunction(const std::vector<ir::LoweredFunc>& lowered_
 }
 
 std::unique_ptr<Program> GraphCompiler::Build(const std::string& code) {
-  CompileOptions options;
+  GraphCompiler::CompileOptions options;
   options.attached_code              = code;
   options.with_instantiate_variables = true;
 
@@ -342,7 +342,7 @@ std::unique_ptr<Program> GraphCompiler::Build(const std::string& code) {
   return std::move(result.runtime_program);
 }
 
-CompilationResult GraphCompiler::Build(const CompileOptions& options) {
+GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::CompileOptions& options) {
   auto topo_order = graph_->topological_order();
   auto& nodes     = std::get<0>(topo_order);
   auto& edges     = std::get<1>(topo_order);
@@ -396,7 +396,7 @@ CompilationResult GraphCompiler::Build(const CompileOptions& options) {
     }
   }
 
-  CompilationResult result;
+  GraphCompiler::CompilationResult result;
   result.runtime_program.reset(new Program(scope_, BuildInstructions()));
   return result;
 }

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -39,8 +39,8 @@ void AddAttrs(const absl::flat_hash_map<std::string, AttrType>& attrs_store,
 
 void GraphCompiler::PrintFunc() {
   auto topo_order = graph_->topological_order();
-  auto &nodes = std::get<0>(topo_order);
-  auto &edges = std::get<1>(topo_order);
+  auto& nodes     = std::get<0>(topo_order);
+  auto& edges     = std::get<1>(topo_order);
 
   for (auto& n : nodes) {
     auto* node = n->safe_as<Node>();
@@ -52,8 +52,8 @@ void GraphCompiler::PrintFunc() {
 
 std::string GraphCompiler::GenSourceCode() {
   auto topo_order = graph_->topological_order();
-  auto &nodes = std::get<0>(topo_order);
-  auto &edges = std::get<1>(topo_order);
+  auto& nodes     = std::get<0>(topo_order);
+  auto& edges     = std::get<1>(topo_order);
 
   for (auto& n : nodes) {
     auto* node = n->safe_as<Node>();
@@ -319,10 +319,9 @@ void GraphCompiler::ProcessFunction(const std::vector<ir::LoweredFunc>& lowered_
           for (auto& shape_dim : j.buffer_arg()->shape) {
             VLOG(3) << shape_dim << ",";
             CHECK(shape_dim.is_constant());
-            shape.push_back((int)(shape_dim.get_constant()));
+            shape.push_back(static_cast<int>(shape_dim.get_constant()));
           }
           tensor->Resize(Shape{shape});
-          tensor->mutable_data<float>(target_);
         }
       }
       function2input_args_[i->name]  = input_args;
@@ -335,11 +334,20 @@ void GraphCompiler::ProcessFunction(const std::vector<ir::LoweredFunc>& lowered_
 }
 
 std::unique_ptr<Program> GraphCompiler::Build(const std::string& code) {
-  auto topo_order = graph_->topological_order();
-  auto &nodes = std::get<0>(topo_order);
-  auto &edges = std::get<1>(topo_order);
+  CompileOptions options;
+  options.attached_code              = code;
+  options.with_instantiate_variables = true;
 
-  auto& groups        = graph_->groups;
+  auto&& result = Build(options);
+  return std::move(result.runtime_program);
+}
+
+CompilationResult GraphCompiler::Build(const CompileOptions& options) {
+  auto topo_order = graph_->topological_order();
+  auto& nodes     = std::get<0>(topo_order);
+  auto& edges     = std::get<1>(topo_order);
+
+  auto& groups = graph_->groups;
 
   if (!groups.empty()) {
     for (int i = 0; i < groups.size(); i++) {
@@ -377,18 +385,29 @@ std::unique_ptr<Program> GraphCompiler::Build(const std::string& code) {
     VLOG(3) << "[X86] C Code is:\n" << out;
   }
 
-  compiler_->Build(build_module, code);
+  compiler_->Build(build_module, options.attached_code);
+  if (options.with_instantiate_variables) {
+    VLOG(3) << "Initantiate all variables on compile-time";
+    // All variables reside in scope_, so traverse it to instantiate each one
+    for (auto& name : scope_->var_names()) {
+      auto* var    = scope_->Var<Tensor>(std::string({name.data(), name.size()}));
+      auto& tensor = absl::get<Tensor>(*var);
+      tensor->mutable_data<float>(target_);
+    }
+  }
 
-  return std::unique_ptr<Program>(new Program(scope_, BuildInstructions()));
+  CompilationResult result;
+  result.runtime_program.reset(new Program(scope_, BuildInstructions()));
+  return result;
 }
 
 std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions() {
   std::vector<std::unique_ptr<Instruction>> instructions;
   auto topo_order = graph_->topological_order();
-  auto &nodes = std::get<0>(topo_order);
-  auto &edges = std::get<1>(topo_order);
+  auto& nodes     = std::get<0>(topo_order);
+  auto& edges     = std::get<1>(topo_order);
 
-  auto& groups        = graph_->groups;
+  auto& groups = graph_->groups;
   for (auto& group : groups) {
     if (group.size() == 1) {
       auto node  = group[0];
@@ -520,7 +539,7 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions() {
       int i                   = 1;
       std::string new_op_func = op_func_name + "_" + std::to_string(i);
       if (function2input_args_.count(new_op_func) != 0) {
-        CHECK(function2input_args_.count(op_func_name) > 0);
+        CHECK_GT(function2input_args_.count(op_func_name), 0);
         instr->AddInArgs(function2input_args_[op_func_name]);
         instr->AddOutArgs(function2output_args_[op_func_name]);
       }
@@ -616,7 +635,6 @@ std::shared_ptr<Scope> BuildScope(Target target, const std::shared_ptr<Graph>& g
     tensor->Resize(Shape{shape});
     CHECK_EQ(dtype_dict.at(iter.first), Float(32))
         << "The dtype of node " << iter.first << " is not float! Other dtype is not implemented yet.";
-    tensor->mutable_data<float>(target);
   }
   return scope;
 }

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -105,16 +105,15 @@ class GraphCompiler final {
 
   struct CompilationResult {
     std::unique_ptr<Program> runtime_program;
-  }
+  };
 
   struct CompileOptions {
     std::string attached_code       = "";
     bool with_instantiate_variables = false;
-  }
+  };
 
   // Compile with a packing option and result, to be extended easily.
-  CompilationResult
-  Build(const CompileOptions& options);
+  CompilationResult Build(const CompileOptions& options);
 
   std::unique_ptr<Program> Build(const std::string& code = "");
 

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -101,6 +102,19 @@ class GraphCompiler final {
  public:
   GraphCompiler(Target target, const std::shared_ptr<Scope>& scope, const std::shared_ptr<Graph>& graph)
       : target_(std::move(target)), scope_(scope), graph_(graph), m_builder_(UniqName("module"), target) {}
+
+  struct CompilationResult {
+    std::unique_ptr<Program> runtime_program;
+  }
+
+  struct CompileOptions {
+    std::string attached_code       = "";
+    bool with_instantiate_variables = false;
+  }
+
+  // Compile with a packing option and result, to be extended easily.
+  CompilationResult
+  Build(const CompileOptions& options);
 
   std::unique_ptr<Program> Build(const std::string& code = "");
 


### PR DESCRIPTION
现在变量底层buffer开辟空间是在编译过程的BuildScope和GraphCompiler::ProcessFunction进行，为了支持在外部调用方进行此项操作，此PR增加一个编译选项，允许用户控制是否在编译期间顺带申请空间，具体改动如下：
1. 去除BuildScope和GraphCompiler::ProcessFunction中的tensor mutable_data。
2. 在GraphCompiler类重载Build接口，接收封装类CompileOptions作为编译参数，返回CompilationResult类结果，以便兼容当前默认编译接口并支持扩展参数。