### PR TITLE
Fix the bug case in which conv2d_grad only has one output.

### DIFF
--- a/cinn/frontend/decomposer/conv2d_grad.cc
+++ b/cinn/frontend/decomposer/conv2d_grad.cc
@@ -26,17 +26,19 @@ void conv2d_grad(const Instruction& instr, const DecomposerContext& context) {
 
   CinnBuilder* builder = context.builder();
   // create backward data
-  auto dx = builder->Conv(w,
-                          dy,
-                          instr.GetAttrs<std::vector<int>>("strides"),
-                          instr.GetAttrs<std::vector<int>>("paddings"),
-                          instr.GetAttrs<std::vector<int>>("dilations"),
-                          instr.GetAttrs<int>("groups"),
-                          "backward_data",
-                          instr.GetAttrs<std::string>("data_format"),
-                          instr.GetAttrs<std::string>("padding_algorithm"),
-                          x->shape);
-  context.MapOutToOrigin(dx, instr->outputs[0]);
+  if (!instr->outputs[0].is_const()) {
+    auto dx = builder->Conv(w,
+                            dy,
+                            instr.GetAttrs<std::vector<int>>("strides"),
+                            instr.GetAttrs<std::vector<int>>("paddings"),
+                            instr.GetAttrs<std::vector<int>>("dilations"),
+                            instr.GetAttrs<int>("groups"),
+                            "backward_data",
+                            instr.GetAttrs<std::string>("data_format"),
+                            instr.GetAttrs<std::string>("padding_algorithm"),
+                            x->shape);
+    context.MapOutToOrigin(dx, instr->outputs[0]);
+  }
 
   // create backward filter
   auto dw = builder->Conv(x,


### PR DESCRIPTION
In general, `conv2d_grad` have two outputs, as shown in the following figure:
![image](https://user-images.githubusercontent.com/17102274/142170404-a30c71b9-3afc-4479-b747-dc0b85cfc031.png)

However, if the input `X` of `conv2d` don't need to compute its gradient (`stop_gradient=True`), there will only be one output for `conv2d_grad`, which is shown below:
![image](https://user-images.githubusercontent.com/17102274/142169729-d3e473e8-a574-404e-879c-338573994d31.png)

This pr fixes this bug case.