### PR TITLE
Add the check of output shape and make the unittest helper of decomposer more flexible to reuse.

### DIFF
--- a/cinn/frontend/decomposer/activation_test.cc
+++ b/cinn/frontend/decomposer/activation_test.cc
@@ -18,7 +18,7 @@ namespace cinn::frontend {
 
 TEST(Decomposer, relu) {
   NetBuilder builder("relu");
-  auto x   = builder.CreateInput(Float(32), {20, 10});
+  auto x   = builder.CreateInput(Float(32), {20, 10}, "x");
   auto out = builder.relu(x);
 
   auto relu_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
@@ -31,15 +31,16 @@ TEST(Decomposer, relu) {
     }
   };
 
-  std::vector<std::string> input_names  = {x.id().data()};
-  std::vector<std::string> output_names = {out->id};
-  RunAndCheck<float>(builder, input_names, output_names, relu_cpu);
+  std::vector<std::string> input_names        = {x.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{20, 10}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, relu_cpu);
 }
 
 TEST(Decomposer, relu_grad) {
   NetBuilder builder("relu_grad");
-  auto dout = builder.CreateInput(Float(32), {20, 10});
-  auto out  = builder.CreateInput(Float(32), {20, 10});
+  auto dout = builder.CreateInput(Float(32), {20, 10}, "dout");
+  auto out  = builder.CreateInput(Float(32), {20, 10}, "out");
   auto dx   = builder.relu_grad(dout, out);
 
   auto relu_grad_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
@@ -52,9 +53,10 @@ TEST(Decomposer, relu_grad) {
     }
   };
 
-  std::vector<std::string> input_names  = {dout.id().data(), out.id().data()};
-  std::vector<std::string> output_names = {dx->id};
-  RunAndCheck<float>(builder, input_names, output_names, relu_grad_cpu);
+  std::vector<std::string> input_names        = {dout.id().data(), out.id().data()};
+  std::vector<std::string> output_names       = {dx->id};
+  std::vector<std::vector<int>> output_shapes = {{20, 10}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, relu_grad_cpu);
 }
 
 }  // namespace cinn::frontend

--- a/cinn/frontend/decomposer/broadcast_test.cc
+++ b/cinn/frontend/decomposer/broadcast_test.cc
@@ -22,9 +22,10 @@ TEST(Decomposer, elementwise_add_bcast0) {
   auto y   = builder.CreateInput(Float(32), {10, 20});
   auto out = builder.elementwise_add(x, y, 1);
 
-  auto prog     = builder.Build();
-  Target target = GetTarget();
-  RunDecomposer(&prog, target);
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{4, 10, 20, 10}};
+  RunAndCheckShape<float>(builder, input_names, output_names, output_shapes);
 }
 
 TEST(Decomposer, elementwise_add_grad_bcast0) {
@@ -34,9 +35,10 @@ TEST(Decomposer, elementwise_add_grad_bcast0) {
   auto y         = builder.CreateInput(Float(32), {10, 20});
   auto out_grads = builder.elementwise_add_grad(dout, x, y, 1);
 
-  auto prog     = builder.Build();
-  Target target = GetTarget();
-  RunDecomposer(&prog, target);
+  std::vector<std::string> input_names        = {dout.id().data()};
+  std::vector<std::string> output_names       = {out_grads[0]->id, out_grads[1]->id};
+  std::vector<std::vector<int>> output_shapes = {{4, 1, 20, 10}, {10, 20}};
+  RunAndCheckShape<float>(builder, input_names, output_names, output_shapes);
 }
 
 TEST(Decomposer, elementwise_add_bcast1) {
@@ -45,9 +47,10 @@ TEST(Decomposer, elementwise_add_bcast1) {
   auto y   = builder.CreateInput(Float(32), {10, 1, 10});
   auto out = builder.elementwise_add(x, y, 1);
 
-  auto prog     = builder.Build();
-  Target target = GetTarget();
-  RunDecomposer(&prog, target);
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{4, 10, 20, 10}};
+  RunAndCheckShape<float>(builder, input_names, output_names, output_shapes);
 }
 
 TEST(Decomposer, elementwise_add_grad_bcast1) {
@@ -57,9 +60,10 @@ TEST(Decomposer, elementwise_add_grad_bcast1) {
   auto y         = builder.CreateInput(Float(32), {10, 1, 10});
   auto out_grads = builder.elementwise_add_grad(dout, x, y, 1);
 
-  auto prog     = builder.Build();
-  Target target = GetTarget();
-  RunDecomposer(&prog, target);
+  std::vector<std::string> input_names        = {dout.id().data()};
+  std::vector<std::string> output_names       = {out_grads[0]->id, out_grads[1]->id};
+  std::vector<std::vector<int>> output_shapes = {{4, 1, 20, 1}, {10, 1, 10}};
+  RunAndCheckShape<float>(builder, input_names, output_names, output_shapes);
 }
 
 TEST(Decomposer, elementwise_add_bcast2) {
@@ -79,9 +83,10 @@ TEST(Decomposer, elementwise_add_bcast2) {
     }
   };
 
-  std::vector<std::string> input_names  = {x.id().data(), y.id().data()};
-  std::vector<std::string> output_names = {out->id};
-  RunAndCheck<float>(builder, input_names, output_names, add_cpu);
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 16}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, add_cpu);
 }
 
 TEST(Decomposer, elementwise_add_grad_bcast2) {
@@ -103,9 +108,10 @@ TEST(Decomposer, elementwise_add_grad_bcast2) {
     }
   };
 
-  std::vector<std::string> input_names  = {dout.id().data()};
-  std::vector<std::string> output_names = {out_grads[0]->id, out_grads[1]->id};
-  RunAndCheck<float>(builder, input_names, output_names, add_grad_cpu);
+  std::vector<std::string> input_names        = {dout.id().data()};
+  std::vector<std::string> output_names       = {out_grads[0]->id, out_grads[1]->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 16}, {1}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, add_grad_cpu);
 }
 
 TEST(Decomposer, elementwise_add_same_dims) {
@@ -124,9 +130,10 @@ TEST(Decomposer, elementwise_add_same_dims) {
     }
   };
 
-  std::vector<std::string> input_names  = {x.id().data(), y.id().data()};
-  std::vector<std::string> output_names = {out->id};
-  RunAndCheck<float>(builder, input_names, output_names, add_cpu);
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 16}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, add_cpu);
 }
 
 TEST(Decomposer, elementwise_add_grad_same_dims) {
@@ -148,9 +155,10 @@ TEST(Decomposer, elementwise_add_grad_same_dims) {
     }
   };
 
-  std::vector<std::string> input_names  = {dout.id().data()};
-  std::vector<std::string> output_names = {out_grads[0]->id, out_grads[1]->id};
-  RunAndCheck<float>(builder, input_names, output_names, add_grad_cpu);
+  std::vector<std::string> input_names        = {dout.id().data()};
+  std::vector<std::string> output_names       = {out_grads[0]->id, out_grads[1]->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 16}, {32, 16}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, add_grad_cpu);
 }
 
 }  // namespace cinn::frontend

--- a/cinn/frontend/decomposer/elementwise_test.cc
+++ b/cinn/frontend/decomposer/elementwise_test.cc
@@ -34,9 +34,10 @@ TEST(Decomposer, sum) {
     }
   };
 
-  std::vector<std::string> input_names  = {x.id().data(), y.id().data(), z.id().data()};
-  std::vector<std::string> output_names = {out->id};
-  RunAndCheck<float>(builder, input_names, output_names, sum_cpu);
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data(), z.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 16}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, sum_cpu);
 }
 
 }  // namespace cinn::frontend


### PR DESCRIPTION
如题：

1. C++端的测试，一些复杂的配置下，对比的reference版本不好构造，但需要保证能够执行并且输出shape符合预期。
2. 单测的test_helper中封装更多基础函数，以便不同情况下复用。