### PR TITLE
fix var_type_utils not found VarDesc problem

### DIFF
--- a/cinn/frontend/var_type_utils.h
+++ b/cinn/frontend/var_type_utils.h
@@ -24,7 +24,7 @@ namespace cinn {
 namespace frontend {
 namespace utils {
 
-common::Type CppVarType2CommonType(paddle::cpp::VarDescAPI::Type type) {
+inline common::Type CppVarType2CommonType(paddle::cpp::VarDescAPI::Type type) {
 #define SET_TYPE_CASE_ITEM(v_type, c_type)    \
   case paddle::cpp::VarDescAPI::Type::v_type: \
     return common::c_type();                  \
@@ -48,7 +48,7 @@ common::Type CppVarType2CommonType(paddle::cpp::VarDescAPI::Type type) {
   return common::Void();
 }
 
-OpMapperContext::FeedInfo GetFeedInfoFromDesc(const paddle::cpp::VarDesc& desc) {
+inline OpMapperContext::FeedInfo GetFeedInfoFromDesc(const paddle::cpp::VarDesc& desc) {
   OpMapperContext::FeedInfo info;
   for (auto num : desc.GetShape()) {
     info.shape.emplace_back(static_cast<int>(num));

--- a/cinn/frontend/var_type_utils.h
+++ b/cinn/frontend/var_type_utils.h
@@ -18,6 +18,7 @@
 #include "cinn/common/type.h"
 #include "cinn/frontend/op_mapper_registry.h"
 #include "cinn/frontend/paddle/cpp/desc_api.h"
+#include "cinn/frontend/paddle/cpp/var_desc.h"
 
 namespace cinn {
 namespace frontend {


### PR DESCRIPTION
Fix cinn_launch_op cannot found ‘VarDesc’ in namespace ‘cinn::frontend::paddle::cpp’ problem:
![image](https://user-images.githubusercontent.com/31386411/140016128-a66c1e6a-86bf-4510-971c-40930a56b5b3.png)
