### PR TITLE
[cinnrt]perfect the constant op definition

### DIFF
--- a/cinnrt/dialect/pd_ops.td
+++ b/cinnrt/dialect/pd_ops.td
@@ -21,23 +21,20 @@ def PD_FeedOp : PD_Op<"Feed", [NoSideEffect]> {
   }];
 }
 
-def PD_ConstantOp : PD_Op<"Constant", [NoSideEffect, ConstantLike]> {
+def PD_ConstantOp : PD_Op<"Constant", [NoSideEffect, ConstantLike, DeclareOpInterfaceMethods<InferTypeOpInterface>, AllTypesMatch<["value", "output"]>]> {
   let summary = "constant Op";
-
-  let description = [{
-  }];
+  let description = [{}];
 
   let arguments = (ins ElementsAttr:$value);
-  let results = (outs PD_Tensor:$out);
+  let results = (outs PD_Tensor:$output);
+  let hasFolder = 1;
 
   let builders = [
     OpBuilder<"OpBuilder &builder, OperationState &state, Attribute value">,
-    OpBuilder<"OpBuilder &builder, OperationState &state, Type type, Attribute value">
   ];
-  let hasFolder = 1;
 }
 
-def PD_AbsOp : PD_Op<"Abs", [NoSideEffect]> {
+def PD_AbsOp : PD_Op<"Abs", [NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes the absolute value of a tensor";
 
   let description = [{
@@ -85,12 +82,6 @@ def PD_ElementwiseAdd : PD_Op<"ElementwiseAdd", [NoSideEffect, Commutative, Decl
 
   let arguments = (ins PD_Tensor:$x, PD_Tensor:$y, DefaultValuedAttr<I32Attr, "-1">:$axis);
   let results = (outs PD_Tensor:$out);
-
-  let builders = [
-    OpBuilder<"OpBuilder &builder, OperationState &state, Attribute value">,
-    OpBuilder<"OpBuilder &builder, OperationState &state, Type type, Attribute value">
-  ];
-
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }


### PR DESCRIPTION
完善了cinnrt中对constant op的定义。给constant op添加新的约束：
1. DeclareOpInterfaceMethods<InferTypeOpInterface>
  表明该op可以通过Input和Attribute推断出outpu的type。通过这个，mlir会给constant自动生成不带resultType的build函数。
2.  AllTypesMatch<["value", "output"]
  表明该op的 $value 和 $output的底层type是一样的。通过这个，mlir会给constant的verify函数中添加相应的类型检查。
