### PR TITLE
Enhance the unittest of decomposer and add the precision check of results.

### DIFF
--- a/cinn/frontend/decomposer/activation_test.cc
+++ b/cinn/frontend/decomposer/activation_test.cc
@@ -12,83 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
-#include <random>
-
-#include "cinn/frontend/decomposer/use_decomposer.h"
-#include "cinn/frontend/decomposer_registry.h"
-#include "cinn/frontend/net_builder.h"
-#include "cinn/frontend/pass/use_program_pass.h"
-#include "cinn/frontend/program_pass.h"
-#include "cinn/hlir/framework/graph.h"
-#include "cinn/hlir/framework/graph_compiler.h"
-#include "cinn/hlir/framework/pass.h"
-#include "cinn/hlir/framework/tensor.h"
-#include "cinn/hlir/op/use_ops.h"
-#include "cinn/hlir/pass/use_pass.h"
+#include "cinn/frontend/decomposer/test_helper.h"
 
 namespace cinn::frontend {
-
-void SetRandData(hlir::framework::Tensor tensor, Target target) {
-  auto* data = tensor->mutable_data<float>(target);
-  std::random_device seed;
-  std::default_random_engine engine(seed());
-  std::uniform_real_distribution<float> dist(1.f, 2.f);
-  size_t num_ele = tensor->shape().numel();
-  std::vector<float> random_data(num_ele);
-  for (size_t i = 0; i < num_ele; i++) {
-    random_data[i] = dist(engine);  // All random data
-  }
-
-#ifdef CINN_WITH_CUDA
-  cudaMemcpy(data, random_data.data(), num_ele * sizeof(float), cudaMemcpyHostToDevice);
-#else
-  std::copy(random_data.begin(), random_data.end(), data);
-#endif
-}
-
-Target GetTarget() {
-#ifdef CINN_WITH_CUDA
-  return common::DefaultNVGPUTarget();
-#else
-  return common::DefaultHostTarget();
-#endif
-}
-
-void RunProgram(NetBuilder& builder, const std::vector<std::string>& inputs) {
-  auto prog     = builder.Build();
-  Target target = GetTarget();
-  LOG(INFO) << "===================== Before Decomposition =====================";
-  for (int i = 0; i < prog.size(); i++) {
-    LOG(INFO) << "instruction: " << prog[i];
-  }
-  ProgramPass::Apply(&prog, target, {"Decomposer"});
-  LOG(INFO) << "===================== After Decomposition =====================";
-  for (int i = 0; i < prog.size(); i++) {
-    LOG(INFO) << "instruction: " << prog[i];
-  }
-  auto graph = std::make_shared<hlir::framework::Graph>(prog, target);
-  hlir::framework::ApplyPass(graph.get(), "OpFusion");
-  auto scope = BuildScope(target, graph);
-  hlir::framework::GraphCompiler gc(target, scope, graph);
-
-  auto runtime_program = gc.Build();
-  for (auto& in : inputs) {
-    scope->Var<hlir::framework::Tensor>(in);
-    auto tensor = scope->GetTensor(in);
-    SetRandData(tensor, target);
-  }
-  runtime_program->Execute();
-}
 
 TEST(Decomposer, relu) {
   NetBuilder builder("relu");
   auto x   = builder.CreateInput(Float(32), {20, 10});
   auto out = builder.relu(x);
 
-  std::vector<std::string> inputs = {"X"};
-  RunProgram(builder, inputs);
+  std::vector<std::string> input_names = {"X"};
+  RunProgram<float>(builder, input_names);
 }
 
 TEST(Decomposer, relu_grad) {
@@ -97,8 +31,8 @@ TEST(Decomposer, relu_grad) {
   auto out  = builder.CreateInput(Float(32), {20, 10});
   auto dx   = builder.relu_grad(dout, out);
 
-  std::vector<std::string> inputs = {"Dout", "Out"};
-  RunProgram(builder, inputs);
+  std::vector<std::string> input_names = {"Dout", "Out"};
+  RunProgram<float>(builder, input_names);
 }
 
 }  // namespace cinn::frontend

--- a/cinn/frontend/decomposer/activation_test.cc
+++ b/cinn/frontend/decomposer/activation_test.cc
@@ -21,7 +21,7 @@ TEST(Decomposer, relu) {
   auto x   = builder.CreateInput(Float(32), {20, 10});
   auto out = builder.relu(x);
 
-  auto relu_cpu = [](std::vector<size_t> lengths, std::vector<void*> ptrs) -> void {
+  auto relu_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n   = lengths[0];
     float* x   = static_cast<float*>(ptrs[0]);
     float* out = static_cast<float*>(ptrs[1]);
@@ -42,7 +42,7 @@ TEST(Decomposer, relu_grad) {
   auto out  = builder.CreateInput(Float(32), {20, 10});
   auto dx   = builder.relu_grad(dout, out);
 
-  auto relu_grad_cpu = [](std::vector<size_t> lengths, std::vector<void*> ptrs) -> void {
+  auto relu_grad_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n    = lengths[0];
     float* dout = static_cast<float*>(ptrs[0]);
     float* out  = static_cast<float*>(ptrs[1]);

--- a/cinn/frontend/decomposer/test_helper.h
+++ b/cinn/frontend/decomposer/test_helper.h
@@ -32,7 +32,7 @@
 
 namespace cinn::frontend {
 
-using CPUKernelFunc = std::function<void(std::vector<size_t> lengths, std::vector<void*> ptrs)>;
+using CPUKernelFunc = std::function<void(const std::vector<size_t>& lengths, const std::vector<void*>& ptrs)>;
 
 Target GetTarget() {
 #ifdef CINN_WITH_CUDA

--- a/cinn/frontend/decomposer/test_helper.h
+++ b/cinn/frontend/decomposer/test_helper.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <random>
+
+#include "cinn/frontend/decomposer/use_decomposer.h"
+#include "cinn/frontend/decomposer_registry.h"
+#include "cinn/frontend/net_builder.h"
+#include "cinn/frontend/pass/use_program_pass.h"
+#include "cinn/frontend/program_pass.h"
+#include "cinn/hlir/framework/graph.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+#include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/framework/tensor.h"
+#include "cinn/hlir/op/use_ops.h"
+#include "cinn/hlir/pass/use_pass.h"
+
+namespace cinn::frontend {
+
+Target GetTarget() {
+#ifdef CINN_WITH_CUDA
+  return common::DefaultNVGPUTarget();
+#else
+  return common::DefaultHostTarget();
+#endif
+}
+
+template <typename T>
+void InitRandomVector(std::vector<T> *vec, size_t numel) {
+  std::random_device seed;
+  std::default_random_engine engine(seed());
+  std::uniform_real_distribution<float> dist(-1.0, 1.0);
+
+  vec->resize(numel);
+  for (size_t i = 0; i < numel; ++i) {
+    vec->at(i) = static_cast<T>(dist(engine));
+  }
+}
+
+template <typename T>
+void CopyFromVector(const std::vector<T> &vec, hlir::framework::Tensor tensor, Target target) {
+  auto* data = tensor->mutable_data<T>(target);
+
+  size_t numel = tensor->shape().numel();
+  EXPECT_EQ(vec.size(), numel);
+
+#ifdef CINN_WITH_CUDA
+  cudaMemcpy(data, vec.data(), numel * sizeof(T), cudaMemcpyHostToDevice);
+#else
+  std::copy(vec.begin(), vec.end(), data);
+#endif
+}
+
+template <typename T>
+void RunProgram(NetBuilder& builder, const std::vector<std::string>& input_names) {
+  auto prog     = builder.Build();
+  Target target = GetTarget();
+  LOG(INFO) << "===================== Before Decomposition =====================";
+  for (int i = 0; i < prog.size(); i++) {
+    LOG(INFO) << "instruction: " << prog[i];
+  }
+  ProgramPass::Apply(&prog, target, {"Decomposer"});
+  LOG(INFO) << "===================== After Decomposition =====================";
+  for (int i = 0; i < prog.size(); i++) {
+    LOG(INFO) << "instruction: " << prog[i];
+  }
+  auto graph = std::make_shared<hlir::framework::Graph>(prog, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusion");
+  auto scope = BuildScope(target, graph);
+  hlir::framework::GraphCompiler gc(target, scope, graph);
+
+  auto runtime_program = gc.Build();
+  for (auto& name : input_names) {
+    scope->Var<hlir::framework::Tensor>(name);
+    auto tensor = scope->GetTensor(name);
+  
+    std::vector<T> vec;
+    InitRandomVector<T>(&vec, tensor->shape().numel());
+    CopyFromVector<T>(vec, tensor, target);
+  }
+  runtime_program->Execute();
+}
+
+}  // namespace cinn::frontend


### PR DESCRIPTION
优化test_activation_decomposer测试的代码，主要包括两点：

1. 提取公共代码到头文件test_helper.h中，方便后续其他算子复用。
2. 增加对计算结果检查的逻辑，通过与CPU reference版对比，保证算子拆分和计算的正确性。