### PR TITLE
fix broadcastTo

### DIFF
--- a/cinn/hlir/op/op_broadcast_test.cc
+++ b/cinn/hlir/op/op_broadcast_test.cc
@@ -129,25 +129,25 @@ TEST(Operator, Operator_ElementWise_Add_Test1) {
 }
 
 TEST(Operator, Operator_BroadcastTo) {
-  auto broadcast_to      = Operator::Get("broadcast_to");
-  Operator temp = *broadcast_to;
-  auto strategy = Operator::GetAttrs<StrategyFunction>("CINNStrategy");
+  auto broadcast_to = Operator::Get("broadcast_to");
+  Operator temp     = *broadcast_to;
+  auto strategy     = Operator::GetAttrs<StrategyFunction>("CINNStrategy");
 
   Expr N(1);
   Placeholder<float> B("B", {N});
 
   NodeAttr attrs;
-  std::vector<int> out_shape = {16};
+  std::vector<int> out_shape    = {16};
   attrs.attr_store["out_shape"] = out_shape;
 
-  std::vector<int> broadcast_axes = {0};
+  std::vector<int> broadcast_axes    = {0};
   attrs.attr_store["broadcast_axes"] = broadcast_axes;
 
   std::vector<ir::Tensor> inputs{B.tensor()};
   std::vector<Type> type{Float(32)};
-  common::Target target            = common::DefaultHostTarget();
+  common::Target target = common::DefaultHostTarget();
 
-  auto impl                        = OpStrategy::SelectImpl(strategy[broadcast_to](attrs, inputs, type, {out_shape}, target));
+  auto impl = OpStrategy::SelectImpl(strategy[broadcast_to](attrs, inputs, type, {out_shape}, target));
   common::CINNValuePack cinn_input = common::CINNValuePack{{common::CINNValue(B)}};
   common::CINNValuePack rets       = impl->fcompute(cinn_input);
 

--- a/cinn/hlir/pe/broadcast.cc
+++ b/cinn/hlir/pe/broadcast.cc
@@ -251,7 +251,7 @@ Tensor BroadcastTo(const Tensor& A,
           CHECK(a_shape_i == 1 || a_shape_i == out_shape[broadcast_axes[i]])
               << "broadcast_shape should be 1 or same with the target mapping dim, but get " << A_shape[i] << " and "
               << out_shape[broadcast_axes[i]];
-          broadcast_indice.push_back(indice[broadcast_axes[i]]);
+          broadcast_indice.push_back(indice[broadcast_axes[i]] % A_shape[i]);
         }
         return A(broadcast_indice);
       },


### PR DESCRIPTION
原始的broadcastTo支持指定维度相同的broadcast，
例如
   [16] -> [8, 16, 8, 8] when axes = 1
而不能支持类似：
  [1] -> [16] when axes = 0

修复之后能够支持
[1] -> [16] when axes = [0] 
[1] -> [16,16, 16, 16] when axes = [0]

测试用例：
[1] -> [16], axes = [0]

生成IR如下：
function broadcast_to (_B, _broadcast_to_Out)
{
  broadcast_to_Out[Ramp(0,1,16)] = Broadcast(B[0],16)
}
