### PR TITLE
fix meta ops

### DIFF
--- a/cinn/frontend/cinn_builder_test.cc
+++ b/cinn/frontend/cinn_builder_test.cc
@@ -53,6 +53,10 @@ Program CreateTestProgram() {
   auto i = builder.Max(e, h);
   auto j = builder.Min(e, h);
   auto k = builder.Mul(i, j);
+  auto l = builder.ConstScalar<bool>(1, "condition");
+  auto m = builder.BroadcastTo(l, {B, M, N}, {0});
+  auto n = builder.Select(m, j, k);
+  auto o = builder.Reduce(n, ReduceKind::kSum, {0, 1, 2});
 
   auto program = builder.Build();
   return program;

--- a/cinn/frontend/syntax.cc
+++ b/cinn/frontend/syntax.cc
@@ -131,7 +131,7 @@ Variable Program::primitive_const_scalar(PrimType value, const std::string& name
   auto out = instr.GetOutput(0);
   out.set_id(name);
   auto out_type = type_of<PrimType>();
-  CHECK(out_type.is_float() || out_type.is_int()) << "no supported type: " << out_type;
+  CHECK(out_type.is_float() || out_type.is_int() || out_type.is_bool()) << "no supported type: " << out_type;
   out->type = out_type;
   return out;
 }

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -101,9 +101,14 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const Node* node) {
     std::string input_id = i->source()->as<NodeData>()->id();
     auto in_shape        = shape_dict.at(input_id);
     Type dtype           = dtype_dict.at(input_id);
-    CHECK_EQ(dtype, Float(32)) << "The dtype of node " << input_id
-                               << " is not float! Other dtype is not implemented yet.";
-    lang::Placeholder<float> temp(input_id, in_shape);
+    CHECK(dtype == Float(32) || dtype.is_bool())
+        << "The dtype of node " << input_id << " is not float or bool! Other dtype is not implemented yet.";
+    ir::Tensor temp;
+    if (dtype == Float(32)) {
+      temp = lang::Placeholder<float>(input_id, in_shape);
+    } else if (dtype.is_bool()) {
+      temp = lang::Placeholder<bool>(input_id, in_shape);
+    }
     inputs.push_back(temp);
     cinn_inputs.push_back(common::CINNValue(temp));
   }
@@ -189,9 +194,14 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const std::vector<Node*>& 
         std::string input_id = source_data->id();
         auto in_shape        = shape_dict.at(input_id);
         Type dtype           = dtype_dict.at(input_id);
-        CHECK_EQ(dtype, Float(32)) << "The dtype of node " << input_id
-                                   << " is not float! Other dtype is not implemented yet.";
-        lang::Placeholder<float> temp_in(input_id, in_shape);
+        CHECK(dtype == Float(32) || dtype.is_bool())
+            << "The dtype of node " << input_id << " is not float or bool! Other dtype is not implemented yet.";
+        ir::Tensor temp_in;
+        if (dtype == Float(32)) {
+          temp_in = lang::Placeholder<float>(input_id, in_shape);
+        } else if (dtype.is_bool()) {
+          temp_in = lang::Placeholder<bool>(input_id, in_shape);
+        }
         inputs.push_back(temp_in);
         temp_inputs.push_back(temp_in);
         cinn_inputs.push_back(common::CINNValue(temp_in));
@@ -664,8 +674,8 @@ std::shared_ptr<Scope> BuildScope(Target target, const std::shared_ptr<Graph>& g
     }
     VLOG(3) << "Tensor [" << iter.first << "] resize to " << utils::Join(shape, ",");
     tensor->Resize(Shape{shape});
-    CHECK_EQ(dtype_dict.at(iter.first), Float(32))
-        << "The dtype of node " << iter.first << " is not float! Other dtype is not implemented yet.";
+    CHECK(dtype_dict.at(iter.first) == Float(32) || dtype_dict.at(iter.first).is_bool())
+        << "The dtype of node " << iter.first << " is not float or bool! Other dtype is not implemented yet.";
   }
   return scope;
 }

--- a/cinn/hlir/op/broadcast.cc
+++ b/cinn/hlir/op/broadcast.cc
@@ -120,6 +120,11 @@ std::vector<Type> InferDtypeForBroadcast(const std::vector<Type> &inputs_type, c
   return res;
 }
 
+std::vector<Type> InferDtypeForBroadcastCmp(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
+  CHECK(!inputs_type.empty()) << "The input's type size is 0! Please check again.";
+  return {Bool()};
+}
+
 std::vector<std::vector<std::string>> InferLayoutForBroadcast(const std::vector<std::vector<int>> &input_shapes,
                                                               const std::vector<std::string> &input_layouts,
                                                               const framework::NodeAttr &attrs,
@@ -280,6 +285,18 @@ CINN_REGISTER_HELPER(broadcast_ops) {
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kBroadcast) \
       .set_support_level(4);
 
+#define CINN_REGISTER_BINARY_CMP(op__, op_stragegy__)                                                                \
+  CINN_REGISTER_OP(op__)                                                                                             \
+      .describe(#op__ " function")                                                                                   \
+      .set_num_inputs(1)                                                                                             \
+      .set_num_outputs(1)                                                                                            \
+      .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyFor##op_stragegy__) \
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForBroadcast))                                \
+      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForBroadcastCmp))                             \
+      .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForBroadcast))                              \
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kBroadcast) \
+      .set_support_level(4);
+
   CINN_REGISTER_BINARY(elementwise_add, Add);
   CINN_REGISTER_BINARY(elementwise_mul, Multiply);
 
@@ -291,15 +308,16 @@ CINN_REGISTER_HELPER(broadcast_ops) {
   CINN_REGISTER_BINARY(max, Maximum);
   CINN_REGISTER_BINARY(min, Minimum);
   CINN_REGISTER_BINARY(power, Power);
-  CINN_REGISTER_BINARY(logical_and, LogicalAnd);
-  CINN_REGISTER_BINARY(logical_or, LogicalOr);
-  CINN_REGISTER_BINARY(logical_xor, LogicalXOr);
-  CINN_REGISTER_BINARY(greater, Greater);
-  CINN_REGISTER_BINARY(less, Less);
-  CINN_REGISTER_BINARY(equal, Equal);
-  CINN_REGISTER_BINARY(not_equal, NotEqual);
-  CINN_REGISTER_BINARY(greater_equal, GreaterEqual);
-  CINN_REGISTER_BINARY(less_equal, LessEqual);
+
+  CINN_REGISTER_BINARY_CMP(logical_and, LogicalAnd);
+  CINN_REGISTER_BINARY_CMP(logical_or, LogicalOr);
+  CINN_REGISTER_BINARY_CMP(logical_xor, LogicalXOr);
+  CINN_REGISTER_BINARY_CMP(greater, Greater);
+  CINN_REGISTER_BINARY_CMP(less, Less);
+  CINN_REGISTER_BINARY_CMP(equal, Equal);
+  CINN_REGISTER_BINARY_CMP(not_equal, NotEqual);
+  CINN_REGISTER_BINARY_CMP(greater_equal, GreaterEqual);
+  CINN_REGISTER_BINARY_CMP(less_equal, LessEqual);
 
   CINN_REGISTER_BINARY(bitwise_or, BitwiseOr);
   CINN_REGISTER_BINARY(bitwise_xor, BitwiseXor);

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -1860,7 +1860,7 @@ std::shared_ptr<OpStrategy> StrategyForSelect(const framework::NodeAttr &attrs,
     if (target.arch == Target::Arch::NVGPU) {
       pe::CudaScheduleInjective(stages[out.as_tensor_ref()], output_shapes[0], target);
     } else if (target.arch == Target::Arch::X86) {
-      pe::ScheduleInjectiveCPU(stages[out.as_tensor_ref()], output_shapes[0], target);
+      pe::ScheduleInjectiveCPU(stages[out.as_tensor_ref()], output_shapes[0], target, false);
     }
     *ret = arg_pack;
   });

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -1844,8 +1844,9 @@ std::shared_ptr<OpStrategy> StrategyForSelect(const framework::NodeAttr &attrs,
     CHECK(false_value.as_tensor());
     auto out = pe::Select(
         condition.as_tensor_ref(), true_value.as_tensor_ref(), false_value.as_tensor_ref(), UniqName("Select_output"));
-    auto stages = CreateStages({out});
-    *ret        = CINNValuePack{{CINNValue(out), CINNValue(stages)}};
+    auto stages =
+        CreateStages({condition.as_tensor_ref(), true_value.as_tensor_ref(), false_value.as_tensor_ref(), out});
+    *ret = CINNValuePack{{CINNValue(out), CINNValue(stages)}};
   });
 
   framework::CINNSchedule select_schedule([=](lang::Args args, lang::RetValue *ret) {

--- a/cinn/hlir/op/op_nn_test.cc
+++ b/cinn/hlir/op/op_nn_test.cc
@@ -374,27 +374,18 @@ TEST(Operator, Operator_Select_Test0) {
   cinn_pod_value_t args[] = {a_arg, b_arg, c_arg, d_arg};
   fn_(args, 4);
 
-  /*
-  auto condition_   = reinterpret_cast<int16_t *>(A_buf->memory);
+  auto condition_   = reinterpret_cast<int8_t *>(A_buf->memory);
   auto true_value_  = reinterpret_cast<float *>(B_buf->memory);
   auto false_value_ = reinterpret_cast<float *>(C_buf->memory);
   auto output_      = reinterpret_cast<float *>(D_buf->memory);
-  for (int idx = 0; idx < 64 * 64; ++idx) {
-    auto value = static_cast<int16_t>(*condition_);
-    for (int idy = 0; idy < 16; ++idy) {
-      if ((value & 0x01)) {
-        ASSERT_EQ(*output_, *true_value_);
-      } else {
-        ASSERT_EQ(*output_, *false_value_);
-      }
-      ++true_value_;
-      ++false_value_;
-      ++output_;
-      value = value >> 1;
+
+  for (int i = 0; i < A_buf->num_elements(); i++) {
+    if (static_cast<bool>(condition_[i])) {
+      ASSERT_EQ(output_[i], true_value_[i]);
+    } else {
+      ASSERT_EQ(output_[i], false_value_[i]);
     }
-    ++condition_;
   }
-  */
 
   ASSERT_EQ(impl->name, "strategy.select.x86");
   ASSERT_EQ(select->description, "This operator implements the meta op 'Select'.");

--- a/cinn/hlir/op/reduction.cc
+++ b/cinn/hlir/op/reduction.cc
@@ -87,6 +87,10 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
         stages[out]->Split(1, 2);
         stages[out]->Bind(0, "blockIdx.x");
         stages[out]->Bind(1, "threadIdx.x");
+      } else {
+        stages[out]->Split(0, 2);
+        stages[out]->Bind(0, "blockIdx.x");
+        stages[out]->Bind(1, "threadIdx.x");
       }
     }
     *ret = arg_pack;
@@ -109,8 +113,29 @@ std::vector<shape_t> InferShapeForReduction(const std::vector<shape_t> &inputs_s
   if (attrs.find("keep_dim") != attrs.end()) {
     keep_dim = absl::get<bool>(attrs.at("keep_dim"));
   }
-  std::vector<shape_t> res{inputs_shape[0]};
-  return res;
+  CHECK(!dim.empty()) << "should have reduce dim, please check!";
+  CHECK_LE(dim.size(), inputs_shape[0].size()) << "reduce dim should no more than the input size";
+  std::vector<int> out_shapes;
+  auto ndim = inputs_shape[0].size();
+  if (keep_dim) {
+    for (size_t i = 0; i < ndim; ++i) {
+      if (std::find(dim.begin(), dim.end(), i) != dim.end()) {
+        out_shapes.push_back(1);
+      } else {
+        out_shapes.push_back(inputs_shape[0][i]);
+      }
+    }
+  } else {
+    for (size_t i = 0; i < ndim; ++i) {
+      if (std::find(dim.begin(), dim.end(), i) == dim.end()) {
+        out_shapes.push_back(inputs_shape[0][i]);
+      }
+    }
+  }
+  if (out_shapes.empty()) {
+    out_shapes.push_back(1);
+  }
+  return {out_shapes};
 }
 
 std::vector<Type> InferDtypeForReduction(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
@@ -124,7 +149,14 @@ std::vector<std::vector<std::string>> InferLayoutForReduction(const std::vector<
                                                               const framework::NodeAttr &attrs,
                                                               const Target &target) {
   CHECK_EQ(input_layouts.size(), 1U) << "The input's layouts size is not 1! Please check again.";
-  return {input_layouts, input_layouts};
+  std::vector<std::string> new_input_layouts = input_layouts;
+  if (input_shapes[0].size() > 4) {
+    // alter input layout back
+    new_input_layouts[0] = "NCHW";
+    VLOG(3) << "alter input layout from " << input_layouts[0] << " to " << new_input_layouts[0];
+  }
+
+  return {{""}, new_input_layouts};
 }
 
 StrategyForReduction(reduce_sum, ReduceSum, PeFunc);

--- a/cinn/hlir/pass/test_primitive_ops.cc
+++ b/cinn/hlir/pass/test_primitive_ops.cc
@@ -106,13 +106,13 @@ TEST(reduction, reduce) {
 
   Program program;
   std::unordered_map<std::string, Program::attr_t> attrs;
-  std::vector<int> axis = {1};
+  std::vector<int> axis = {1, 2};
   bool keep_dim         = false;
 
   auto a = program.reduce_max(A, axis, keep_dim);
   auto b = program.reduce_min(A, axis, keep_dim);
   auto c = program.reduce_prod(A, axis, keep_dim);
-  auto d = program.reduce_sum(A, axis, keep_dim);
+  auto d = program.reduce_sum(A, {0, 1, 2, 3}, keep_dim);
 
   Target target = GetTarget();
   program.SetInputs({A});

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -1026,7 +1026,7 @@ ir::Tensor Select(const ir::Tensor &condition,
                   const ir::Tensor &true_value,
                   const ir::Tensor &false_value,
                   const std::string &output_name) {
-  CHECK(condition->type().is_bool()) << "The condtion tensor type should be bool!";
+  CHECK(condition->type().is_bool()) << "The condition tensor type should be bool!";
   CHECK(condition->shape == true_value->shape && true_value->shape == false_value->shape)
       << "The input tensor shape is not equal!";
   return lang::Compute(condition->shape, [=](const std::vector<Expr> &indice) {

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -166,7 +166,7 @@ Tensor Reduce(const Tensor& tensor,
               ir::Expr initial,
               const std::string& output_name) {
   auto ndim = tensor->shape.size();
-  CHECK_NE(ndim, 0) << "Reduce tensor's dim must be more than 0";
+  CHECK_GT(ndim, 0) << "Reduce tensor's dim must be more than 0";
   std::vector<int> real_axes;
   GetRealAxes(static_cast<int>(ndim), axes, &real_axes);
   std::vector<Expr> output_shapes;

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -62,8 +62,14 @@ int GetBetterSplitFactor(int shape, int split_factor);
 
 int GetArrayPackingFactor(int shape, const Type &type, const common::Target &target);
 
-void ScheduleInjectiveCPU(poly::Stage *stage, const std::vector<int> &output_shape, const common::Target &target);
-void ScheduleInjectiveCPUFuse(poly::Stage *stage, const std::vector<int> &output_shape, const common::Target &target);
+void ScheduleInjectiveCPU(poly::Stage *stage,
+                          const std::vector<int> &output_shape,
+                          const common::Target &target,
+                          bool vectorizable = true);
+void ScheduleInjectiveCPUFuse(poly::Stage *stage,
+                              const std::vector<int> &output_shape,
+                              const common::Target &target,
+                              bool vectorizable = true);
 
 void MatmulScheduleCPU(poly::StageMap stage,
                        const ir::Tensor &output,

--- a/cinn/ir/tensor.cc
+++ b/cinn/ir/tensor.cc
@@ -293,6 +293,7 @@ ir::Tensor _Tensor_::InitReduction(poly::StageMap stages, const Target &target) 
   std::map<int, poly::StageForloopInfo> init_forloop_info;
   for (auto &i : temp_forloop_info) {
     for (int j = 0; j < init_dim_out_names.size(); j++) {
+      if (i.first < 0) continue;
       int new_i = poly::isl_get_original_axes_from_optimized_level(stages[this]->transformed_domain().get(), i.first);
       if (dim_out_names[new_i] == init_dim_out_names[j]) {
         stages[init_tensor]->AddForloopInfo(j, i.second);

--- a/cinn/lang/lower_impl.cc
+++ b/cinn/lang/lower_impl.cc
@@ -167,6 +167,7 @@ Expr LowerGroup(const poly::ScheduleGroup& group,
       auto iters = common::GatherItersToTensorProducer(stage->id(), &e);
       std::map<std::string, poly::StageForloopInfo> for_infos;
       for (auto& item : stage->forloop_infos()) {
+        if (item.first < 0) continue;
         CHECK_LT(item.first, iters.size());
         for_infos[iters[item.first]] = item.second;
       }

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -272,6 +272,7 @@ ir::CudaAxisInfo GatherAxisInfoFromStages(const std::vector<poly::Stage *> &stag
   for (auto *stage : stage_group) {
     if (stage->IfCudaBind()) info.set_valid(true);
     for (auto &item : stage->forloop_infos()) {
+      if (item.first < 0) continue;
       int level = poly::isl_get_original_axes_from_optimized_level(stage->transformed_domain().get(), item.first);
       auto _min_val_max_val_ = poly::isl_set_get_axis_range(stage->transformed_domain().get(), level);
       auto &min_val          = std::get<0>(_min_val_max_val_);

--- a/cinn/poly/stage.cc
+++ b/cinn/poly/stage.cc
@@ -116,7 +116,7 @@ std::tuple<Iterator, Iterator> Stage::SplitOuter(const Iterator &level, int npar
   auto &maxv       = std::get<1>(_minv_maxv_);
   int max_iv       = maxv.get_num_si();
   auto dim_names   = isl_get_dim_names(transform_, isl_dim_out);
-  double temp      = double(max_iv + 1.0) / double(nparts);
+  double temp      = static_cast<double>(max_iv + 1.0) / static_cast<double>(nparts);
   int factor_inner = ceil(temp);
   return Split(level, factor_inner);
 }
@@ -1256,11 +1256,18 @@ void Stage::AddForloopInfo(int level, const StageForloopInfo &info) {
   CHECK_GE(level, 0);
   CHECK_LT(level, num_levels);
   auto transformed_domain = this->transformed_domain();
+  int removed_axes_counts = isl_get_precending_removed_axes_counts(transformed_domain.get(), level);
+
   if (isl_is_removed_axis(transformed_domain.get(), level)) {
+    // For scalar case, forloop info will be lost after for-1 and reduce-axis elimination. We record the forloop info in
+    // the -1th level for backup.
+    if (level == 0 && n_out_dims() == removed_axes_counts + tensor()->reduce_axis.size() + 1) {
+      VLOG(3) << "get scalar tensor, add forloop_infos in the -1 level";
+      forloop_infos_[-1] = info;
+    }
     VLOG(3) << "for-1 has no sense, skip it";
     return;
   }
-  int removed_axes_counts = isl_get_precending_removed_axes_counts(transformed_domain.get(), level);
   VLOG(3) << "removed_axes_counts are " << removed_axes_counts << " before axis " << ith_dim_name(level);
   forloop_infos_[level - removed_axes_counts] = info;
 }

--- a/cinn/poly/stage.cc
+++ b/cinn/poly/stage.cc
@@ -1261,8 +1261,8 @@ void Stage::AddForloopInfo(int level, const StageForloopInfo &info) {
   if (isl_is_removed_axis(transformed_domain.get(), level)) {
     // For scalar case, forloop info will be lost after for-1 and reduce-axis elimination. We record the forloop info in
     // the -1th level for backup.
-    if (level == 0 && n_out_dims() == removed_axes_counts + tensor()->reduce_axis.size() + 1) {
-      VLOG(3) << "get scalar tensor, add forloop_infos in the -1 level";
+    if (level == 0) {
+      VLOG(3) << "add forloop_infos in the -1 level for backup";
       forloop_infos_[-1] = info;
     }
     VLOG(3) << "for-1 has no sense, skip it";


### PR DESCRIPTION
fix meta ops:
(1) gpu forloop info will be lost in the case of scalar out tensor(ops like const_scalar and reduce). we back up the forloop info in the -1 level so that can generate gpu kernels correctly.
(2) support bool type in cinn_builder
(3) fix select op accuracy problem
(4) fix infershape and inferlayout