### PR TITLE
Polish OpTest to allow to set max_relative_error and print more error message.

### DIFF
--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -26,24 +26,34 @@ logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO').upper())
 logger = logging.getLogger()
 
 
+def random(shape, dtype="float32", low=0.0, high=1.0):
+    if dtype == "float32":
+        return np.random.uniform(low, high, shape).astype(dtype)
+    else:
+        raise Exception("Not supported yet.")
+
+
 class OpTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(OpTest, self).__init__(*args, **kwargs)
-        self.init_target()
-        self.init_results()
+        self._init_target()
+        self._init_results()
 
-    def init_results(self):
+    def _init_results(self):
         self.paddle_outputs = []
         self.paddle_grads = []
         self.cinn_outputs = []
         self.cinn_grads = []
 
-    def init_target(self):
+    def _init_target(self):
         self.target = DefaultHostTarget()
         if is_compiled_with_cuda():
             self.target = DefaultNVGPUTarget()
 
-    def build_paddle_program():
+    def _get_device(self):
+        return "NVGPU" if is_compiled_with_cuda() else "CPU"
+
+    def build_paddle_program(self, target):
         raise Exception("Not implemented.")
 
     def get_paddle_grads(self, outputs, inputs, grad_outputs):
@@ -54,7 +64,7 @@ class OpTest(unittest.TestCase):
 
         return grads
 
-    def build_cinn_program():
+    def build_cinn_program(self, target):
         raise Exception("Not implemented.")
 
     def get_cinn_output(self, prog, target, inputs, feed_data, outputs):
@@ -81,22 +91,57 @@ class OpTest(unittest.TestCase):
         logger.debug("============ After Decomposer Pass ============")
         print_program(prog)
 
-    def check_outputs_and_grads(self):
+    def check_outputs_and_grads(self, max_relative_error=1e-5):
         self.build_paddle_program(self.target)
         self.build_cinn_program(self.target)
+
         logger.debug("============ Check Outputs ============")
-        self.check_results(self.paddle_outputs, self.cinn_outputs)
+        self.check_results(self.paddle_outputs, self.cinn_outputs,
+                           max_relative_error)
 
         if len(self.cinn_grads) != 0:
             logger.debug("============ Check Grads ============")
-            self.check_results(self.paddle_grads, self.cinn_grads)
+            self.check_results(self.paddle_grads, self.cinn_grads,
+                               max_relative_error)
 
-    def check_results(self, expect_res, actual_res):
+    def check_results(self, expect_res, actual_res, max_relative_error):
+        def _compute_max_relative_error(output_id, expect, actual):
+            absolute_diff = np.abs(expect - actual).flatten()
+            relative_diff = absolute_diff / np.abs(expect).flatten()
+            max_diff = 0
+            min_diff = max_relative_error
+            offset = 0
+            num_diffs = 0
+            for i in range(len(relative_diff)):
+                if relative_diff[i] > max_diff:
+                    max_diff = relative_diff[i]
+                    offset = i
+                if relative_diff[i] > max_relative_error:
+                    num_diffs = num_diffs + 1
+                    # The following print can be used to debug.
+                    # print("i=%d, %e vs %e, relative_diff=%e, absolute_diff=%e" % (i, expect.flatten()[i], actual.flatten()[i], relative_diff[i], absolute_diff[i]))
+            error_message = "[%s] The %d-th output: total %d different results, offset=%d, shape=%s, %e vs %e, maximum_relative_diff=%e (absolute_diff=%e)." % (
+                self._get_device(), output_id, num_diffs, offset,
+                str(expect.shape), expect.flatten()[offset],
+                actual.flatten()[offset], max_diff, absolute_diff[offset])
+            return error_message
+
         self.assertEqual(len(expect_res), len(actual_res))
         for i in range(len(expect_res)):
-            logger.debug("Check the %d -th Result..." % i)
-            self.assertTrue(
-                np.allclose(expect_res[i], actual_res[i], atol=1e-6))
+            if expect_res[i] is None:
+                continue
+
+            if isinstance(expect_res[i], paddle.Tensor):
+                expect = expect_res[i].numpy()
+            else:
+                expect = expect_res[i]
+            actual = actual_res[i]
+            is_allclose = np.allclose(
+                expect, actual, atol=1e-6, rtol=max_relative_error)
+            logger.debug("{} {}".format(
+                is_allclose, _compute_max_relative_error(i, expect, actual)))
+            self.assertTrue(is_allclose,
+                            _compute_max_relative_error(i, expect, actual))
 
 
 class OpTestTool:


### PR DESCRIPTION
优化精度检查失败时的log，修改后如下：
```
2021-11-08 19:44:39 ======================================================================
2021-11-08 19:44:39 FAIL: test_check_results (__main__.TestConv2dOp)
2021-11-08 19:44:39 ----------------------------------------------------------------------
2021-11-08 19:44:39 Traceback (most recent call last):
2021-11-08 19:44:39   File "/workspace/CINN/CINN/python/tests/ops/test_conv2d_op.py", line 79, in test_check_results
2021-11-08 19:44:39     self.check_outputs_and_grads()
2021-11-08 19:44:39   File "/workspace/CINN/CINN/python/tests/ops/op_test.py", line 100, in check_outputs_and_grads
2021-11-08 19:44:39     max_relative_error)
2021-11-08 19:44:39   File "/workspace/CINN/CINN/python/tests/ops/op_test.py", line 144, in check_results
2021-11-08 19:44:39     _compute_max_relative_error(i, expect, actual))
2021-11-08 19:44:39 AssertionError: False is not true : [NVGPU] The 1-th output: total 1 different results, offset=853215, shape=(3, 16, 224, 224), 2.944653e+00 vs 2.944687e+00, maximum_relative_diff=1.165919e-05 (absolute_diff=3.433228e-05).
2021-11-08 19:44:39 
2021-11-08 19:44:39 ----------------------------------------------------------------------
2021-11-08 19:44:39 Ran 1 test in 33.300s
2021-11-08 19:44:39 
2021-11-08 19:44:39 FAILED (failures=1)
```
