### PR TITLE
enhance opfusion and support new injective ops

### DIFF
--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -153,8 +153,9 @@ int GetMasterRefNode(const std::vector<Node*>& nodes) {
   int master_index      = 0;
   int master_pattern    = op_pattern_dict[nodes[0]->op()];
   for (int i = 1; i < nodes.size(); i++) {
-    int pattern  = op_pattern_dict[nodes[i]->op()];
-    master_index = pattern >= master_pattern ? i : master_index;
+    int pattern    = op_pattern_dict[nodes[i]->op()];
+    master_index   = pattern >= master_pattern ? i : master_index;
+    master_pattern = std::max(pattern, master_pattern);
   }
   VLOG(3) << "master_index: " << master_index << ", master op: " << nodes[master_index]->op()->name;
   return master_index;

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -2216,7 +2216,7 @@ CINN_REGISTER_HELPER(nn_ops) {
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForSlice))
 #endif
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective)
       .set_support_level(4);
 
   CINN_REGISTER_OP(dropout_infer)

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -1191,17 +1191,7 @@ CINN_REGISTER_HELPER(transform_ops) {
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForConcat))
 #endif
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
-      .set_support_level(4);
-
-  CINN_REGISTER_OP(reshape)
-      .describe("This operator is used to reshape input tensor X.")
-      .set_num_inputs(1)
-      .set_num_outputs(1)
-      .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForReshape)
-      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForReshape))
-      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForReshape))
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective)
       .set_support_level(4);
 
   CINN_REGISTER_OP(reverse)
@@ -1214,7 +1204,7 @@ CINN_REGISTER_HELPER(transform_ops) {
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForReverse))
 #endif
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElemWise)
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective)
       .set_support_level(4);
 
   CINN_REGISTER_OP(transpose)
@@ -1227,7 +1217,11 @@ CINN_REGISTER_HELPER(transform_ops) {
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForTranspose))
 #endif
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElemWise)
+#ifdef CINN_WITH_CUDNN
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
+#else
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective)
+#endif
       .set_support_level(4);
 
   CINN_REGISTER_OP(mul)
@@ -1264,7 +1258,7 @@ CINN_REGISTER_HELPER(transform_ops) {
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForLayoutTransform))
 #endif
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective)
       .set_support_level(4);
   return true;
 }

--- a/cinn/hlir/pass/opfusion_test.cc
+++ b/cinn/hlir/pass/opfusion_test.cc
@@ -423,5 +423,51 @@ TEST(conv_add_mul, conv_add_mul) {
   runtime_program->Execute();
 }
 
+// conv+add with different out shape
+TEST(fuse_conv_add1, fuse_conv_add1) {
+  Placeholder A(Float(32), {1, 8, 1, 1}, "A");
+  Placeholder B(Float(32), {32, 8, 1, 1}, "B");
+  Placeholder C(Float(32), {1, 32, 112, 112}, "C");
+
+  Program program;
+  absl::flat_hash_map<std::string, Program::attr_t> attrs;
+  attrs["stride"]        = std::vector<int>({1, 1});
+  attrs["dilation"]      = std::vector<int>({1, 1});
+  attrs["padding"]       = std::vector<int>({0, 0});
+  std::string src_layout = "NCHW";
+  attrs["data_format"]   = src_layout;
+
+  auto c = program.conv2d(A, B, attrs);
+  auto d = program.elementwise_add(c, C);
+
+  Target target = GetTarget();
+  program.SetInputs({A, B, C});
+  program.Validate();
+  LOG(INFO) << "Program:\n" << program;
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+
+  hlir::framework::ApplyPass(graph.get(), "InferShape");
+  hlir::framework::ApplyPass(graph.get(), "AlterLayout");
+  hlir::framework::ApplyPass(graph.get(), "OpFusion");
+  auto scope = BuildScope(target, graph);
+  LOG(INFO) << "graph:\n" << graph->Visualize();
+
+  hlir::framework::GraphCompiler gc(target, scope, graph);
+  auto runtime_program = gc.Build();
+
+  scope->Var<hlir::framework::Tensor>("A");
+  scope->Var<hlir::framework::Tensor>("B");
+  scope->Var<hlir::framework::Tensor>("C");
+
+  auto A1 = scope->GetTensor("A");
+  auto B1 = scope->GetTensor("B");
+  auto C1 = scope->GetTensor("C");
+  SetRandData(A1, target);
+  SetRandData(B1, target);
+  SetRandData(C1, target);
+
+  runtime_program->Execute();
+}
+
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/hlir/pe/nn.h
+++ b/cinn/hlir/pe/nn.h
@@ -58,7 +58,7 @@ ir::Tensor Relu6(const ir::Tensor &A,
                  T threshold                    = static_cast<T>(0),
                  const std::string &output_name = UniqName("T_Relu6_out")) {
   return lang::Compute(
-      A->shape, [&](const std::vector<Expr> &indice) { return lang::Relu6(A(indice), threshold); }, output_name);
+      A->shape, [=](const std::vector<Expr> &indice) { return lang::Relu6(A(indice), threshold); }, output_name);
 }
 
 /**


### PR DESCRIPTION
enhance opfusion:
1. support fuse injective ops, like concat, transpose, slice, layout_transform, reverse
2. not fuse if conv and ops like broadcast outshapes are not same

For facedet model，it can optimized from 6.5ms to 5.9ms in x86.

For fused_batchnorm_inference emplemented by primitive ops, it can be fused to one kernel, which you can refer to the test_primitive_ops.cc's testcase.

e.g.
before fuse:
```
Program {
  epsilon = const_scalar(value=0.001)
  var_6 = broadcast_to(epsilon, out_shape=[64], broadcast_axes=[0])
  var_7 = elementwise_add(Variance, var_6)
  var_8 = rsqrt(var_7)
  var_9 = elementwise_mul(var_8, Scale)
  var_10 = negative(Mean)
  var_11 = elementwise_mul(var_9, var_10)
  var_12 = elementwise_add(var_11, Bias)
  var_13 = broadcast_to(var_9, out_shape=[1,64,112,112], broadcast_axes=[1])
  var_14 = broadcast_to(var_12, broadcast_axes=[1], out_shape=[1,64,112,112])
  var_15 = elementwise_mul(var_13, A)
  var_16 = elementwise_add(var_15, var_14)
}
```
after opfusion,  fused_batchnorm_inference can be fused into one kernel and the lowered ir is as follows:
```
function fn_const_scalar_1_negative_6_broadcast_to_2_elementwise_add_3_rsqrt_4_elementwise_mul_5_elementwise_mul_7_broadcast_to_9_elementwise_add_8_elementwise_mul_11_broadcast_to_10_elementwise_add_12_fused (_Mean, _Variance, _Scale, _Bias, _A, _elementwise_add_Out_1)
{
  parallel for (i_j_fused, 0, 64)
  {
    for (k, 0, 112)
    {
      for (a_outer, 0, 7)
      {
        elementwise_add_Out_1[Broadcast(0,16), Broadcast(i_j_fused,16), Broadcast(k,16), Ramp((16 * a_outer),1,16)] = ((Broadcast((1 * (1 / sqrt((Variance[i_j_fused] + 0.001)))),16) * (Broadcast(Scale[i_j_fused],16) * A[Broadcast(0,16), Broadcast(i_j_fused,16), Broadcast(k,16), Ramp((16 * a_outer),1,16)])) + Broadcast(((-1 * ((1 * (1 / sqrt((Variance[i_j_fused] + 0.001)))) * (Scale[i_j_fused] * Mean[i_j_fused]))) + Bias[i_j_fused]),16))
      }
    }
  }
}
```

