### PR TITLE
Use the stream created by Paddle in CINN cuda kernels.

### DIFF
--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -28,9 +28,9 @@ namespace cinn {
 namespace backends {
 using ir::Module;
 
-void Compiler::Build(const Module& module, const std::string& code) {
+void Compiler::Build(const Module& module, const std::string& code, void* stream) {
   if (target_.arch == Target::Arch::NVGPU) {
-    CompileCudaModule(module, code);
+    CompileCudaModule(module, code, stream);
   } else if (target_.arch == Target::Arch::X86) {
     CompileX86Module(module);
   } else {
@@ -65,7 +65,7 @@ void Compiler::BuildDefault(const Module& module) {
   }
 }
 
-void Compiler::CompileCudaModule(const Module& module, const std::string& code) {
+void Compiler::CompileCudaModule(const Module& module, const std::string& code, void* stream) {
 #ifdef CINN_WITH_CUDA
   auto _host_module_device_module_ = SplitCudaAndHostModule(module);  // NOLINT
   auto& host_module                = std::get<0>(_host_module_device_module_);
@@ -95,8 +95,8 @@ void Compiler::CompileCudaModule(const Module& module, const std::string& code) 
 
       backends::RuntimeSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_ptr_",
                                                             reinterpret_cast<void*>(fn_kernel));
-      cudaStream_t stream = nullptr;
-      backends::RuntimeSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_", stream);
+      backends::RuntimeSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_",
+                                                            static_cast<cudaStream_t>(stream));
     }
   }
 

--- a/cinn/backends/compiler.h
+++ b/cinn/backends/compiler.h
@@ -39,7 +39,7 @@ class Compiler final {
   /**
    * Compile and link to a CINN module.
    */
-  void Build(const ir::Module& module, const std::string& code = "");
+  void Build(const ir::Module& module, const std::string& code = "", void* stream = nullptr);
 
   void ExportObject(const std::string& path);
 
@@ -54,7 +54,7 @@ class Compiler final {
   lower_func_ptr_t Lookup(absl::string_view fn_name);
 
  private:
-  void CompileCudaModule(const ir::Module& module, const std::string& code = "");
+  void CompileCudaModule(const ir::Module& module, const std::string& code = "", void* stream = nullptr);
 
   void CompileX86Module(const ir::Module& module);
 

--- a/cinn/backends/llvm/execution_engine.cc
+++ b/cinn/backends/llvm/execution_engine.cc
@@ -15,7 +15,6 @@
 #include "cinn/backends/llvm/execution_engine.h"
 
 #include <absl/strings/string_view.h>
-#include <cuda_runtime.h>
 #include <llvm/ADT/Triple.h>
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/Config/llvm-config.h>
@@ -227,12 +226,6 @@ void ExecutionEngine::RegisterRuntimeSymbols() {
   for (const auto &_name_addr_ : registry.All()) {
     auto &name = std::get<0>(_name_addr_);
     auto &addr = std::get<1>(_name_addr_);
-    if (name.find("stream_ptr_") != std::string::npos) {
-      VLOG(2) << "-- Register [name = " << name << ", stream addr = " << addr
-              << ", stream = " << *static_cast<cudaStream_t *>(addr) << "] to ExecutionEngine";
-    } else {
-      VLOG(2) << "-- Register [name = " << name << ", val = " << addr << "] to ExecutionEngine";
-    }
     llvm::cantFail(jit_->define(llvm::orc::absoluteSymbols(
         {{session->intern(name), {llvm::pointerToJITTargetAddress(addr), llvm::JITSymbolFlags::None}}})));
   }

--- a/cinn/backends/llvm/execution_engine.cc
+++ b/cinn/backends/llvm/execution_engine.cc
@@ -15,6 +15,7 @@
 #include "cinn/backends/llvm/execution_engine.h"
 
 #include <absl/strings/string_view.h>
+#include <cuda_runtime.h>
 #include <llvm/ADT/Triple.h>
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/Config/llvm-config.h>
@@ -226,6 +227,12 @@ void ExecutionEngine::RegisterRuntimeSymbols() {
   for (const auto &_name_addr_ : registry.All()) {
     auto &name = std::get<0>(_name_addr_);
     auto &addr = std::get<1>(_name_addr_);
+    if (name.find("stream_ptr_") != std::string::npos) {
+      VLOG(2) << "-- Register [name = " << name << ", stream addr = " << addr
+              << ", stream = " << *static_cast<cudaStream_t *>(addr) << "] to ExecutionEngine";
+    } else {
+      VLOG(2) << "-- Register [name = " << name << ", val = " << addr << "] to ExecutionEngine";
+    }
     llvm::cantFail(jit_->define(llvm::orc::absoluteSymbols(
         {{session->intern(name), {llvm::pointerToJITTargetAddress(addr), llvm::JITSymbolFlags::None}}})));
   }

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -191,13 +191,13 @@ void Program::Export(const std::vector<std::string>& persistent_vars, const std:
   fclose(f);
 }
 
-void Program::Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs) {
+void Program::Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs, const cudaStream_t& stream) {
   for (auto& ins : instrs_) {
-    ins->Run(name2podargs);
+    ins->Run(name2podargs, false, stream);
   }
 #ifdef CINN_WITH_CUDA
   if (instrs_[0]->target_.arch == Target::Arch::NVGPU) {
-    CUDA_CALL(cudaDeviceSynchronize());
+    // CUDA_CALL(cudaDeviceSynchronize());
   }
 #endif
 }

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -57,7 +57,8 @@ class Program {
   /**
    * Execute the program -- that is running all the instructions inside it.
    */
-  void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr);
+  void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
+               const cudaStream_t& stream                                  = nullptr);
 
   void ExecuteTest(int repeat_);
 

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -57,8 +57,7 @@ class Program {
   /**
    * Execute the program -- that is running all the instructions inside it.
    */
-  void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
-               const cudaStream_t& stream                                  = nullptr);
+  void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr, void* stream = nullptr);
 
   void ExecuteTest(int repeat_);
 
@@ -97,7 +96,9 @@ class GraphCompiler final {
   };
 
   // Compile with a packing option and result, to be extended easily.
-  CompilationResult Build(const CompileOptions& options, std::unordered_set<std::string>&& fetch_var_ids = {});
+  CompilationResult Build(const CompileOptions& options,
+                          std::unordered_set<std::string>&& fetch_var_ids = {},
+                          void* stream                                    = nullptr);
   void ExportObject(const std::string& path) { compiler_->ExportObject(path); }
 
   std::unique_ptr<Program> Build(const std::string& code = "");

--- a/cinn/hlir/framework/instruction.h
+++ b/cinn/hlir/framework/instruction.h
@@ -66,7 +66,9 @@ class Instruction {
   /**
    * Run the Instruction.
    */
-  void Run(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr, bool dryrun = false);
+  void Run(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
+           bool dryrun                                                 = false,
+           const cudaStream_t& stream                                  = nullptr);
 
   std::vector<std::vector<std::string>> GetInArgs() { return in_args_; }
   std::vector<std::vector<std::string>> GetOutArgs() { return out_args_; }

--- a/cinn/hlir/framework/instruction.h
+++ b/cinn/hlir/framework/instruction.h
@@ -68,7 +68,7 @@ class Instruction {
    */
   void Run(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
            bool dryrun                                                 = false,
-           const cudaStream_t& stream                                  = nullptr);
+           void* stream                                                = nullptr);
 
   std::vector<std::vector<std::string>> GetInArgs() { return in_args_; }
   std::vector<std::vector<std::string>> GetOutArgs() { return out_args_; }

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -69,10 +69,11 @@ void cinn_gpu_cublas_mul(const std::vector<int> &attrs,
                          cinn_buffer_t *output,
                          const cudaStream_t &stream) {
   cublasHandle_t &cublas = CublasHandle::get_instance().GetCublasHandle();
-  float *x_data          = reinterpret_cast<float *>(input1->memory);
-  float *y_data          = reinterpret_cast<float *>(input2->memory);
-  float *out_data        = reinterpret_cast<float *>(output->memory);
-  int M                  = 1;
+  cublasSetStream(cublas, stream);
+  float *x_data   = reinterpret_cast<float *>(input1->memory);
+  float *y_data   = reinterpret_cast<float *>(input2->memory);
+  float *out_data = reinterpret_cast<float *>(output->memory);
+  int M           = 1;
   CHECK_GE(attrs.size(), 6);
   for (int i = 0; i < attrs[attrs.size() - 2]; i++) {
     M *= attrs[i];
@@ -156,9 +157,10 @@ void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int> &attr,
   GetAttrValue(attr, output_w, -1);
 
   cudnnHandle_t &handle = CudnnHandle::get_instance().GetCudnnHandle();
-  float *_x             = reinterpret_cast<float *>(x->memory);
-  float *_w             = reinterpret_cast<float *>(w->memory);
-  float *_y             = reinterpret_cast<float *>(y->memory);
+  CUDNN_CALL(cudnnSetStream(handle, stream));
+  float *_x = reinterpret_cast<float *>(x->memory);
+  float *_w = reinterpret_cast<float *>(w->memory);
+  float *_y = reinterpret_cast<float *>(y->memory);
 
   cudnnTensorDescriptor_t x_desc;
   CUDNN_CALL(cudnnCreateTensorDescriptor(&x_desc));
@@ -246,9 +248,10 @@ void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, 
   GetAttrValue(attr, output_w, -1);
 
   cudnnHandle_t &handle = CudnnHandle::get_instance().GetCudnnHandle();
-  float *_w             = reinterpret_cast<float *>(w->memory);
-  float *_dy            = reinterpret_cast<float *>(dy->memory);
-  float *_dx            = reinterpret_cast<float *>(dx->memory);
+  CUDNN_CALL(cudnnSetStream(handle, stream));
+  float *_w  = reinterpret_cast<float *>(w->memory);
+  float *_dy = reinterpret_cast<float *>(dy->memory);
+  float *_dx = reinterpret_cast<float *>(dx->memory);
 
   cudnnTensorDescriptor_t x_desc;
   CUDNN_CALL(cudnnCreateTensorDescriptor(&x_desc));
@@ -336,6 +339,7 @@ void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string
   GetAttrValue(attr, output_w, -1);
 
   cudnnHandle_t &handle = CudnnHandle::get_instance().GetCudnnHandle();
+  CUDNN_CALL(cudnnSetStream(handle, stream));
 
   float *_x  = reinterpret_cast<float *>(x->memory);
   float *_dy = reinterpret_cast<float *>(dy->memory);
@@ -407,6 +411,7 @@ void cinn_gpu_cudnn_pool2d(const std::vector<int> &attrs,
                            cinn_buffer_t *output,
                            const cudaStream_t &stream) {
   cudnnHandle_t &cudnn = CudnnHandle::get_instance().GetCudnnHandle();
+  CUDNN_CALL(cudnnSetStream(cudnn, stream));
   CHECK_EQ(attrs.size(), 17);
   // Here the input paddings are pad_top, pad_bottom, pad_left, pad_right.
   // Since pad_top==pad_bottom and pad_left==pad_rifht, we only take pad_top and pad_left.
@@ -495,8 +500,9 @@ void cinn_gpu_cudnn_softmax(const std::vector<int> &attrs,
   rank = shape.size();
 
   cudnnHandle_t &cudnn = CudnnHandle::get_instance().GetCudnnHandle();
-  float *in_data       = reinterpret_cast<float *>(input->memory);
-  float *out_data      = reinterpret_cast<float *>(output->memory);
+  CUDNN_CALL(cudnnSetStream(cudnn, stream));
+  float *in_data  = reinterpret_cast<float *>(input->memory);
+  float *out_data = reinterpret_cast<float *>(output->memory);
 
   cudnnTensorDescriptor_t in_desc;
   CUDNN_CALL(cudnnCreateTensorDescriptor(&in_desc));

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -66,7 +66,8 @@ float *CudnnHandle::GetWorkSpace(size_t size) {
 void cinn_gpu_cublas_mul(const std::vector<int> &attrs,
                          cinn_buffer_t *input1,
                          cinn_buffer_t *input2,
-                         cinn_buffer_t *output) {
+                         cinn_buffer_t *output,
+                         const cudaStream_t &stream) {
   cublasHandle_t &cublas = CublasHandle::get_instance().GetCublasHandle();
   float *x_data          = reinterpret_cast<float *>(input1->memory);
   float *y_data          = reinterpret_cast<float *>(input2->memory);
@@ -132,7 +133,8 @@ void cinn_call_cuda_kernel(void *kernel_fn,
 void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int> &attr,
                            cinn_buffer_t *x,
                            cinn_buffer_t *w,
-                           cinn_buffer_t *y) {
+                           cinn_buffer_t *y,
+                           const cudaStream_t &stream) {
   GetAttrValue(attr, input_n, -1);
   GetAttrValue(attr, input_c, -1);
   GetAttrValue(attr, input_h, -1);
@@ -221,7 +223,8 @@ void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int> &attr,
 void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, int> &attr,
                                          cinn_buffer_t *w,
                                          cinn_buffer_t *dy,
-                                         cinn_buffer_t *dx) {
+                                         cinn_buffer_t *dx,
+                                         const cudaStream_t &stream) {
   GetAttrValue(attr, input_n, -1);
   GetAttrValue(attr, input_c, -1);
   GetAttrValue(attr, input_h, -1);
@@ -310,7 +313,8 @@ void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, 
 void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string, int> &attr,
                                            cinn_buffer_t *x,
                                            cinn_buffer_t *dy,
-                                           cinn_buffer_t *dw) {
+                                           cinn_buffer_t *dw,
+                                           const cudaStream_t &stream) {
   GetAttrValue(attr, input_n, -1);
   GetAttrValue(attr, input_c, -1);
   GetAttrValue(attr, input_h, -1);
@@ -400,7 +404,8 @@ void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string
 void cinn_gpu_cudnn_pool2d(const std::vector<int> &attrs,
                            const std::vector<std::string> &str_attrs,
                            cinn_buffer_t *input,
-                           cinn_buffer_t *output) {
+                           cinn_buffer_t *output,
+                           const cudaStream_t &stream) {
   cudnnHandle_t &cudnn = CudnnHandle::get_instance().GetCudnnHandle();
   CHECK_EQ(attrs.size(), 17);
   // Here the input paddings are pad_top, pad_bottom, pad_left, pad_right.
@@ -468,7 +473,10 @@ void cinn_gpu_cudnn_pool2d(const std::vector<int> &attrs,
   cudnnDestroyPoolingDescriptor(pooling_desc);
 }
 
-void cinn_gpu_cudnn_softmax(const std::vector<int> &attrs, cinn_buffer_t *input, cinn_buffer_t *output) {
+void cinn_gpu_cudnn_softmax(const std::vector<int> &attrs,
+                            cinn_buffer_t *input,
+                            cinn_buffer_t *output,
+                            const cudaStream_t &stream) {
   std::vector<int> shape;
   int rank = attrs.size() - 1;
   for (int i = 0; i < rank; i++) {

--- a/cinn/runtime/cuda/cuda_util.h
+++ b/cinn/runtime/cuda/cuda_util.h
@@ -100,36 +100,36 @@ void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int>& attr,
                            cinn_buffer_t* x,
                            cinn_buffer_t* w,
                            cinn_buffer_t* y,
-                           const cudaStream_t& stream);
+                           const cudaStream_t& stream = nullptr);
 
 void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, int>& attr,
                                          cinn_buffer_t* w,
                                          cinn_buffer_t* dy,
                                          cinn_buffer_t* dx,
-                                         const cudaStream_t& stream);
+                                         const cudaStream_t& stream = nullptr);
 
 void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string, int>& attr,
                                            cinn_buffer_t* x,
                                            cinn_buffer_t* dy,
                                            cinn_buffer_t* dw,
-                                           const cudaStream_t& stream);
+                                           const cudaStream_t& stream = nullptr);
 
 void cinn_gpu_cudnn_pool2d(const std::vector<int>& attrs,
                            const std::vector<std::string>& str_attrs,
                            cinn_buffer_t* input,
                            cinn_buffer_t* output,
-                           const cudaStream_t& stream);
+                           const cudaStream_t& stream = nullptr);
 
 void cinn_gpu_cudnn_softmax(const std::vector<int>& attrs,
                             cinn_buffer_t* input,
                             cinn_buffer_t* output,
-                            const cudaStream_t& stream);
+                            const cudaStream_t& stream = nullptr);
 
 void cinn_gpu_cublas_mul(const std::vector<int>& attrs,
                          cinn_buffer_t* input1,
                          cinn_buffer_t* input2,
                          cinn_buffer_t* output,
-                         const cudaStream_t& stream);
+                         const cudaStream_t& stream = nullptr);
 }  // namespace cuda
 }  // namespace runtime
 }  // namespace cinn

--- a/cinn/runtime/cuda/cuda_util.h
+++ b/cinn/runtime/cuda/cuda_util.h
@@ -99,29 +99,37 @@ void cinn_call_cuda_kernel(void* kernel_fn,
 void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int>& attr,
                            cinn_buffer_t* x,
                            cinn_buffer_t* w,
-                           cinn_buffer_t* y);
+                           cinn_buffer_t* y,
+                           const cudaStream_t& stream);
 
 void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, int>& attr,
                                          cinn_buffer_t* w,
                                          cinn_buffer_t* dy,
-                                         cinn_buffer_t* dx);
+                                         cinn_buffer_t* dx,
+                                         const cudaStream_t& stream);
 
 void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string, int>& attr,
                                            cinn_buffer_t* x,
                                            cinn_buffer_t* dy,
-                                           cinn_buffer_t* dw);
+                                           cinn_buffer_t* dw,
+                                           const cudaStream_t& stream);
 
 void cinn_gpu_cudnn_pool2d(const std::vector<int>& attrs,
                            const std::vector<std::string>& str_attrs,
                            cinn_buffer_t* input,
-                           cinn_buffer_t* output);
+                           cinn_buffer_t* output,
+                           const cudaStream_t& stream);
 
-void cinn_gpu_cudnn_softmax(const std::vector<int>& attrs, cinn_buffer_t* input, cinn_buffer_t* output);
+void cinn_gpu_cudnn_softmax(const std::vector<int>& attrs,
+                            cinn_buffer_t* input,
+                            cinn_buffer_t* output,
+                            const cudaStream_t& stream);
 
 void cinn_gpu_cublas_mul(const std::vector<int>& attrs,
                          cinn_buffer_t* input1,
                          cinn_buffer_t* input2,
-                         cinn_buffer_t* output);
+                         cinn_buffer_t* output,
+                         const cudaStream_t& stream);
 }  // namespace cuda
 }  // namespace runtime
 }  // namespace cinn


### PR DESCRIPTION
Use the stream created by Paddle in CINN cuda kernels. After that, the training speed of ResNet50 is increased by approximately 25%. The more detailed performance gains are shown below:
![image](https://user-images.githubusercontent.com/17102274/143250132-f5a53475-9236-41df-9a11-0001481178f3.png)

Combining the use of this pr and https://github.com/PaddlePaddle/Paddle/pull/37337 can achieve the above-mentioned performance gains.