### PR TITLE
Add a common file to manage the runtime flags.

### DIFF
--- a/cinn/pybind/runtime.cc
+++ b/cinn/pybind/runtime.cc
@@ -23,11 +23,7 @@
 
 #include "cinn/pybind/bind.h"
 #include "cinn/runtime/cinn_runtime.h"
-#include "gflags/gflags.h"
-
-#ifdef CINN_WITH_CUDNN
-DECLARE_bool(cinn_cudnn_deterministic);
-#endif
+#include "cinn/runtime/flags.h"
 
 namespace py = pybind11;
 namespace cinn::pybind {
@@ -123,14 +119,6 @@ void BindSpecialTypes(py::module *m) {
 #undef VOID_PTR_SUPPORT_TYPE
 
   m->def("nullptr", []() { return VoidPointer(); });
-}
-
-void SetCinnCudnnDeterministic(bool state = true) {
-#ifdef CINN_WITH_CUDNN
-  FLAGS_cinn_cudnn_deterministic = state;
-#else
-  LOG(WARNING) << "Compile without CUDNN, this api is invalid!";
-#endif
 }
 
 void BindCinnRuntime(py::module *m) {
@@ -278,7 +266,7 @@ void BindCinnRuntime(py::module *m) {
       .def("cinn_pod_value_to_void_p", &cinn_pod_value_to_void_p)
       .def("cinn_pod_value_to_buffer_p", &cinn_pod_value_to_buffer_p);
 
-  m->def("set_cinn_cudnn_deterministic", &SetCinnCudnnDeterministic, py::arg("state") = true);
+  m->def("set_cinn_cudnn_deterministic", &cinn::runtime::SetCinnCudnnDeterministic, py::arg("state") = true);
 }
 }  // namespace
 

--- a/cinn/runtime/CMakeLists.txt
+++ b/cinn/runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS
+  flags.cc
   intrinsic.cc
   cinn_runtime.cc
   intrinsic_types.cc

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -22,9 +22,8 @@
 #include "cinn/backends/cuda_util.h"
 #include "cinn/backends/extern_func_jit_register.h"
 #include "cinn/common/target.h"
+#include "cinn/runtime/flags.h"
 #include "cinn/utils/timer.h"
-
-DECLARE_bool(cinn_cudnn_deterministic);
 
 namespace cinn {
 namespace runtime {
@@ -200,7 +199,7 @@ void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int> &attr,
     algo               = algo_perf.algo;
   }
 
-  if (FLAGS_cinn_cudnn_deterministic) {
+  if (GetCinnCudnnDeterministic()) {
     algo = static_cast<cudnnConvolutionFwdAlgo_t>(1);
   }
 
@@ -290,7 +289,7 @@ void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, 
     algo               = algo_perf.algo;
   }
 
-  if (FLAGS_cinn_cudnn_deterministic) {
+  if (GetCinnCudnnDeterministic()) {
     algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
   }
 
@@ -380,7 +379,7 @@ void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string
     algo               = algo_perf.algo;
   }
 
-  if (FLAGS_cinn_cudnn_deterministic) {
+  if (GetCinnCudnnDeterministic()) {
     algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
   }
 

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -24,11 +24,7 @@
 #include "cinn/common/target.h"
 #include "cinn/utils/timer.h"
 
-DEFINE_bool(cinn_cudnn_deterministic,
-            false,
-            "Whether allow using an autotuning algorithm for convolution "
-            "operator. The autotuning algorithm may be non-deterministic. If "
-            "true, the algorithm is deterministic.");
+DECLARE_bool(cinn_cudnn_deterministic);
 
 namespace cinn {
 namespace runtime {

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -32,7 +32,16 @@ void SetCinnCudnnDeterministic(bool state) {
 #ifdef CINN_WITH_CUDNN
   FLAGS_cinn_cudnn_deterministic = state;
 #else
-  LOG(WARNING) << "Compile without CUDNN, this api is invalid!";
+  LOG(WARNING) << "CINN is compiled without cuDNN, this api is invalid!";
+#endif
+}
+
+bool GetCinnCudnnDeterministic() {
+#ifdef CINN_WITH_CUDNN
+  return FLAGS_cinn_cudnn_deterministic;
+#else
+  LOG(FATAL) << "CINN is compiled without cuDNN, this api is invalid!";
+  return false;
 #endif
 }
 

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/runtime/flags.h"
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#ifdef CINN_WITH_CUDNN
+DEFINE_bool(cinn_cudnn_deterministic,
+            false,
+            "Whether allow using an autotuning algorithm for convolution "
+            "operator. The autotuning algorithm may be non-deterministic. If "
+            "true, the algorithm is deterministic.");
+#endif
+
+namespace cinn {
+namespace runtime {
+
+void SetCinnCudnnDeterministic(bool state) {
+#ifdef CINN_WITH_CUDNN
+  FLAGS_cinn_cudnn_deterministic = state;
+#else
+  LOG(WARNING) << "Compile without CUDNN, this api is invalid!";
+#endif
+}
+
+}  // namespace runtime
+}  // namespace cinn

--- a/cinn/runtime/flags.h
+++ b/cinn/runtime/flags.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace cinn {
+namespace runtime {
+
+void SetCinnCudnnDeterministic(bool state);
+
+}  // namespace runtime
+}  // namespace cinn

--- a/cinn/runtime/flags.h
+++ b/cinn/runtime/flags.h
@@ -18,6 +18,7 @@ namespace cinn {
 namespace runtime {
 
 void SetCinnCudnnDeterministic(bool state);
+bool GetCinnCudnnDeterministic();
 
 }  // namespace runtime
 }  // namespace cinn


### PR DESCRIPTION
用一个统一的flags.h/.cc来管理FLAGS，并提供设置FLAGS的接口函数`SetCinnCudnnDeterministic`，Paddle中需要调用`SetCinnCudnnDeterministic`来设置对应FLAGS的值。

对应Paddle中PR：https://github.com/PaddlePaddle/Paddle/pull/37173

Paddle中已使用test_resnet50_with_cinn.py单测验证，设置`export FLAGS_allow_cinn_ops="conv2d;conv2d_grad"`，但线程执行，loss如下：
![image](https://user-images.githubusercontent.com/12538138/141754976-dccdca81-b6bc-4f7c-b163-d131d998fdd6.png)
