### PR TITLE
use python3.6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,12 @@ function proxy_on {
 
 function prepare_ci {
   cd $workspace
-  proxy_off
+  proxy_on
+  if [[ ! -z ${PULL_ID} ]]; then
+    # in ci environment, we use aliyun ubuntu mirror, thus turn off proxy
+    proxy_off
+  fi
+
   if [[ $(command -v python) == $build_dir/ci-env/bin/python ]]; then
     return
   elif [[ -e $build_dir/ci-env/bin/activate ]]; then
@@ -62,14 +67,15 @@ function prepare_ci {
     apt install -y doxygen
   fi
 
-  if ! command -v python3.8-config &> /dev/null; then
-    apt install -y python3.8-dev
+  if ! command -v python3.6-config &> /dev/null; then
+    apt install -y python3.6-dev
   fi
 
-  if ! python3.8 -m venv $build_dir/ci-env &> /dev/null; then
-    apt install -y python3.8-venv
-    python3.8 -m venv $build_dir/ci-env
+  if ! python3.6 -m venv $build_dir/ci-env &> /dev/null; then
+    apt install -y python3.6-venv
+    python3.6 -m venv $build_dir/ci-env
   fi
+  proxy_off
   source $build_dir/ci-env/bin/activate
   pip install -U pip --trusted-host mirrors.aliyun.com --index-url https://mirrors.aliyun.com/pypi/simple/
   pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/

--- a/cinn/backends/llvm/CMakeLists.txt
+++ b/cinn/backends/llvm/CMakeLists.txt
@@ -5,7 +5,7 @@ add_definitions(${LLVM_DEFINITIONS})
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/cinn/backends/llvm/cinn_runtime_llvm_ir.h
   COMMAND ${LLVM_PATH}/bin/clang++ -mavx2 -std=c++11 -masm=intel -S -emit-llvm -O3 ${PROJECT_SOURCE_DIR}/cinn/runtime/cinn_runtime.cc -I${PROJECT_SOURCE_DIR} -o ${CMAKE_BINARY_DIR}/cinn/runtime/cinn_runtime.ll
-  COMMAND python3.8 generate_runtime_llvm_ir.py ${CMAKE_BINARY_DIR}/cinn/runtime/cinn_runtime.ll ${CMAKE_BINARY_DIR}/cinn/backends/llvm/cinn_runtime_llvm_ir.h
+  COMMAND python3 generate_runtime_llvm_ir.py ${CMAKE_BINARY_DIR}/cinn/runtime/cinn_runtime.ll ${CMAKE_BINARY_DIR}/cinn/backends/llvm/cinn_runtime_llvm_ir.h
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/cinn/backends/llvm
   DEPENDS ${PROJECT_SOURCE_DIR}/cinn/runtime/cinn_runtime.cc ${PROJECT_SOURCE_DIR}/cinn/runtime/cinn_runtime.h
   )

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -16,7 +16,7 @@ include(ExternalProject)
 
 set(PYBIND_SOURCE_DIR ${THIRD_PARTY_PATH}/pybind)
 
-find_package(Python 3.8 COMPONENTS Development)
+find_package(Python 3.6 EXACT COMPONENTS Development)
 include_directories(${Python_INCLUDE_DIRS})
 
 message(STATUS "pybind path: ${PYBIND_SOURCE_DIR}/src/extern_pybind/include")


### PR DESCRIPTION
加速 CI 构建，使用阿里云提供的 ubuntu 源，apt update 的时候需要关闭 proxy。但是 python 是用 deadsnakes 源，关闭 proxy 会有大概率访问失败。导致后续 python3.8-venv 安装失败。
解决方案：降级 python3.6，不依赖 deadsnakes 源。

说明：很难保证 CI 脚本在各种环境都能跑通，比较好的方式是使用预装了全部依赖的固定 docker 镜像。但是大家在本地开发的时候，依然有可能使用各种环境。只能尽量兼容各种环境。