### PR TITLE
fix problems to let CINN work with Paddle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ gen_cinncore(SHARED)
 
 # --------distribute cinncore lib and include begin--------
 if (PUBLISH_LIBS)
+    set(core_includes "${core_includes};cinn/runtime/cuda/cinn_cuda_runtime_source.cuh")
     foreach(header ${core_includes})
         get_filename_component(prefix ${header} DIRECTORY)
         file(COPY ${header} DESTINATION ${CMAKE_BINARY_DIR}/dist/cinn/include/${prefix})
@@ -151,13 +152,14 @@ if (PUBLISH_LIBS)
       string(REPLACE ${CMAKE_BINARY_DIR}/ "" relname ${proto_header})
       get_filename_component(prefix ${relname} DIRECTORY)
       set(target_name ${CMAKE_BINARY_DIR}/dist/cinn/include/${relname})
-      add_custom_command(TARGET cinncore_static POST_BUILD
+      add_custom_command(TARGET cinnapi POST_BUILD
         COMMENT "copy generated proto header '${relname}' to dist"
-        COMMAND cmake -E copy ${proto_header} ${target_name} DEPENDS cinncore_static)
+        COMMAND cmake -E copy ${proto_header} ${target_name} DEPENDS cinnapi)
     endforeach()
 
     add_custom_command(TARGET cinnapi POST_BUILD
         COMMAND cmake -E copy ${CMAKE_BINARY_DIR}/libcinnapi.so ${CMAKE_BINARY_DIR}/dist/cinn/lib/libcinnapi.so
+        COMMAND cmake -E copy_directory ${CMAKE_BINARY_DIR}/thirds/install ${CMAKE_BINARY_DIR}/dist/third_party
         DEPENDS cinnapi
     )
     add_custom_command(TARGET cinncore_static POST_BUILD
@@ -166,7 +168,6 @@ if (PUBLISH_LIBS)
         COMMAND cmake -E copy ${CMAKE_BINARY_DIR}/libcinncore_static.a ${CMAKE_BINARY_DIR}/dist/cinn/lib/libcinncore_static.a
         COMMAND cmake -E copy ${CMAKE_BINARY_DIR}/cinn/frontend/paddle/libframework_proto.a ${CMAKE_BINARY_DIR}/dist/cinn/lib/libframework_proto.a
         COMMAND cmake -E copy ${CMAKE_BINARY_DIR}/cinn/hlir/pe/libparam_proto.a ${CMAKE_BINARY_DIR}/dist/cinn/lib/libparam_proto.a
-        COMMAND cmake -E copy_directory ${CMAKE_BINARY_DIR}/thirds/install ${CMAKE_BINARY_DIR}/dist/third_party
         COMMENT "distribute libcinncore_static.a and related header files."
         DEPENDS cinncore_static
     )

--- a/cinn/backends/llvm/generate_runtime_llvm_ir.py
+++ b/cinn/backends/llvm/generate_runtime_llvm_ir.py
@@ -39,7 +39,7 @@ def main():
         cmd, shell=True).decode('utf-8').strip().split('.')
     srcs.append("struct llvm_version {")
     for v, n in zip(["major", "minor", "micro"], version):
-        srcs.append(f"  static constexpr int k{v.title()} = {n};")
+        srcs.append("  static constexpr int k{} = {};".format(v.title(), n))
     srcs.append("};")
 
     srcs.append('}  // namespace cinn::backends')

--- a/cinn/gtest_main.cc
+++ b/cinn/gtest_main.cc
@@ -17,7 +17,7 @@
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
-  google::ParseCommandLineFlags(&argc, &argv, false);
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, false);
 
   return RUN_ALL_TESTS();
 }

--- a/cmake/external/gflags.cmake
+++ b/cmake/external/gflags.cmake
@@ -56,6 +56,7 @@ ExternalProject_Add(
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                     -DBUILD_TESTING=OFF
                     -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
+                    -DNAMESPACE=cinn_gflags
                     ${OPTIONAL_ARGS}
                     ${EXTERNAL_OPTIONAL_ARGS}
     CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${GFLAGS_INSTALL_DIR}


### PR DESCRIPTION
1. Paddle 只需要 make cinnapi 即可
2. 修改一处 python 语法 f"" 改成 "".format，不用限制 python >= 3.6
3. 导出 cinn/runtime/cuda/cinn_cuda_runtime_source.cuh 到 dist
4. 修改 gflags 的 namespace，防止与 Paddle 编译时的符号冲突