### PR TITLE
Correct output names of batch_norm_grad in the batchnorm opmapper.

### DIFF
--- a/cinn/common/common.h
+++ b/cinn/common/common.h
@@ -57,6 +57,7 @@ static void CheckVarNameValid(const absl::string_view name) {
   CHECK(!name.empty());
   CHECK(name.find(' ') == std::string::npos &&   //
         name.find('.') == std::string::npos &&   //
+        name.find('@') == std::string::npos &&   //
         name.find('/') == std::string::npos &&   //
         name.find('\t') == std::string::npos &&  //
         name.find('\n') == std::string::npos &&  //

--- a/cinn/frontend/op_mappers/batchnorm.cc
+++ b/cinn/frontend/op_mappers/batchnorm.cc
@@ -102,7 +102,8 @@ void BatchNormGradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCon
   auto outs = ctx.Builder()->batch_norm_grad(dy, x, scale, saved_mean, saved_variance, epsilon, data_layout);
   CHECK_EQ(outs.size(), 3ul) << "batch_norm_grad API's should return 3 Variable!";
 
-  std::vector<std::string> output_names = {"X", "Scale", "Bias"};
+  std::vector<std::string> output_names = {
+      paddle::GradVarName("X"), paddle::GradVarName("Scale"), paddle::GradVarName("Bias")};
   for (int i = 0; i < outs.size(); i++) {
     auto out_name = get_output_name(output_names[i]);
     ctx.AddVar(out_name, outs[i]);

--- a/cinn/utils/string.cc
+++ b/cinn/utils/string.cc
@@ -119,6 +119,7 @@ bool IsSuffix(const char &c) {
 std::string TransValidVarName(std::string name) {
   utils::Replace(&name, ".", "__");
   utils::Replace(&name, "/", "___");
+  utils::Replace(&name, "@", "____");
   name.erase(0, name.find_first_not_of("_"));
   return name;
 }


### PR DESCRIPTION
* Correct output names of batch_norm_grad in the batchnorm opmapper.
* Add `@` check in the `TransValidVarName` function.