### PR TITLE
Conrrect the output order in batch_norm's op_mapper and add reduce_sum to net_builder.

### DIFF
--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -22,6 +22,7 @@
 
 namespace cinn {
 namespace frontend {
+
 Variable NetBuilder::identity(const Variable& operand) {
   Instruction instr("identity", {operand});
   InferShape(instr);
@@ -124,6 +125,15 @@ Variable NetBuilder::relu6(const Variable& a, float threshold) {
 Variable NetBuilder::reverse(const Variable& x, const std::vector<int>& axis) {
   Instruction instr("reverse", {x});
   instr.SetAttr("axis", axis);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable NetBuilder::reduce_sum(const Variable& x, const std::vector<int>& dim, bool keep_dim) {
+  Instruction instr("reduce_sum", {x});
+  instr.SetAttr("dim", dim);
+  instr.SetAttr("keep_dim", keep_dim);
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutput(0);

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -97,6 +97,11 @@ class NetBuilder : public BaseBuilder {
   Variable reverse(const Variable& x, const std::vector<int>& axis);
 
   /**
+   * Compute the sum of Variable x along the given dim.
+   */
+  Variable reduce_sum(const Variable& x, const std::vector<int>& dim, bool keep_dim = false);
+
+  /**
    * The convolution2D layer calculates the output based on the input, filter
    * and strides, paddings, dilations, groups parameters.
    */
@@ -133,8 +138,8 @@ class NetBuilder : public BaseBuilder {
   /**
    * The batchnorm layer can be used as a normalizer function
    * for convolution or fully_connected operations.
-   * is_test(true): batch norm infer (default), output{y}
-   * is_test(false): batch norm training, output{y, moving_mean, moving_variance, save_mean, save_variance}
+   * is_test(true): batch norm infer (default), output={y}
+   * is_test(false): batch norm training, outputs={y, saved_mean, saved_variance, moving_mean, moving_variance}
    */
   std::vector<Variable> batchnorm(const Variable& a,
                                   const Variable& scale,
@@ -146,7 +151,7 @@ class NetBuilder : public BaseBuilder {
                                   const std::string& data_layout = "NCHW",
                                   bool is_test                   = false);
 
-  // batch norm grad, output(grad_x, grad_scale, grad_bias)
+  // batch norm grad, output(x_grad, scale_grad, bias_grad)
   std::vector<Variable> batch_norm_grad(const Variable& dy,
                                         const Variable& x,
                                         const Variable& scale,

--- a/cinn/frontend/op_mappers/batchnorm.cc
+++ b/cinn/frontend/op_mappers/batchnorm.cc
@@ -54,11 +54,11 @@ void BatchnormOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
     output_names = {"Y"};
     VLOG(4) << "Invoke batch_norm OpMapper with test mode";
   } else {
-    output_names = {"Y", "MeanOut", "VarianceOut", "SavedMean", "SavedVariance"};
+    output_names = {"Y", "SavedMean", "SavedVariance", "MeanOut", "VarianceOut"};
     VLOG(4) << "Invoke batch_norm OpMapper with train mode";
   }
 
-  auto outs = ctx.Builder()->batchnorm(x, scale, bias, mean, variance, epsilon, momentum, data_layout, is_test);
+  auto outs = ctx.Builder()->batchnorm(x, scale, bias, mean, variance, epsilon, momentum, data_layout, test_mode);
   CHECK_EQ(outs.size(), output_names.size()) << "batch_norm API's should return" << output_names.size() << "Variables!";
 
   for (int i = 0; i < outs.size(); i++) {

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -336,6 +336,8 @@ void BindFrontend(pybind11::module *m) {
       .def("relu", &NetBuilder::relu, py::arg("a"))
       .def("relu_grad", &NetBuilder::relu_grad, py::arg("dout"), py::arg("out"))
       .def("relu6", &NetBuilder::relu6, py::arg("a"), py::arg("threshold") = 6.0f)
+      .def("reverse", &NetBuilder::reverse, py::arg("x"), py::arg("axis"))
+      .def("reduce_sum", &NetBuilder::reduce_sum, py::arg("x"), py::arg("dim"), py::arg("keep_dim") = false)
       .def("conv2d",
            &NetBuilder::conv2d,
            py::arg("a"),


### PR DESCRIPTION
1. 修复batch_norm op_mapper中输出的顺序，该顺序必须与decomposer中返回的顺序一致。
2. net_builder中添加reduce_sum接口，方便做reduce_sum的精度测试。