### PR TITLE
cuda runtime use default primary context

### DIFF
--- a/cinn/runtime/cuda/cuda_module.h
+++ b/cinn/runtime/cuda/cuda_module.h
@@ -44,11 +44,13 @@ class CUDAModule {
     CHECK(!data.empty());
 
     cudaGetDeviceCount(&num_devices_);
+    CHECK_GT(num_devices_, 0) << "No available devices";
 
     // TODO(Superjomn) Determine whether to initialize all the devices.
-    cuInit(0);
-    cuDeviceGet(&device_, 0);
-    // cuCtxCreate(&context_, 0, device_);
+    int current_device_id;
+    cudaGetDevice(&current_device_id);
+    cudaSetDevice(current_device_id);
+    cuDeviceGet(&device_, current_device_id);
     cuCtxGetCurrent(&context_);
     cuDevicePrimaryCtxRetain(&context_, device_);
   }

--- a/cinn/runtime/cuda/cuda_module.h
+++ b/cinn/runtime/cuda/cuda_module.h
@@ -48,7 +48,9 @@ class CUDAModule {
     // TODO(Superjomn) Determine whether to initialize all the devices.
     cuInit(0);
     cuDeviceGet(&device_, 0);
-    cuCtxCreate(&context_, 0, device_);
+    // cuCtxCreate(&context_, 0, device_);
+    cuCtxGetCurrent(&context_);
+    cuDevicePrimaryCtxRetain(&context_, device_);
   }
 
   void LaunchKernel(int device_id,


### PR DESCRIPTION
修复paddle与cinn联调发现的问题：NVGPU端子图编译命中缓存情况下，二次执行生成kernel时cuLaunchKernel报错CUDA_ERROR_INVALID_HANDLE。

原因：CINN编译生成kernel时，会默认在0号device上创建新的cuda context，并将生成的kernel保存在该context中。paddle op二次执行时直接从缓存中获取kernel，此时设备context与生成kernel时使用的context不一致（因为paddle侧op执行时每次都会通过cudaSetDevice重新设置device id，它会将cuda使用的context切换到默认的primary context），导致cuLaunchKernel识别不了缓存的kernel function，从而报错。

修改方法：去除编译时创建新的cuda context，改为使用默认的primary context对象，另外通过cudaGetDevice、cudaSetDevice动态获取当前使用的设备，而不是绑定在0号卡上，确保paddle与cinn使用的设备一致