### PR TITLE
using `std::unordered_map` instead of `absl::flat_hash_map`

### DIFF
--- a/cinn/frontend/op_mapper_registry.h
+++ b/cinn/frontend/op_mapper_registry.h
@@ -38,8 +38,8 @@ class OpMapperContext {
   OpMapperContext(const hlir::framework::Scope& scope,
                   const common::Target& target,
                   NetBuilder* builder,
-                  absl::flat_hash_map<std::string, Variable>* var_map,
-                  absl::flat_hash_map<std::string, std::string>* var_model_to_program_map)
+                  std::unordered_map<std::string, Variable>* var_map,
+                  std::unordered_map<std::string, std::string>* var_model_to_program_map)
       : scope_(scope),
         target_(target),
         builder_(builder),
@@ -75,11 +75,11 @@ class OpMapperContext {
   const common::Target& target_;
   NetBuilder* builder_{nullptr};
 
-  absl::flat_hash_map<std::string, Variable>* var_map_{nullptr};
+  std::unordered_map<std::string, Variable>* var_map_{nullptr};
   // map from var in Paddle model to var name in program.
-  absl::flat_hash_map<std::string, std::string>* var_model_to_program_map_{nullptr};
+  std::unordered_map<std::string, std::string>* var_model_to_program_map_{nullptr};
 
-  absl::flat_hash_map<std::string, FeedInfo> feed_info_map_;
+  std::unordered_map<std::string, FeedInfo> feed_info_map_;
 };
 
 class OpMapper {

--- a/cinn/frontend/paddle_model_convertor.cc
+++ b/cinn/frontend/paddle_model_convertor.cc
@@ -28,7 +28,7 @@ namespace cinn {
 namespace frontend {
 
 void PaddleModelConvertor::PrepareRun(const paddle::cpp::BlockDesc& block_desc, OpMapperContext* ctx) {
-  absl::flat_hash_map<std::string, const paddle::cpp::VarDesc*> var_desc_map;
+  std::unordered_map<std::string, const paddle::cpp::VarDesc*> var_desc_map;
   // preserve var desc info lik shape and dtype
   for (int i = 0; i < block_desc.VarsSize(); i++) {
     const auto& var_desc          = block_desc.GetConstVar<paddle::cpp::VarDesc>(i);

--- a/cinn/frontend/paddle_model_convertor.h
+++ b/cinn/frontend/paddle_model_convertor.h
@@ -57,9 +57,9 @@ class PaddleModelConvertor {
   const auto& var_model_to_program_map() const { return var_model_to_program_map_; }
 
  private:
-  absl::flat_hash_map<std::string, Variable> var_map_;
+  std::unordered_map<std::string, Variable> var_map_;
   // map from var in Paddle model to var name in program.
-  absl::flat_hash_map<std::string, std::string> var_model_to_program_map_;
+  std::unordered_map<std::string, std::string> var_model_to_program_map_;
   hlir::framework::Scope* scope_{};
   const common::Target& target_;
 };


### PR DESCRIPTION
As title, using `std::unordered_map` instead of `absl::flat_hash_map` in `OpMapperContext` and `PaddleModelConvertor`