### PR TITLE
add relu_grad decomposer

### DIFF
--- a/cinn/frontend/decomposer/CMakeLists.txt
+++ b/cinn/frontend/decomposer/CMakeLists.txt
@@ -3,3 +3,5 @@ core_gather_headers()
 gather_srcs(cinnapi_src SRCS
     activation.cc
     )
+
+cc_test(test_activation_decomposer SRCS activation_test.cc DEPS cinncore)

--- a/cinn/frontend/decomposer/activation.cc
+++ b/cinn/frontend/decomposer/activation.cc
@@ -34,12 +34,35 @@ void relu(const Instruction& instr, const DecomposerContext& context) {
   context.MapVarToOrigin(out, output);
 }
 
+void relu_grad(const Instruction& instr, const DecomposerContext& context) {
+  CHECK_EQ(instr->inputs.size(), 2UL) << " 2 input tensors for " << instr->op_type;
+  CHECK_EQ(instr->outputs.size(), 1UL) << "1 output tensor for " << instr->op_type;
+  auto dout    = instr->inputs[0];
+  auto out     = instr->inputs[1];
+  auto dx      = instr->outputs[0];
+  auto builder = context.builder_;
+
+  auto zero_var   = builder->ConstScalar<float>(0.f, common::UniqName("zero"));
+  auto bcast_zero = builder->BroadcastTo(zero_var, out->shape, {0});
+  auto condition  = builder->Compare(out, bcast_zero, ComparisonKind::kGt);
+  auto res        = builder->Select(condition, dout, bcast_zero);
+
+  // map the the output of decomposed operator to the original.
+  context.MapVarToOrigin(res, dx);
+}
+
 }  // namespace decomposer
 }  // namespace frontend
 }  // namespace cinn
 
 CINN_REGISTER_HELPER(activation) {
   CINN_DECOMPOSER_REGISTER(relu, cinn::frontend::decomposer::relu);
+
+  return true;
+}
+
+CINN_REGISTER_HELPER(activation_grad) {
+  CINN_DECOMPOSER_REGISTER(relu_grad, cinn::frontend::decomposer::relu_grad);
 
   return true;
 }

--- a/cinn/frontend/decomposer/activation_test.cc
+++ b/cinn/frontend/decomposer/activation_test.cc
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "cinn/frontend/decomposer/use_decomposer.h"
+#include "cinn/frontend/decomposer_registry.h"
+#include "cinn/frontend/net_builder.h"
+#include "cinn/frontend/pass/use_program_pass.h"
+#include "cinn/frontend/program_pass.h"
+#include "cinn/hlir/framework/graph.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+#include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/framework/tensor.h"
+#include "cinn/hlir/op/use_ops.h"
+#include "cinn/hlir/pass/use_pass.h"
+
+namespace cinn::frontend {
+
+void SetRandData(hlir::framework::Tensor tensor, Target target) {
+  auto* data = tensor->mutable_data<float>(target);
+  std::random_device seed;
+  std::default_random_engine engine(seed());
+  std::uniform_real_distribution<float> dist(1.f, 2.f);
+  size_t num_ele = tensor->shape().numel();
+  std::vector<float> random_data(num_ele);
+  for (size_t i = 0; i < num_ele; i++) {
+    random_data[i] = dist(engine);  // All random data
+  }
+
+#ifdef CINN_WITH_CUDA
+  cudaMemcpy(data, random_data.data(), num_ele * sizeof(float), cudaMemcpyHostToDevice);
+#else
+  std::copy(random_data.begin(), random_data.end(), data);
+#endif
+}
+
+Target GetTarget() {
+#ifdef CINN_WITH_CUDA
+  return common::DefaultNVGPUTarget();
+#else
+  return common::DefaultHostTarget();
+#endif
+}
+
+void RunProgram(NetBuilder& builder, const std::vector<std::string>& inputs) {
+  auto prog     = builder.Build();
+  Target target = GetTarget();
+  LOG(INFO) << "===================== Before Decomposition =====================";
+  for (int i = 0; i < prog.size(); i++) {
+    LOG(INFO) << "instruction: " << prog[i];
+  }
+  ProgramPass::Apply(&prog, target, {"Decomposer"});
+  LOG(INFO) << "===================== After Decomposition =====================";
+  for (int i = 0; i < prog.size(); i++) {
+    LOG(INFO) << "instruction: " << prog[i];
+  }
+  auto graph = std::make_shared<hlir::framework::Graph>(prog, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusion");
+  auto scope = BuildScope(target, graph);
+  hlir::framework::GraphCompiler gc(target, scope, graph);
+
+  auto runtime_program = gc.Build();
+  for (auto& in : inputs) {
+    scope->Var<hlir::framework::Tensor>(in);
+    auto tensor = scope->GetTensor(in);
+    SetRandData(tensor, target);
+  }
+  runtime_program->Execute();
+}
+
+TEST(Decomposer, relu) {
+  NetBuilder builder("relu");
+  auto x   = builder.CreateInput(Float(32), {20, 10});
+  auto out = builder.relu(x);
+
+  std::vector<std::string> inputs = {"X"};
+  RunProgram(builder, inputs);
+}
+
+TEST(Decomposer, relu_grad) {
+  NetBuilder builder("relu_grad");
+  auto dout = builder.CreateInput(Float(32), {20, 10});
+  auto out  = builder.CreateInput(Float(32), {20, 10});
+  auto dx   = builder.relu_grad(dout, out);
+
+  std::vector<std::string> inputs = {"Dout", "Out"};
+  RunProgram(builder, inputs);
+}
+
+}  // namespace cinn::frontend

--- a/cinn/frontend/decomposer/use_decomposer.h
+++ b/cinn/frontend/decomposer/use_decomposer.h
@@ -17,3 +17,4 @@
 #include "cinn/common/macros.h"
 
 CINN_USE_REGISTER(activation)
+CINN_USE_REGISTER(activation_grad)

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -72,6 +72,13 @@ Variable NetBuilder::relu(const Variable& a) {
   return instr.GetOutput(0);
 }
 
+Variable NetBuilder::relu_grad(const Variable& dout, const Variable& out) {
+  Instruction instr("relu_grad", {dout, out});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
 Variable NetBuilder::relu6(const Variable& a, float threshold) {
   Instruction instr("relu6", {a});
   instr.SetAttr("threshold", threshold);

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -59,6 +59,12 @@ class NetBuilder : public BaseBuilder {
    */
   Variable relu(const Variable& a);
 
+  /**
+   * The gradient of Rectified Linear Unit.
+   * Actually apply: dx = dout * (out > 0)
+   */
+  Variable relu_grad(const Variable& dout, const Variable& out);
+
   Variable relu6(const Variable& a, float threshold = 6.0f);
 
   /**

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -1919,6 +1919,14 @@ CINN_REGISTER_HELPER(nn_ops) {
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElemWise)
       .set_support_level(4);
 
+  CINN_REGISTER_OP(relu_grad)
+      .describe("Output 0 for each input element < 0. Output itself for each input element >= 0.")
+      .set_num_inputs(2)
+      .set_num_outputs(1)
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForRelu))
+      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForRelu))
+      .set_support_level(4);
+
   CINN_REGISTER_OP(relu6)
       .describe("Output 0 for each input element < 0. Output itself for each input element >= 0 and <=6.")
       .set_num_inputs(1)


### PR DESCRIPTION
实现relu_grad的拆解

test输出：
```
73: I1014 09:05:08.286970 17791 activation_test.cc:62] ===================== Before Decomposition =====================
73: I1014 09:05:08.286993 17791 activation_test.cc:64] instruction: var_8 = relu_grad(placeholder_0, placeholder_1)
73: I1014 09:05:08.287493 17791 activation_test.cc:67] ===================== After Decomposition =====================
73: I1014 09:05:08.287508 17791 activation_test.cc:69] instruction: zero_0 = const_scalar(value=0)
73: I1014 09:05:08.287529 17791 activation_test.cc:69] instruction: var_12 = broadcast_to(zero_0, out_shape=[20,10], broadcast_axes=[0])
73: I1014 09:05:08.287545 17791 activation_test.cc:69] instruction: var_13 = greater(placeholder_1, var_12)
73: I1014 09:05:08.287554 17791 activation_test.cc:69] instruction: var_8 = select(var_13, placeholder_0, var_12)
```