### PR TITLE
add sum decomposer

### DIFF
--- a/cinn/frontend/decomposer/CMakeLists.txt
+++ b/cinn/frontend/decomposer/CMakeLists.txt
@@ -2,9 +2,12 @@ core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS
     activation.cc
+    elementwise.cc
     )
 
 # disable the test on x86 due to "SubProcess abort"
 if(WITH_CUDA)
   nv_test(test_activation_decomposer SRCS activation_test.cc DEPS cinncore)
 endif()
+
+cc_test(test_elementwise_decomposer SRCS elementwise_test.cc DEPS cinncore)

--- a/cinn/frontend/decomposer/activation.cc
+++ b/cinn/frontend/decomposer/activation.cc
@@ -55,13 +55,13 @@ void relu_grad(const Instruction& instr, const DecomposerContext& context) {
 }  // namespace frontend
 }  // namespace cinn
 
-CINN_REGISTER_HELPER(activation) {
+CINN_REGISTER_HELPER(activation_decomposers) {
   CINN_DECOMPOSER_REGISTER(relu, cinn::frontend::decomposer::relu);
 
   return true;
 }
 
-CINN_REGISTER_HELPER(activation_grad) {
+CINN_REGISTER_HELPER(activation_grad_decomposers) {
   CINN_DECOMPOSER_REGISTER(relu_grad, cinn::frontend::decomposer::relu_grad);
 
   return true;

--- a/cinn/frontend/decomposer/elementwise.cc
+++ b/cinn/frontend/decomposer/elementwise.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/decomposer_registry.h"
+#include "cinn/frontend/syntax.h"
+
+namespace cinn {
+namespace frontend {
+namespace decomposer {
+
+void sum(const Instruction& instr, const DecomposerContext& context) {
+  CHECK_GT(instr->inputs.size(), 0UL) << "At least 1 input tensor for " << instr->op_type;
+  CHECK_EQ(instr->outputs.size(), 1UL) << "1 output tensor for " << instr->op_type;
+  auto inputs   = instr->inputs;
+  auto output   = instr->outputs[0];
+  auto* builder = context.builder();
+
+  auto sum = builder->Identity(inputs[0]);
+  for (size_t i = 1; i < inputs.size(); ++i) {
+    sum = builder->Add(sum, inputs[i]);
+  }
+
+  // map the the output of decomposed operator to the original.
+  context.MapOutToOrigin(sum, output);
+}
+
+}  // namespace decomposer
+}  // namespace frontend
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(elementwise_decomposers) {
+  CINN_DECOMPOSER_REGISTER(sum, cinn::frontend::decomposer::sum);
+
+  return true;
+}

--- a/cinn/frontend/decomposer/elementwise_test.cc
+++ b/cinn/frontend/decomposer/elementwise_test.cc
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/decomposer/test_helper.h"
+
+namespace cinn::frontend {
+
+TEST(Decomposer, sum) {
+  NetBuilder builder("sum");
+  auto x   = builder.CreateInput(Float(32), {32, 16});
+  auto y   = builder.CreateInput(Float(32), {32, 16});
+  auto z   = builder.CreateInput(Float(32), {32, 16});
+  auto out = builder.sum({x, y, z});
+
+  auto sum_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
+    size_t n   = lengths[0];
+    float* x   = static_cast<float*>(ptrs[0]);
+    float* y   = static_cast<float*>(ptrs[1]);
+    float* z   = static_cast<float*>(ptrs[2]);
+    float* out = static_cast<float*>(ptrs[3]);
+    for (size_t i = 0; i < n; ++i) {
+      out[i] = x[i] + y[i] + z[i];
+    }
+  };
+
+  std::vector<std::string> input_names  = {x.id().data(), y.id().data(), z.id().data()};
+  std::vector<std::string> output_names = {out->id};
+  RunAndCheck<float>(builder, input_names, output_names, sum_cpu);
+}
+
+}  // namespace cinn::frontend

--- a/cinn/frontend/decomposer/use_decomposer.h
+++ b/cinn/frontend/decomposer/use_decomposer.h
@@ -16,5 +16,6 @@
 
 #include "cinn/common/macros.h"
 
-CINN_USE_REGISTER(activation)
-CINN_USE_REGISTER(activation_grad)
+CINN_USE_REGISTER(activation_decomposers)
+CINN_USE_REGISTER(activation_grad_decomposers)
+CINN_USE_REGISTER(elementwise_decomposers)

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -22,7 +22,6 @@
 
 namespace cinn {
 namespace frontend {
-
 Variable NetBuilder::add(const Variable& a, const Variable& b) {
   Instruction instr("elementwise_add", {a, b});
   InferShape(instr);
@@ -222,6 +221,13 @@ Variable NetBuilder::dropout_infer(const Variable& a, float dropout_prob, const 
   Instruction instr("dropout_infer", {a});
   instr.SetAttr("dropout_prob", dropout_prob);
   instr.SetAttr("dropout_implementation", dropout_implementation);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable NetBuilder::sum(const std::vector<Variable>& inputs) {
+  Instruction instr("sum", inputs);
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutput(0);

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -130,6 +130,8 @@ class NetBuilder : public BaseBuilder {
   Variable dropout_infer(const Variable& a,
                          float dropout_prob                        = 0.5f,
                          const std::string& dropout_implementation = "downgrade_in_infer");
+
+  Variable sum(const std::vector<Variable>& inputs);
 };
 
 }  // namespace frontend


### PR DESCRIPTION
添加sum的拆解函数，对N个相同shape的输入tensor求和

test输出
```
I1021 03:10:20.460263 25161 test_helper.h:130] ===================== Before Decomposition =====================
I1021 03:10:20.460460 25161 test_helper.h:132] instruction: var_2 = sum(placeholder, placeholder_0, placeholder_1)
I1021 03:10:20.463220 25161 test_helper.h:135] ===================== After Decomposition =====================
I1021 03:10:20.463274 25161 test_helper.h:137] instruction: var_6 = identity(placeholder)
I1021 03:10:20.463315 25161 test_helper.h:137] instruction: var_7 = elementwise_add(var_6, placeholder_0)
I1021 03:10:20.463346 25161 test_helper.h:137] instruction: var_2 = elementwise_add(var_7, placeholder_1)
```

拆解后，融合生成的kernel
```
__global__
void fn_identity_0_elementwise_add_1_elementwise_add_2_fused_kernel(const float* __restrict__ placeholder, const float* __restrict__ placeholder_0, const float* __restrict__ placeholder_1, float* __restrict__ elementwise_add_Out_0)
{
  if ((threadIdx.x < 512)) {
    elementwise_add_Out_0[threadIdx.x] = (placeholder[threadIdx.x] + (placeholder_0[threadIdx.x] + placeholder_1[threadIdx.x]));
  };
}
```