### PR TITLE
polish decomposer and relu_grad

### DIFF
--- a/cinn/frontend/decomposer/activation.cc
+++ b/cinn/frontend/decomposer/activation.cc
@@ -24,23 +24,23 @@ void relu(const Instruction& instr, const DecomposerContext& context) {
   CHECK_EQ(instr->outputs.size(), 1UL) << "1 output tensor for " << instr->op_type;
   auto x        = instr->inputs[0];
   auto output   = instr->outputs[0];
-  auto* builder = context.builder_;
+  auto* builder = context.builder();
 
   auto zero_var   = builder->ConstScalar<float>(0.f, common::UniqName("zero"));
   auto bcast_zero = builder->BroadcastTo(zero_var, x->shape, {0});
   auto out        = builder->Max(x, bcast_zero);
 
   // map the the output of decomposed operator to the original.
-  context.MapVarToOrigin(out, output);
+  context.MapOutToOrigin(out, output);
 }
 
 void relu_grad(const Instruction& instr, const DecomposerContext& context) {
   CHECK_EQ(instr->inputs.size(), 2UL) << " 2 input tensors for " << instr->op_type;
   CHECK_EQ(instr->outputs.size(), 1UL) << "1 output tensor for " << instr->op_type;
-  auto dout    = instr->inputs[0];
-  auto out     = instr->inputs[1];
-  auto dx      = instr->outputs[0];
-  auto builder = context.builder_;
+  auto dout     = instr->inputs[0];
+  auto out      = instr->inputs[1];
+  auto dx       = instr->outputs[0];
+  auto* builder = context.builder();
 
   auto zero_var   = builder->ConstScalar<float>(0.f, common::UniqName("zero"));
   auto bcast_zero = builder->BroadcastTo(zero_var, out->shape, {0});
@@ -48,7 +48,7 @@ void relu_grad(const Instruction& instr, const DecomposerContext& context) {
   auto res        = builder->Select(condition, dout, bcast_zero);
 
   // map the the output of decomposed operator to the original.
-  context.MapVarToOrigin(res, dx);
+  context.MapOutToOrigin(res, dx);
 }
 
 }  // namespace decomposer

--- a/cinn/frontend/decomposer_registry.h
+++ b/cinn/frontend/decomposer_registry.h
@@ -32,12 +32,13 @@ class DecomposerContext {
   explicit DecomposerContext(CinnBuilder* builder, absl::flat_hash_map<std::string, Variable>* var_map)
       : builder_(builder), var_map_(var_map) {}
 
-  CinnBuilder* builder_{nullptr};
+  CinnBuilder* builder() const { return builder_; };
 
   // Map the new var to the original var.
-  void MapVarToOrigin(const Variable& new_var, const Variable& ori_var) const { (*var_map_)[new_var->id] = ori_var; }
+  void MapOutToOrigin(const Variable& new_var, const Variable& ori_var) const { (*var_map_)[new_var->id] = ori_var; }
 
  private:
+  CinnBuilder* builder_{nullptr};
   absl::flat_hash_map<std::string, Variable>* var_map_{nullptr};
 };
 

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -1901,6 +1901,15 @@ std::vector<std::vector<std::string>> InferLayoutForUnary(const std::vector<fram
   return {input_layouts, input_layouts};
 }
 
+std::shared_ptr<OpStrategy> StrategyForGradOp(const framework::NodeAttr &attrs,
+                                              const std::vector<ir::Tensor> &inputs,
+                                              const std::vector<Type> &out_type,
+                                              const std::vector<std::vector<int>> &output_shapes,
+                                              const Target &target) {
+  LOG(FATAL)
+      << "Gradient operator will be decomposed into several primitive operators. Please Use Decomposer Program Pass.";
+}
+
 }  // namespace op
 }  // namespace hlir
 }  // namespace cinn
@@ -1920,12 +1929,13 @@ CINN_REGISTER_HELPER(nn_ops) {
       .set_support_level(4);
 
   CINN_REGISTER_OP(relu_grad)
-      .describe("Output 0 for each input element < 0. Output itself for each input element >= 0.")
+      .describe("The gradient of relu.")
       .set_num_inputs(2)
       .set_num_outputs(1)
+      .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForGradOp)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForRelu))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForRelu))
-      .set_support_level(4);
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElemWise);
 
   CINN_REGISTER_OP(relu6)
       .describe("Output 0 for each input element < 0. Output itself for each input element >= 0 and <=6.")


### PR DESCRIPTION
- DecomposerContext 中将builder_修改为私有成员
- relu_grad注册的修改：
  - 增加OpPattern的说明
  - 删除了set_support_level，因为考虑到与代码生成的循环层数有关，反向算子并不直接生成所以应该使用不到。
  - 增加StrategyForGradOp。考虑到反向必须通过Decomposer Pass拆解，如果未使用该Pass，会导致程序中断。给出如下提示会更友好：
![image](https://user-images.githubusercontent.com/26615455/137660703-03b82bb7-fdc9-4783-8982-411607371da6.png)
