### PR TITLE
gpu globalpool warp reduce

### DIFF
--- a/cinn/backends/codegen_cuda_dev_test.cc
+++ b/cinn/backends/codegen_cuda_dev_test.cc
@@ -371,6 +371,278 @@ void __launch_bounds__(5) elementwise_add_splitouter(const float* __restrict__ X
   }
 }
 
+TEST(GlobalPool, pool2d_max) {
+  Context::Global().ResetNameId();
+
+  Target target = common::DefaultNVGPUTarget();
+
+  Expr N(24);
+  Expr C(24);
+  Expr H(96);
+  Expr W(96);
+
+  Placeholder<float> A("X", {N, C, H, W});
+  auto res    = hlir::pe::GlobalPool2d(A, "max", "pool_out");
+  auto stages = CreateStages(res);
+
+  stages[res[0]]->Bind(0, "blockIdx.x");
+  stages[res[0]]->Bind(1, "threadIdx.y");
+  stages[res[1]]->ComputeAt2(stages[res[0]], 1);
+  stages[res[1]]->Bind(2, "threadIdx.x");
+  stages[res[1]]->SetBuffer("local");
+
+  auto func = cinn::lang::LowerVec("global_pool2d_max", stages, {A, res[0]}, {}, {}, nullptr, target);
+  CodeGenCUDA_Dev codegen(target);
+  Module::Builder builder("module", target);
+  for (auto& f : func) {
+    builder.AddFunction(f);
+  }
+  auto source_code = codegen.Compile(builder.Build());
+  ASSERT_NE(source_code.find("cinn_warp_reduce_max"), std::string::npos);
+  LOG(INFO) << "compiled global_pool2d_max code:\n\n\n" << source_code;
+
+  using runtime::cuda::CUDAModule;
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+  CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
+  CUDA_CALL(cudaDeviceSynchronize());
+
+  CUdeviceptr Ad, Bd;
+  cuMemAlloc(&Ad, 24 * 24 * 96 * 96 * sizeof(float));
+  cuMemAlloc(&Bd, 24 * 24 * 1 * 1 * sizeof(float));
+
+  std::vector<float> host_data1(24 * 24 * 96 * 96);
+  std::vector<float> host_data2(24 * 24 * 1 * 1);
+  std::vector<float> host_data3(24 * 24 * 1 * 1);
+
+  for (float& v : host_data1) v = static_cast<float>(rand()) / INT_MAX;
+  for (int i = 0; i < 24 * 24; i++) {
+    float* p = &host_data1[i * 96 * 96];
+    float mv = -3.402823e+38f;
+    for (int j = 0; j < 96 * 96; j++) {
+      mv = std::max(p[j], mv);
+    }
+    host_data3[i] = mv;
+  }
+  CUDA_CALL(cudaMemcpy(
+      reinterpret_cast<void*>(Ad), host_data1.data(), host_data1.size() * sizeof(float), cudaMemcpyHostToDevice));
+  void* args[] = {&Ad, &Bd};
+  dim3 blocks_per_grid(24, 1, 1);
+  dim3 threads_per_block(32, 24, 1);
+  cuda_module.LaunchKernel(0, "global_pool2d_max", blocks_per_grid, threads_per_block, args);
+  CUDA_CALL(cudaMemcpy(
+      host_data2.data(), reinterpret_cast<void*>(Bd), 24 * 24 * 1 * 1 * sizeof(float), cudaMemcpyDeviceToHost));
+  for (int i = 0; i < host_data2.size(); i++) {
+    ASSERT_NEAR(host_data2[i], host_data3[i], 1e-5);
+  }
+}
+
+TEST(GlobalPool, pool2d_avg) {
+  Context::Global().ResetNameId();
+
+  Target target = common::DefaultNVGPUTarget();
+
+  Expr N(24);
+  Expr C(24);
+  Expr H(96);
+  Expr W(96);
+
+  Placeholder<float> A("X", {N, C, H, W});
+  auto res    = hlir::pe::GlobalPool2d(A, "avg", "pool_out");
+  auto stages = CreateStages(res);
+
+  stages[res[0]]->Bind(0, "blockIdx.x");
+  stages[res[0]]->Bind(1, "threadIdx.y");
+  stages[res[1]]->ComputeAt2(stages[res[0]], 1);
+  stages[res[1]]->Bind(2, "threadIdx.x");
+  stages[res[1]]->SetBuffer("local");
+
+  auto func = cinn::lang::LowerVec("global_pool2d_avg", stages, {A, res[0]}, {}, {}, nullptr, target);
+  CodeGenCUDA_Dev codegen(target);
+  Module::Builder builder("module", target);
+  for (auto& f : func) {
+    builder.AddFunction(f);
+  }
+  auto source_code = codegen.Compile(builder.Build());
+  ASSERT_NE(source_code.find("cinn_warp_reduce_avg"), std::string::npos);
+  LOG(INFO) << "compiled global_pool2d_avg code:\n\n\n" << source_code;
+
+  using runtime::cuda::CUDAModule;
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+  CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
+  CUDA_CALL(cudaDeviceSynchronize());
+
+  CUdeviceptr Ad, Bd;
+  cuMemAlloc(&Ad, 24 * 24 * 96 * 96 * sizeof(float));
+  cuMemAlloc(&Bd, 24 * 24 * 1 * 1 * sizeof(float));
+
+  std::vector<float> host_data1(24 * 24 * 96 * 96);
+  std::vector<float> host_data2(24 * 24 * 1 * 1);
+  std::vector<float> host_data3(24 * 24 * 1 * 1);
+
+  for (float& v : host_data1) v = static_cast<float>(rand()) / INT_MAX;
+  for (int i = 0; i < 24 * 24; i++) {
+    float* p = &host_data1[i * 96 * 96];
+    float sv = 0;
+    for (int j = 0; j < 96 * 96; j++) {
+      sv += p[j];
+    }
+    host_data3[i] = sv / (96 * 96);
+  }
+  CUDA_CALL(cudaMemcpy(
+      reinterpret_cast<void*>(Ad), host_data1.data(), host_data1.size() * sizeof(float), cudaMemcpyHostToDevice));
+  void* args[] = {&Ad, &Bd};
+  dim3 blocks_per_grid(24, 1, 1);
+  dim3 threads_per_block(32, 24, 1);
+  cuda_module.LaunchKernel(0, "global_pool2d_avg", blocks_per_grid, threads_per_block, args);
+  CUDA_CALL(cudaMemcpy(
+      host_data2.data(), reinterpret_cast<void*>(Bd), 24 * 24 * 1 * 1 * sizeof(float), cudaMemcpyDeviceToHost));
+  for (int i = 0; i < host_data2.size(); i++) {
+    ASSERT_NEAR(host_data2[i], host_data3[i], 1e-5);
+  }
+}
+
+TEST(GlobalPool, pool2d_avg_1_1_7_7) {
+  Context::Global().ResetNameId();
+
+  Target target = common::DefaultNVGPUTarget();
+
+  Expr N(1);
+  Expr C(1);
+  Expr H(7);
+  Expr W(7);
+
+  Placeholder<float> A("X", {N, C, H, W});
+  auto res    = hlir::pe::GlobalPool2d(A, "avg", "pool_out");
+  auto stages = CreateStages(res);
+
+  stages[res[0]]->Bind(0, "blockIdx.x");
+  stages[res[0]]->Bind(1, "threadIdx.y");
+  stages[res[1]]->ComputeAt2(stages[res[0]], 1);
+  stages[res[1]]->Bind(2, "threadIdx.x");
+  stages[res[1]]->SetBuffer("local");
+
+  auto func = cinn::lang::LowerVec("global_pool2d_avg", stages, {A, res[0]}, {}, {}, nullptr, target);
+  CodeGenCUDA_Dev codegen(target);
+  Module::Builder builder("module", target);
+  for (auto& f : func) {
+    builder.AddFunction(f);
+  }
+  auto source_code = codegen.Compile(builder.Build());
+  ASSERT_NE(source_code.find("cinn_warp_reduce_avg"), std::string::npos);
+  LOG(INFO) << "compiled global_pool2d_avg code:\n\n\n" << source_code;
+
+  using runtime::cuda::CUDAModule;
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+  CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
+  CUDA_CALL(cudaDeviceSynchronize());
+
+  CUdeviceptr Ad, Bd;
+  cuMemAlloc(&Ad, 1 * C.as_int32() * 7 * 7 * sizeof(float));
+  cuMemAlloc(&Bd, 1 * C.as_int32() * 1 * 1 * sizeof(float));
+
+  std::vector<float> host_data1(1 * C.as_int32() * 7 * 7);
+  std::vector<float> host_data2(1 * C.as_int32() * 1 * 1);
+  std::vector<float> host_data3(1 * C.as_int32() * 1 * 1);
+
+  for (float& v : host_data1) v = static_cast<float>(rand()) / INT_MAX;
+  for (int i = 0; i < C.as_int32(); i++) {
+    float* p = &host_data1[i * 7 * 7];
+    float sv = 0;
+    for (int j = 0; j < 7 * 7; j++) {
+      sv += p[j];
+    }
+    host_data3[i] = sv / (7 * 7);
+  }
+  CUDA_CALL(cudaMemcpy(
+      reinterpret_cast<void*>(Ad), host_data1.data(), host_data1.size() * sizeof(float), cudaMemcpyHostToDevice));
+  void* args[] = {&Ad, &Bd};
+  dim3 blocks_per_grid(1, 1, 1);
+  dim3 threads_per_block(32, 1, 1);
+  cuda_module.LaunchKernel(0, "global_pool2d_avg", blocks_per_grid, threads_per_block, args);
+  CUDA_CALL(cudaMemcpy(host_data2.data(),
+                       reinterpret_cast<void*>(Bd),
+                       1 * C.as_int32() * 1 * 1 * sizeof(float),
+                       cudaMemcpyDeviceToHost));
+  for (int i = 0; i < host_data2.size(); i++) {
+    ASSERT_NEAR(host_data2[i], host_data3[i], 1e-5);
+  }
+}
+
+TEST(GlobalPool, pool2d_avg_1_32_7_7) {
+  Context::Global().ResetNameId();
+
+  Target target = common::DefaultNVGPUTarget();
+
+  Expr N(1);
+  Expr C(32);
+  Expr H(7);
+  Expr W(7);
+
+  Placeholder<float> A("X", {N, C, H, W});
+  auto res    = hlir::pe::GlobalPool2d(A, "avg", "pool_out");
+  auto stages = CreateStages(res);
+
+  stages[res[0]]->Bind(0, "blockIdx.x");
+  stages[res[0]]->Bind(1, "threadIdx.y");
+  stages[res[1]]->ComputeAt2(stages[res[0]], 1);
+  stages[res[1]]->Bind(2, "threadIdx.x");
+  stages[res[1]]->SetBuffer("local");
+
+  auto func = cinn::lang::LowerVec("global_pool2d_avg", stages, {A, res[0]}, {}, {}, nullptr, target);
+  CodeGenCUDA_Dev codegen(target);
+  Module::Builder builder("module", target);
+  for (auto& f : func) {
+    builder.AddFunction(f);
+  }
+  auto source_code = codegen.Compile(builder.Build());
+  ASSERT_NE(source_code.find("cinn_warp_reduce_avg"), std::string::npos);
+  LOG(INFO) << "compiled global_pool2d_avg code:\n\n\n" << source_code;
+
+  using runtime::cuda::CUDAModule;
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+  CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
+  CUDA_CALL(cudaDeviceSynchronize());
+
+  CUdeviceptr Ad, Bd;
+  cuMemAlloc(&Ad, 1 * C.as_int32() * 7 * 7 * sizeof(float));
+  cuMemAlloc(&Bd, 1 * C.as_int32() * 1 * 1 * sizeof(float));
+
+  std::vector<float> host_data1(1 * C.as_int32() * 7 * 7);
+  std::vector<float> host_data2(1 * C.as_int32() * 1 * 1);
+  std::vector<float> host_data3(1 * C.as_int32() * 1 * 1);
+
+  for (float& v : host_data1) v = static_cast<float>(rand()) / INT_MAX;
+  for (int i = 0; i < C.as_int32(); i++) {
+    float* p = &host_data1[i * 7 * 7];
+    float sv = 0;
+    for (int j = 0; j < 7 * 7; j++) {
+      sv += p[j];
+    }
+    host_data3[i] = sv / (7 * 7);
+  }
+  CUDA_CALL(cudaMemcpy(
+      reinterpret_cast<void*>(Ad), host_data1.data(), host_data1.size() * sizeof(float), cudaMemcpyHostToDevice));
+  void* args[] = {&Ad, &Bd};
+  dim3 blocks_per_grid(1, 1, 1);
+  dim3 threads_per_block(32, 32, 1);
+  cuda_module.LaunchKernel(0, "global_pool2d_avg", blocks_per_grid, threads_per_block, args);
+  CUDA_CALL(cudaMemcpy(host_data2.data(),
+                       reinterpret_cast<void*>(Bd),
+                       1 * C.as_int32() * 1 * 1 * sizeof(float),
+                       cudaMemcpyDeviceToHost));
+  for (int i = 0; i < host_data2.size(); i++) {
+    ASSERT_NEAR(host_data2[i], host_data3[i], 1e-5);
+  }
+}
+
 TEST(CodeGenCUDA2, test_schedule_conv2d_0) {
   Context::Global().ResetNameId();
   Expr N(1);

--- a/cinn/hlir/pe/nn.h
+++ b/cinn/hlir/pe/nn.h
@@ -355,7 +355,9 @@ std::vector<ir::Tensor> Pool2d(const ir::Tensor &tensor,
                                const std::string &data_format = "NCHW",
                                bool adaptive                  = false,
                                const std::string &output_name = UniqName("T_Pool2d_out"));
-
+std::vector<ir::Tensor> GlobalPool2d(const ir::Tensor &tensor,
+                                     const std::string &pool_type,
+                                     const std::string &output_name);
 /**
  * @brief Perform pooling on the depth, height and width dimension of the tensor.
  *        Depth, height and width axis is determined by the data_format string in which 'D' means depth, 'H' means

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -112,7 +112,7 @@ void Conv2d_NCHWc_Schedule_CPU(poly::StageMap stages,
                                const common::Target &target,
                                const std::string &key,
                                bool do_padding);
-
+void GlobalPoolScheduleGPU(poly::StageMap stages, const std::vector<ir::Tensor> &output, const common::Target &target);
 void PoolScheduleCPU(poly::StageMap stages, const ir::Tensor &output, const common::Target &target);
 void PoolScheduleGPU(poly::StageMap stages, ir::Tensor &output, const common::Target &target);
 

--- a/cinn/optim/transform_gpu_forloop_test.cc
+++ b/cinn/optim/transform_gpu_forloop_test.cc
@@ -94,7 +94,7 @@ TEST(TransformGpuForloops, multiple_thread_axis) {
   stages[D]->Bind(0, "blockIdx.x");
   stages[D]->Bind(1, "blockIdx.y");
   stages[D]->Bind(2, "threadIdx.x");
-  stages[C]->ComputeAt(stages[D], 1);
+  stages[C]->ComputeAt(stages[D], 2);
 
   auto func = Lower("elementwise_add", stages, {A, B, C, D});
 
@@ -105,12 +105,9 @@ function elementwise_add (_A, _B, _C, _D)
 {
   if ((blockIdx.x < 10)) {
     if ((blockIdx.y < 10)) {
-      {
-        for (j, 0, 200)
+      if ((threadIdx.x < 200)) {
         {
-          C[((10 * blockIdx.x) + blockIdx.y), j] = (A[((10 * blockIdx.x) + blockIdx.y), j] * B[((10 * blockIdx.x) + blockIdx.y), j])
-        }
-        if ((threadIdx.x < 200)) {
+          C[((10 * blockIdx.x) + blockIdx.y), threadIdx.x] = (A[((10 * blockIdx.x) + blockIdx.y), threadIdx.x] * B[((10 * blockIdx.x) + blockIdx.y), threadIdx.x])
           D[((10 * blockIdx.x) + blockIdx.y), threadIdx.x] = (C[((10 * blockIdx.x) + blockIdx.y), threadIdx.x] + A[((10 * blockIdx.x) + blockIdx.y), threadIdx.x])
         }
       }

--- a/cinn/poly/stage.cc
+++ b/cinn/poly/stage.cc
@@ -1205,6 +1205,24 @@ void CacheReadWriteReplace(std::vector<ir::Tensor> &readers, ir::Tensor cache_te
   }
 }
 
+void Stage::SetBuffer(const std::string &memory_type) {
+  tensor_->WithBuffer(memory_type, "_" + this->tensor_->name + "_temp_buffer");
+  if (memory_type == "shared") {
+    this->SetScope(ScopeKind::kShared);
+  } else if (memory_type == "local") {
+    this->SetScope(ScopeKind::kLocal);
+  } else if (memory_type == "global") {
+    this->SetScope(ScopeKind::kGlobal);
+  } else {
+    CINN_NOT_IMPLEMENTED
+  }
+  if (tensor_->buffer.defined()) {
+    VLOG(2) << "Has tensor_->buffer: " << tensor_->buffer->name;
+  } else {
+    VLOG(2) << "No tensor_->buffer";
+  }
+}
+
 /*
  * To create a read cache:
  * 1. create a cache write stage for cache assign.

--- a/cinn/poly/stage.h
+++ b/cinn/poly/stage.h
@@ -331,6 +331,8 @@ class Stage : public Object {
   Iterator Fuse(const std::vector<int>& levels);
   Iterator Fuse(const std::string& level0, const std::string& level1);
 
+  void SetBuffer(const std::string& memory_type);
+
   const isl::set& domain() const { return domain_; }
   const isl::map& transform() const { return transform_; }
   isl::set transformed_domain() const;

--- a/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -52,6 +52,38 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
   REGISTER_EXTERN_FUNC_1_IN_1_OUT_FLOAT(isfinite);
   REGISTER_EXTERN_FUNC_1_IN_1_OUT_FLOAT(isinf);
 
+  FunctionProto::shape_inference_t inference_shape_globalpool = [](const std::vector<cinn::ir::Expr> &args,
+                                                                   int offset) {
+    auto t = args[0].as_tensor();
+    std::vector<cinn::ir::Expr> shape;
+    shape.push_back(t->shape[0]);
+    shape.push_back(t->shape[1]);
+    shape.push_back(cinn::ir::Expr(1));
+    shape.push_back(cinn::ir::Expr(1));
+    return shape;
+  };
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_warp_reduce_max, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .AddInputType<int>()
+      .End();
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_warp_reduce_sum, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .AddInputType<int>()
+      .End();
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_warp_reduce_avg, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .AddInputType<int>()
+      .End();
+
   return true;
 }
 


### PR DESCRIPTION
1. 修复 compute_at 的情况下，cuda kernel 的某些赋值语句会被执行多次。
如果 A 的 compute 如下
```
compute_A {
  for (threadIdx.x, 0, 32) {
    buf_A[threadIdx.x] = .....;
  }
}
```
如果 B 的 compute 如下
```
compute_B {
  for (blockIdx.x, 0, 16} {
    for (threadIdx.y, 0, 32) {
      buf_B[block_Idx.x * 32 + threadIdx.y] = buf_A[threadIdx.y];
    }
  }
}
```

如果 A 在 B 中计算
```
compute_A_in_B {
 for (blockIdx.x, 0, 16} {
   for (threadIdx.y, 0, 32) {
     for (threadIdx.x, 0, 32) {
       buf_A[threadIdx.x] = .....;
     }
     // when launched the store operation will run 32 times
     buf_B[block_Idx.x * 32 + threadIdx.y] = buf_A[threadIdx.y];
   }
 }
}
```
这个生成的 kernel 的 launch param 的 grid 比 B 的范围大（多了 threadIdx.x）, 所以需要限制 B 的赋值语句在某一个 threadIdx.x 对应的 thread 中执行。
```
compute_A_in_B {
 for (blockIdx.x, 0, 16} {
   for (threadIdx.y, 0, 32) {
     for (threadIdx.x, 0, 32) {
       buf_A[threadIdx.x] = .....;
     }
     if (threadIdx.x == 0) {
       // make sure only one thread runs this store operation
       buf_B[block_Idx.x * 32 + threadIdx.y] = buf_A[threadIdx.y];
     }
   }
 }
}
```



2. 增加 warp shuffle reduce intrinsics, 在 global pooling 的情况下，会利用 warp 同步指令来计算。