### PR TITLE
force set work directory for codestyle_check & sync glog & gflags version with PaddlePaddle

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,13 @@ function proxy_on {
 
 function prepare_ci {
   cd $workspace
+  if [[ $(command -v python) == $build_dir/ci-env/bin/python ]]; then
+    return
+  elif [[ -e $build_dir/ci-env/bin/activate ]]; then
+    source $build_dir/ci-env/bin/activate
+    return
+  fi
+
   apt update
   echo "the current user EUID=$EUID: $(whoami)"
   if ! command -v doxygen &> /dev/null; then
@@ -62,8 +69,6 @@ function prepare_ci {
     apt install -y python3.8-venv
     python3.8 -m venv $build_dir/ci-env
   fi
-  ## if [[ $? != 0 ]]; then
-  ## fi
   proxy_off
   source $build_dir/ci-env/bin/activate
   pip install -U pip --trusted-host mirrors.aliyun.com --index-url https://mirrors.aliyun.com/pypi/simple/
@@ -73,7 +78,6 @@ function prepare_ci {
   pip install clang-format==9.0
   pip install sphinx==3.3.1 sphinx_gallery==0.8.1 recommonmark==0.6.0 exhale scipy breathe==4.24.0 matplotlib
   pip install paddlepaddle-gpu==2.1.2.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-  export runtime_include_dir=$workspace/cinn/runtime/cuda
 }
 
 function make_doc {
@@ -205,6 +209,7 @@ function run_test {
 function CI {
     mkdir -p $build_dir
     cd $build_dir
+    export runtime_include_dir=$workspace/cinn/runtime/cuda
 
     prepare_ci
     codestyle_check

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ function proxy_on {
 }
 
 function prepare_ci {
+  cd $workspace
   apt update
   echo "the current user EUID=$EUID: $(whoami)"
   if ! command -v doxygen &> /dev/null; then
@@ -155,6 +156,7 @@ function prepare_model {
 
 function codestyle_check {
     proxy_on
+    cd $workspace
     pre-commit run -a
     if ! git diff-index --quiet HEAD --; then
 

--- a/cmake/external/gflags.cmake
+++ b/cmake/external/gflags.cmake
@@ -48,7 +48,7 @@ ExternalProject_Add(
     extern_gflags
     ${EXTERNAL_PROJECT_LOG_ARGS}
     GIT_REPOSITORY  "https://github.com/gflags/gflags.git"
-    GIT_TAG         77592648e3f3be87d6c7123eb81cbad75f9aef5a
+    GIT_TAG         "v2.2.2"
     PREFIX          ${GFLAGS_SOURCES_DIR}
     UPDATE_COMMAND  ""
     CMAKE_ARGS      -DBUILD_STATIC_LIBS=ON

--- a/cmake/external/glog.cmake
+++ b/cmake/external/glog.cmake
@@ -29,7 +29,7 @@ ENDIF(WIN32)
 INCLUDE_DIRECTORIES(${GLOG_INCLUDE_DIR})
 
 SET(GLOG_REPOSITORY "https://github.com/google/glog.git")
-SET(GLOG_TAG "v0.3.5")
+SET(GLOG_TAG "v0.4.0")
 
 SET(OPTIONAL_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                   "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
@@ -61,8 +61,7 @@ ExternalProject_Add(
                     -DCMAKE_INSTALL_PREFIX=${GLOG_INSTALL_DIR}
                     -DCMAKE_INSTALL_LIBDIR=${GLOG_INSTALL_DIR}/lib
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-                    -DWITH_GFLAGS=ON
-                    -Dgflags_DIR=${GFLAGS_INSTALL_DIR}/lib/cmake/gflags
+                    -DWITH_GFLAGS=OFF
                     -DBUILD_TESTING=OFF
                     -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
                     ${EXTERNAL_OPTIONAL_ARGS}


### PR DESCRIPTION
有些 git 版本和 pre-commit 版本的组合，需要在 CINN 目录才能运行 pre-commit run -a。
prepare_ci 中增加了 virtualenv 的检查，如果已经在 venv 中或者 venv 存在，就不走 prepare_ci 的逻辑，加速本地 ci 速度。
把 glog 和 gflags 的版本与 Paddle 同步，glog 编译选项改成 -DWITH_GFLAGS=OFF，能够与Paddle连编。