### PR TITLE
fix the error when compiling infrt separately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ set(infrt_mlir_incs
         rewrite_inc
         )
 
-cc_library(infrt SRCS ${infrt_src} DEPS glog absl framework_proto ${mlir_libs})
+cc_library(infrt SRCS ${infrt_src} DEPS glog absl paddle_framework_proto ${mlir_libs})
 add_dependencies(infrt ${infrt_mlir_incs})
 
 # --------distribute cinncore lib and include begin--------


### PR DESCRIPTION
编译infrt时会报如下编译错误：
![01d59fc02ce5be04eef106643](https://user-images.githubusercontent.com/78149749/141399724-e63d39da-07d4-42e7-8451-b103f56b57fe.png)

予以修复。
