### PR TITLE
add ProggramPass and DecomposerPass

### DIFF
--- a/cinn/frontend/CMakeLists.txt
+++ b/cinn/frontend/CMakeLists.txt
@@ -6,7 +6,8 @@ gather_srcs(cinnapi_src SRCS
   base_builder.cc
   net_builder.cc
   cinn_builder.cc
-  paddle_model_to_netbuilder.cc)
+  paddle_model_to_netbuilder.cc
+  program_pass.cc)
 
 if(NOT WITH_CUDA)
   cc_test(test_frontend_syntax
@@ -42,5 +43,6 @@ cc_test(test_decomposer_registry
 add_subdirectory(paddle)
 add_subdirectory(decomposer)
 add_subdirectory(op_mappers)
+add_subdirectory(pass)
 
 cc_test(test_op_mapper_registry SRCS op_mapper_registry_test.cc DEPS cinncore)

--- a/cinn/frontend/base_builder.cc
+++ b/cinn/frontend/base_builder.cc
@@ -57,6 +57,16 @@ Placeholder BaseBuilder::CreateInput(const Type& type, const std::vector<int>& s
   return Placeholder(var);
 }
 
+void BaseBuilder::SetInputs(const std::vector<Variable>& inputs) {
+  CHECK(inputs_.empty()) << "The original inputs is not empty, which doesn't support to be set.";
+  CHECK(!inputs.empty()) << "At least one input is needed for building a program!";
+  for (int i = 0; i < inputs.size(); i++) {
+    CHECK(!inputs[i]->shape.empty()) << "Found " << i << "-th input's shape is not set yet";
+    CHECK(!inputs[i]->type.is_unk()) << "Found " << i << "-th input's type is not set yet";
+    inputs_.push_back(inputs[i]);
+  }
+}
+
 void BaseBuilder::InferShape(Instruction instr) const {
   using shape_func_t        = std::function<std::vector<shape_t>(const std::vector<shape_t>&, const AttrMapType&)>;
   using type_func_t         = std::function<std::vector<Type>(const std::vector<Type>&, const AttrMapType&)>;

--- a/cinn/frontend/base_builder.cc
+++ b/cinn/frontend/base_builder.cc
@@ -92,5 +92,15 @@ void BaseBuilder::InferShape(Instruction instr) const {
   }
 }
 
+Instruction& BaseBuilder::GetInstruction(size_t i) {
+  CHECK_LT(i, instrs_.size());
+  return instrs_[i];
+}
+
+const Instruction& BaseBuilder::GetInstruction(size_t i) const {
+  CHECK_LT(i, instrs_.size());
+  return instrs_[i];
+}
+
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/frontend/base_builder.cc
+++ b/cinn/frontend/base_builder.cc
@@ -57,14 +57,11 @@ Placeholder BaseBuilder::CreateInput(const Type& type, const std::vector<int>& s
   return Placeholder(var);
 }
 
-void BaseBuilder::SetInputs(const std::vector<Variable>& inputs) {
-  CHECK(inputs_.empty()) << "The original inputs is not empty, which doesn't support to be set.";
-  CHECK(!inputs.empty()) << "At least one input is needed for building a program!";
-  for (int i = 0; i < inputs.size(); i++) {
-    CHECK(!inputs[i]->shape.empty()) << "Found " << i << "-th input's shape is not set yet";
-    CHECK(!inputs[i]->type.is_unk()) << "Found " << i << "-th input's type is not set yet";
-    inputs_.push_back(inputs[i]);
-  }
+Placeholder BaseBuilder::CreateInput(const Variable& var) {
+  CHECK(!var->shape.empty()) << "The input's shape is not set yet";
+  CHECK(!var->type.is_unk()) << "The input's type is not set yet";
+  inputs_.push_back(var);
+  return Placeholder(var);
 }
 
 void BaseBuilder::InferShape(Instruction instr) const {
@@ -90,16 +87,6 @@ void BaseBuilder::InferShape(Instruction instr) const {
     outs[i]->shape = out_shapes[i];
     outs[i]->type  = out_types[i];
   }
-}
-
-Instruction& BaseBuilder::GetInstruction(size_t i) {
-  CHECK_LT(i, instrs_.size());
-  return instrs_[i];
-}
-
-const Instruction& BaseBuilder::GetInstruction(size_t i) const {
-  CHECK_LT(i, instrs_.size());
-  return instrs_[i];
 }
 
 }  // namespace frontend

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -31,15 +31,16 @@ class BaseBuilder {
   Program Build();
 
   Placeholder CreateInput(const common::Type& type, const std::vector<int>& shape, const std::string& id_hint = "");
+  void SetInputs(const std::vector<Variable>& inputs);
 
   // name of this builder
   const std::string& name() { return name_; }
 
   virtual ~BaseBuilder() {}
 
- protected:
   void AppendInstruction(const Instruction& instr) { instrs_.push_back(instr); }
 
+ protected:
   void InferShape(Instruction instr) const;
 
   std::string name_;

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -31,7 +31,7 @@ class BaseBuilder {
   Program Build();
 
   Placeholder CreateInput(const common::Type& type, const std::vector<int>& shape, const std::string& id_hint = "");
-  void SetInputs(const std::vector<Variable>& inputs);
+  Placeholder CreateInput(const Variable& input);
 
   // name of this builder
   const std::string& name() { return name_; }
@@ -39,18 +39,6 @@ class BaseBuilder {
   virtual ~BaseBuilder() {}
 
   void AppendInstruction(const Instruction& instr) { instrs_.push_back(instr); }
-
-  /**
-   * Get \p i-th instruction.
-   */
-  Instruction& GetInstruction(size_t i);
-
-  const Instruction& GetInstruction(size_t i) const;
-
-  /**
-   * Get number of instructions in the program.
-   */
-  inline size_t NumInstructions() const { return instrs_.size(); }
 
  protected:
   void InferShape(Instruction instr) const;

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -40,6 +40,18 @@ class BaseBuilder {
 
   void AppendInstruction(const Instruction& instr) { instrs_.push_back(instr); }
 
+  /**
+   * Get \p i-th instruction.
+   */
+  Instruction& GetInstruction(size_t i);
+
+  const Instruction& GetInstruction(size_t i) const;
+
+  /**
+   * Get number of instructions in the program.
+   */
+  inline size_t NumInstructions() const { return instrs_.size(); }
+
  protected:
   void InferShape(Instruction instr) const;
 

--- a/cinn/frontend/decomposer/activation.cc
+++ b/cinn/frontend/decomposer/activation.cc
@@ -13,19 +13,34 @@
 // limitations under the License.
 
 #include "cinn/frontend/decomposer_registry.h"
+#include "cinn/frontend/syntax.h"
 
 namespace cinn {
 namespace frontend {
 namespace decomposer {
 
-void relu(const Instruction& instr, const DecomposerContext& context) { LOG(FATAL) << "not implemented"; }
+void relu(const Instruction& instr, const DecomposerContext& context) {
+  CHECK_EQ(instr->inputs.size(), 1UL) << " 1 input tensor for " << instr->op_type;
+  CHECK_EQ(instr->outputs.size(), 1UL) << "1 output tensor for " << instr->op_type;
+  auto x       = instr->inputs[0];
+  auto output  = instr->outputs[0];
+  auto builder = context.builder_;
+
+  auto zero_var   = builder->ConstScalar<float>(0.f, common::UniqName("zero"));
+  auto bcast_zero = builder->BroadcastTo(zero_var, x->shape, {0});
+  auto out        = builder->Max(x, bcast_zero);
+
+  // out needs to be mapped to origin out_id
+  out.set_id(output->id);
+}
 
 }  // namespace decomposer
 }  // namespace frontend
 }  // namespace cinn
 
 CINN_REGISTER_HELPER(activation) {
-  CINN_DECOMPOSER_REGISTER(relu, ::cinn::common::DefaultHostTarget()).set_body(cinn::frontend::decomposer::relu);
+  CINN_DECOMPOSER_REGISTER(relu, ::cinn::common::DefaultHostTarget()).SetBody(cinn::frontend::decomposer::relu);
+  CINN_DECOMPOSER_REGISTER(relu, ::cinn::common::DefaultNVGPUTarget()).SetBody(cinn::frontend::decomposer::relu);
 
   return true;
 }

--- a/cinn/frontend/decomposer/activation.cc
+++ b/cinn/frontend/decomposer/activation.cc
@@ -30,8 +30,9 @@ void relu(const Instruction& instr, const DecomposerContext& context) {
   auto bcast_zero = builder->BroadcastTo(zero_var, x->shape, {0});
   auto out        = builder->Max(x, bcast_zero);
 
-  // out needs to be mapped to origin out_id
-  out.set_id(output->id);
+  // set the original output to the output of decomposed operator.
+  auto max_instr        = builder->GetInstruction(builder->NumInstructions() - 1);
+  max_instr->outputs[0] = output;
 }
 
 }  // namespace decomposer

--- a/cinn/frontend/decomposer_registry.h
+++ b/cinn/frontend/decomposer_registry.h
@@ -51,10 +51,6 @@ class InstrDecomposerRegistry : public Registry<Decomposer> {
     return Registry<Decomposer>::Find(name + "_" + target.arch_str());
   }
 
-  inline Decomposer& __REGISTER__(const std::string& name, const common::Target& target) {
-    return Registry<Decomposer>::__REGISTER__(name + "_" + target.arch_str());
-  }
-
  private:
   InstrDecomposerRegistry() = default;
   CINN_DISALLOW_COPY_AND_ASSIGN(InstrDecomposerRegistry);
@@ -77,9 +73,10 @@ class Decomposer {
   DecomposerKernel kernel_;
 };
 
-#define CINN_DECOMPOSER_REGISTER(name, target)                                                \
-  static ::cinn::frontend::Decomposer& CINN_STR_CONCAT(__make_Decomposer_name, __COUNTER__) = \
-      ::cinn::frontend::InstrDecomposerRegistry::Global()->__REGISTER__(#name, target)
+#define CINN_DECOMPOSER_REGISTER(name, target)                                                            \
+  static ::cinn::frontend::Decomposer& CINN_STR_CONCAT(__make_Decomposer_name, __COUNTER__) =             \
+      ::cinn::frontend::InstrDecomposerRegistry::Global()->__REGISTER_OR_GET__(std::string(#name) + "_" + \
+                                                                               target.arch_str())
 
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/frontend/decomposer_registry.h
+++ b/cinn/frontend/decomposer_registry.h
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "cinn/common/target.h"
+#include "cinn/frontend/cinn_builder.h"
 #include "cinn/frontend/syntax.h"
 
 namespace cinn {
@@ -28,9 +29,9 @@ class Decomposer;
 
 class DecomposerContext {
  public:
-  explicit DecomposerContext(Program* prog) : program(prog) {}
+  explicit DecomposerContext(CinnBuilder* builder) : builder_(builder) {}
 
-  Program* program{nullptr};
+  CinnBuilder* builder_{nullptr};
 };
 
 class InstrDecomposerRegistry : public Registry<Decomposer> {
@@ -63,12 +64,12 @@ class Decomposer {
  public:
   using DecomposerKernel = std::function<void(const Instruction& instr, const DecomposerContext&)>;
 
-  Decomposer& set_body(const DecomposerKernel& kernel) {
+  Decomposer& SetBody(const DecomposerKernel& kernel) {
     kernel_ = kernel;
     return *this;
   }
 
-  void Run(const Instruction& instr, const DecomposerContext& context) { kernel_(instr, context); }
+  void Run(const Instruction& instr, const DecomposerContext& context) const { kernel_(instr, context); }
 
   std::string name;
 

--- a/cinn/frontend/pass/CMakeLists.txt
+++ b/cinn/frontend/pass/CMakeLists.txt
@@ -1,0 +1,8 @@
+core_gather_headers()
+
+gather_srcs(cinnapi_src SRCS
+    decomposer.cc
+    )
+
+
+cc_test(test_decomposer_pass SRCS decomposer_test.cc DEPS cinncore)

--- a/cinn/frontend/pass/decomposer.cc
+++ b/cinn/frontend/pass/decomposer.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/decomposer_registry.h"
+#include "cinn/frontend/program_pass.h"
+
+namespace cinn {
+namespace frontend {
+namespace pass {
+
+class DecomposerPass : public ProgramPass {
+ public:
+  void ApplyImpl(Program* prog, const common::Target& target) const {
+    // step 1: set the inputs of the origin program to the new program
+    CinnBuilder builder("decomposer_builder");
+    builder.SetInputs(prog->GetInputs());
+
+    // step 2: use primitive instructions to build the new program
+    DecomposerContext context(&builder);
+    for (int i = 0; i < prog->size(); i++) {
+      auto instr      = (*prog)[i];
+      auto decomposer = InstrDecomposerRegistry::Global()->Find(instr->op_type, target);
+      if (decomposer) {
+        decomposer->Run(instr, context);
+      } else {
+        builder.AppendInstruction(instr);
+      }
+    }
+    *prog = builder.Build();
+  }
+};
+
+}  // namespace pass
+}  // namespace frontend
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(Decomposer) {
+  CINN_REGISTER_PROGRAM_PASS(Decomposer, ::cinn::frontend::pass::DecomposerPass);
+
+  return true;
+}

--- a/cinn/frontend/pass/decomposer.cc
+++ b/cinn/frontend/pass/decomposer.cc
@@ -21,6 +21,8 @@ namespace pass {
 
 class DecomposerPass : public ProgramPass {
  public:
+  using ProgramPass::ProgramPass;
+
   void ApplyImpl(Program* prog, const common::Target& target) const {
     // step 1: set the inputs of the origin program to the new program
     CinnBuilder builder("decomposer_builder");

--- a/cinn/frontend/pass/decomposer_test.cc
+++ b/cinn/frontend/pass/decomposer_test.cc
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "cinn/frontend/decomposer/use_decomposer.h"
+#include "cinn/frontend/decomposer_registry.h"
+#include "cinn/frontend/net_builder.h"
+#include "cinn/frontend/pass/use_program_pass.h"
+#include "cinn/frontend/program_pass.h"
+#include "cinn/hlir/framework/graph.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+#include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/framework/tensor.h"
+#include "cinn/hlir/op/use_ops.h"
+#include "cinn/hlir/pass/use_pass.h"
+
+namespace cinn::frontend {
+
+Program CreateAddProgram() {
+  constexpr int M = 32;
+  constexpr int N = 24;
+
+  NetBuilder builder("net_builder");
+  auto a       = builder.CreateInput(Float(32), {M, N});
+  auto b       = builder.CreateInput(Float(32), {M, N});
+  auto c       = builder.relu(a);
+  auto d       = builder.add(b, c);
+  auto program = builder.Build();
+
+  return program;
+}
+
+void SetRandData(hlir::framework::Tensor tensor, Target target) {
+  auto* data = tensor->mutable_data<float>(target);
+  std::random_device seed;
+  std::default_random_engine engine(seed());
+  std::uniform_real_distribution<float> dist(0.f, 1.f);
+  size_t num_ele = tensor->shape().numel();
+  std::vector<float> random_data(num_ele);
+  for (size_t i = 0; i < num_ele; i++) {
+    random_data[i] = dist(engine);  // All random data
+  }
+
+#ifdef CINN_WITH_CUDA
+  cudaMemcpy(data, random_data.data(), num_ele * sizeof(float), cudaMemcpyHostToDevice);
+#else
+  std::copy(random_data.begin(), random_data.end(), data);
+#endif
+}
+
+TEST(DecomposePassRegistry, basic) {
+  ASSERT_NE(cinn::frontend::ProgramPassRegistry::Global()->Find("Decomposer"), nullptr);
+  ASSERT_EQ(cinn::frontend::ProgramPassRegistry::Global()->Find("Test"), nullptr);
+}
+
+TEST(DecomposePass, basic) {
+  auto prog = CreateAddProgram();
+  for (int i = 0; i < prog.size(); i++) {
+    LOG(INFO) << "instruction: " << prog[i];
+  }
+
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
+  Target target = common::DefaultHostTarget();
+#endif
+
+  ProgramPass::Apply(&prog, target, {"Decomposer"});
+  for (int i = 0; i < prog.size(); i++) {
+    LOG(INFO) << "new instruction: " << prog[i];
+  }
+
+  auto graph = std::make_shared<hlir::framework::Graph>(prog, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusion");
+  auto scope = BuildScope(target, graph);
+  hlir::framework::GraphCompiler gc(target, scope, graph);
+  auto runtime_program = gc.Build();
+
+  scope->Var<hlir::framework::Tensor>("A");
+  scope->Var<hlir::framework::Tensor>("B");
+
+  auto A = scope->GetTensor("A");
+  auto B = scope->GetTensor("B");
+  SetRandData(A, target);
+  SetRandData(B, target);
+
+  runtime_program->Execute();
+}
+
+}  // namespace cinn::frontend

--- a/cinn/frontend/pass/use_program_pass.h
+++ b/cinn/frontend/pass/use_program_pass.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/common/macros.h"
+
+CINN_USE_REGISTER(Decomposer)

--- a/cinn/frontend/program_pass.cc
+++ b/cinn/frontend/program_pass.cc
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/program_pass.h"
+
+namespace cinn {
+namespace frontend {
+
+void ProgramPass::Apply(Program* prog, const common::Target& target, const std::vector<std::string>& passes) {
+  std::vector<const ProgramPass*> fpass;
+  for (auto& name : passes) {
+    auto pass = ProgramPassRegistry::Global()->Get(name);
+    fpass.push_back(pass);
+  }
+  for (auto& pass : fpass) {
+    pass->ApplyImpl(prog, target);
+  }
+}
+
+}  // namespace frontend
+}  // namespace cinn

--- a/cinn/frontend/program_pass.h
+++ b/cinn/frontend/program_pass.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cinn/frontend/syntax.h"
+#include "cinn/utils/registry.h"
+
+namespace cinn {
+namespace frontend {
+
+class ProgramPass {
+ public:
+  /**
+   * \brief Apply a sequence of passes on a program.
+   * @param prog The input program to apply passes on.
+   * @param passes The sequence of pass.
+   * @return The program after being modified by the passes.
+   */
+  static void Apply(Program* prog, const common::Target& target, const std::vector<std::string>& passes);
+  virtual void ApplyImpl(Program* prog, const common::Target& target) const {}
+
+  std::string name;
+};
+
+class ProgramPassRegistry : public Registry<ProgramPass> {
+ public:
+  static ProgramPassRegistry* Global() {
+    static ProgramPassRegistry x;
+    return &x;
+  }
+
+  inline const ProgramPass* Get(const std::string& name) {
+    const ProgramPass* pass = Registry<ProgramPass>::Find(name);
+    CHECK(pass) << "Pass [" << name << "] is not registered";
+    return pass;
+  }
+
+  inline ProgramPass* __REGISTER__(const std::string& name, ProgramPass* pass) {
+    RAW_LOG(INFO, "Register %s program pass", name.c_str());
+    std::lock_guard<std::mutex> guard(registering_mutex);
+    if (fmap_.count(name)) {
+      return fmap_[name];
+    }
+
+    pass->name  = name;
+    fmap_[name] = pass;
+    const_list_.push_back(pass);
+    entry_list_.push_back(pass);
+    return pass;
+  }
+
+ private:
+  ProgramPassRegistry() = default;
+  CINN_DISALLOW_COPY_AND_ASSIGN(ProgramPassRegistry);
+};
+
+/**
+ * @def CINN_REGISTER_PROGRAM_PASS
+ * \brief Register a new program pass
+ *
+ * @param PassType The type of pass
+ * @param PassClass The pass inherited from ProgramPass
+ *
+ * \code
+ *  CINN_REGISTER_PROGRAM_PASS(decompose, DecomposerPass());
+ * \endcode
+ */
+#define CINN_REGISTER_PROGRAM_PASS(PassType, PassClass)         \
+  static ::cinn::frontend::ProgramPass* __make_##PassType##__ = \
+      ::cinn::frontend::ProgramPassRegistry::Global()->__REGISTER__(#PassType, new PassClass)
+
+}  // namespace frontend
+}  // namespace cinn

--- a/cinn/frontend/syntax.h
+++ b/cinn/frontend/syntax.h
@@ -184,6 +184,7 @@ struct Program {
       : instrs_(std::move(instrs)), inputs_(std::move(inputs)) {}
 
   void SetInputs(const std::vector<Variable>& xs);
+  const std::vector<Variable>& GetInputs() const { return inputs_; }
 
   /**
    * create scalar with the specific value and type

--- a/cinn/utils/registry.h
+++ b/cinn/utils/registry.h
@@ -111,7 +111,7 @@ class Registry {
     }
   }
 
- private:
+ protected:
   /** \brief list of entry types */
   std::vector<EntryType *> entry_list_;
   /** \brief list of entry types */


### PR DESCRIPTION
添加ProggramPass基类并实现粗粒度算子拆解的pass

**实现说明**
ProgramPass：
- 基类，Program层级的Pass都继承自该类
- ProgramPass::Apply接受一组pass_name，其调用子类的ApplyImpl实现program的优化

ProgramPassRegistry：
- 注册机制复用CINN的registry
- 由于registry中的__REGISTER__ 中new的是基类的对象，注册的是指向基类对象的指针，而这里需要注册的是指向派生类对象的基类指针。因此ProgramPassRegistry重写了__REGISTER__函数
- registry的修改说明：private成员变量修改为protected，因为ProgramPassRegistry重写了__REGISTER__，需要修改基类的相关成员变量


**注册案例**
- 在cinn/frontend/pass/decomposer.cc文件中实现以及注册DecomposerPass
```
CINN_REGISTER_HELPER(Decomposer) {
  CINN_REGISTER_PROGRAM_PASS(Decomposer, ::cinn::frontend::pass::DecomposerPass());

  return true;
}
```
- 在cinn/frontend/pass/use_program_pass.h中，需要添加：CINN_USE_REGISTER(Decomposer)


**DecomposerPass实现**
保证拆解后的program，输入和输出的name都不变，https://github.com/PaddlePaddle/CINN/pull/449。

- 输入：原始的program，target
- 使用原始program的输入设置新的program的输入
- 遍历所有原始的指令：
  - 如果找到其拆解函数，在拆解函数中使用CINNBuidler往新的program中添加指令，在拆解函数中将最终的输出变量映射到原始的输出变量，即将映射关系存入context的var_map中。
  ```
  void relu(const Instruction& instr, const DecomposerContext& context) {
    CHECK_EQ(instr->inputs.size(), 1UL) << " 1 input tensor for " << instr->op_type;
    CHECK_EQ(instr->outputs.size(), 1UL) << "1 output tensor for " << instr->op_type;
    auto x       = instr->inputs[0];
    auto output  = instr->outputs[0];
    auto builder = context.builder_;

    auto zero_var   = builder->ConstScalar<float>(0.f, common::UniqName("zero"));
    auto bcast_zero = builder->BroadcastTo(zero_var, x->shape, {0});
    auto out        = builder->Max(x, bcast_zero);
  
    // map the the output of decomposed operator to the original.
    context.MapVarToOrigin(out, output);
  }
  ```
  - 否则将原始的指令添加到新的program中
  - 最后遍历新的program的每一条指令的输出，如果在var_map中，就替换为原始的var。
- decomposer_test.cc的测试输出，"instruction"表示的是旧的program中的指令，“new instruction”表示新的program的指令。pass前后，并未改变program的输入和输出
```
70: I1009 06:44:25.186440 22629 decomposer_test.cc:59] instruction: var_1 = relu(placeholder)
70: I1009 06:44:25.186524 22629 decomposer_test.cc:59] instruction: var_2 = elementwise_add(placeholder_0, var_1)
70: I1009 06:44:25.186666 22629 decomposer_test.cc:70] new instruction: zero = const_scalar(value=0)
70: I1009 06:44:25.186733 22629 decomposer_test.cc:70] new instruction: var_4 = broadcast_to(zero, broadcast_axes=[0], out_shape=[32,24])
70: I1009 06:44:25.186777 22629 decomposer_test.cc:70] new instruction: var_1 = max(placeholder, var_4)
70: I1009 06:44:25.186795 22629 decomposer_test.cc:70] new instruction: var_2 = elementwise_add(placeholder_0, var_1)
```


