### PR TITLE
Reduce the ci log.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -210,7 +210,11 @@ function run_demo {
 function run_test {
     cd $build_dir
     export LD_LIBRARY_PATH=$build_dir/paddle/mkldnn:$build_dir/thirds/install/mklml/lib:$LD_LIBRARY_PATH
-    ctest --parallel 10 -V
+    if [ ${TESTING_DEBUG_MODE:-OFF} == "ON" ] ; then
+        ctest --parallel 10 -V
+    else
+        ctest --parallel 10 --output-on-failure
+    fi
 }
 
 function CI {


### PR DESCRIPTION
单测默认设置`--output-on-failure`（代替`-V`），即只在单测失败的时候才输出详细log，便于查找CI上的错误。