### PR TITLE
Reduce the unittest time.

### DIFF
--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -138,10 +138,13 @@ class OpTest(unittest.TestCase):
             actual = actual_res[i]
             is_allclose = np.allclose(
                 expect, actual, atol=1e-6, rtol=max_relative_error)
-            logger.debug("{} {}".format(
-                is_allclose, _compute_max_relative_error(i, expect, actual)))
-            self.assertTrue(is_allclose,
-                            _compute_max_relative_error(i, expect, actual))
+            if not is_allclose:
+                error_message = _compute_max_relative_error(i, expect, actual)
+            else:
+                error_message = "np.allclose(expect, actual, atol=1e-6, rtol={}) checks succeed!".format(
+                    max_relative_error)
+            logger.debug("{} {}".format(is_allclose, error_message))
+            self.assertTrue(is_allclose, error_message)
 
 
 class OpTestTool:

--- a/python/tests/ops/test_elementwise_add_op.py
+++ b/python/tests/ops/test_elementwise_add_op.py
@@ -90,9 +90,9 @@ class TestElementwiseAddOp(OpTest):
 class TestAddCase1(TestElementwiseAddOp):
     def init_case(self):
         self.inputs = {
-            "x": np.random.random([8, 64, 256, 256]).astype("float32"),
-            "y": np.random.random([256, 256]).astype("float32"),
-            "dout": np.random.random((8, 64, 256, 256)).astype("float32")
+            "x": np.random.random([8, 16, 32, 32]).astype("float32"),
+            "y": np.random.random([32, 32]).astype("float32"),
+            "dout": np.random.random((8, 16, 32, 32)).astype("float32")
         }
         self.axis = -1
 
@@ -101,8 +101,8 @@ class TestAddCase2(TestElementwiseAddOp):
     def init_case(self):
         self.inputs = {
             "x": np.random.random([8, 1, 32, 32]).astype("float32"),
-            "y": np.random.random([64, 32]).astype("float32"),
-            "dout": np.random.random((8, 64, 32, 32)).astype("float32")
+            "y": np.random.random([16, 32]).astype("float32"),
+            "dout": np.random.random((8, 16, 32, 32)).astype("float32")
         }
         self.axis = 1
 


### PR DESCRIPTION
#554 为了在单测精度检查失败时，能够看到具体的diff信息，增加了一个python实现的`_compute_max_relative_error`函数来计算最大相对误差、并统计不满足精度要求的输出个数。该实现在数据shape很大时，耗时很长。解决方法：

- 当前pr，通过修改保证`np.allclose`精度检查成功时不会调用`_compute_max_relative_error`函数，从而减少精度检查通过时的单测耗时。
- 后续PR将改写`_compute_max_relative_error`的实现，保证计时精度检查失败时也不会产生大的耗时。