### PR TITLE
Add callback to cinn_buffer_t

### DIFF
--- a/cinn/runtime/cinn_runtime.cc
+++ b/cinn/runtime/cinn_runtime.cc
@@ -161,6 +161,33 @@ cinn_buffer_t* cinn_buffer_new(cinn_device_kind_t device, cinn_type_t type, cons
   return cinn_buffer_t::new_(device, type, shape, align);
 }
 
+cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer) {
+  if (buffer->memory == NULL) {
+    fprintf(stderr, "cinn_buffer_t's memory is NULL in callback interface.");
+    return NULL;
+  }
+  cinn_buffer_callback_interface* ret = malloc(sizeof(cinn_buffer_callback_interface));
+  ret->cinn_buffer_                   = buffer;
+  ret->external_malloc_               = NULL;
+  ret->external_free_                 = NULL;
+}
+
+cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer,
+                                                                   int (*external_malloc)(void* context,
+                                                                                          struct cinn_buffer_t* buf),
+                                                                   int (*external_free)(void* context,
+                                                                                        struct cinn_buffer_t* buf)) {
+  if (buffer->memory != NULL) {
+    fprintf(stderr, "cinn_buffer_t's memory is not NULL in callback interface.");
+    return NULL;
+  }
+  cinn_buffer_callback_interface* ret = malloc(sizeof(cinn_buffer_callback_interface));
+  ret->cinn_buffer_                   = buffer;
+  ret->external_malloc_               = external_malloc;
+  ret->external_free_                 = external_free;
+  return ret;
+}
+
 cinn_pod_value_t::operator double() const {
   CINN_CHECK_EQ(type_code_, ::cinn_type_code<double>());
   return value_.v_float64;

--- a/cinn/runtime/cinn_runtime.cc
+++ b/cinn/runtime/cinn_runtime.cc
@@ -161,34 +161,6 @@ cinn_buffer_t* cinn_buffer_new(cinn_device_kind_t device, cinn_type_t type, cons
   return cinn_buffer_t::new_(device, type, shape, align);
 }
 
-cinn_buffer_callback_interface* cinn_buffer_interface_with_mem(struct cinn_buffer_t* buffer) {
-  if (buffer->memory == NULL) {
-    fprintf(stderr, "cinn_buffer_t's memory is NULL in callback interface.");
-    return NULL;
-  }
-  cinn_buffer_callback_interface* ret = (cinn_buffer_callback_interface*)malloc(sizeof(cinn_buffer_callback_interface));
-  ret->cinn_buffer_                   = buffer;
-  ret->external_malloc_               = NULL;
-  ret->external_free_                 = NULL;
-  return ret;
-}
-
-cinn_buffer_callback_interface* cinn_buffer_interface_with_callback(struct cinn_buffer_t* buffer,
-                                                                    int (*external_malloc)(void* context,
-                                                                                           struct cinn_buffer_t* buf),
-                                                                    int (*external_free)(void* context,
-                                                                                         struct cinn_buffer_t* buf)) {
-  if (buffer->memory != NULL) {
-    fprintf(stderr, "cinn_buffer_t's memory is not NULL in callback interface.");
-    return NULL;
-  }
-  cinn_buffer_callback_interface* ret = (cinn_buffer_callback_interface*)malloc(sizeof(cinn_buffer_callback_interface));
-  ret->cinn_buffer_                   = buffer;
-  ret->external_malloc_               = external_malloc;
-  ret->external_free_                 = external_free;
-  return ret;
-}
-
 cinn_pod_value_t::operator double() const {
   CINN_CHECK_EQ(type_code_, ::cinn_type_code<double>());
   return value_.v_float64;

--- a/cinn/runtime/cinn_runtime.cc
+++ b/cinn/runtime/cinn_runtime.cc
@@ -95,6 +95,10 @@ cinn_buffer_t* cinn_buffer_new_default(int target, uint64_t memory_size, int ali
   buf->memory_size          = memory_size;
   buf->align                = align;
   buf->lazy                 = true;
+#ifdef __cplusplus
+  buf->external_malloc = nullptr;
+  buf->external_free   = nullptr;
+#endif  // __cplusplus
   // NOTE set device_interface for each buffer.
   switch (buf->device) {
     case cinn_x86_device:
@@ -154,6 +158,10 @@ struct cinn_buffer_t* cinn_buffer_t::new_(cinn_device_kind_t device,
 
   buf->dimensions = dimensions;
   buf->align      = align;
+#ifdef __cplusplus
+  buf->external_malloc = nullptr;
+  buf->external_free   = nullptr;
+#endif  // __cplusplus
   return buf;
 }
 

--- a/cinn/runtime/cinn_runtime.cc
+++ b/cinn/runtime/cinn_runtime.cc
@@ -161,27 +161,28 @@ cinn_buffer_t* cinn_buffer_new(cinn_device_kind_t device, cinn_type_t type, cons
   return cinn_buffer_t::new_(device, type, shape, align);
 }
 
-cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer) {
+cinn_buffer_callback_interface* cinn_buffer_interface_with_mem(struct cinn_buffer_t* buffer) {
   if (buffer->memory == NULL) {
     fprintf(stderr, "cinn_buffer_t's memory is NULL in callback interface.");
     return NULL;
   }
-  cinn_buffer_callback_interface* ret = malloc(sizeof(cinn_buffer_callback_interface));
+  cinn_buffer_callback_interface* ret = (cinn_buffer_callback_interface*)malloc(sizeof(cinn_buffer_callback_interface));
   ret->cinn_buffer_                   = buffer;
   ret->external_malloc_               = NULL;
   ret->external_free_                 = NULL;
+  return ret;
 }
 
-cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer,
-                                                                   int (*external_malloc)(void* context,
-                                                                                          struct cinn_buffer_t* buf),
-                                                                   int (*external_free)(void* context,
-                                                                                        struct cinn_buffer_t* buf)) {
+cinn_buffer_callback_interface* cinn_buffer_interface_with_callback(struct cinn_buffer_t* buffer,
+                                                                    int (*external_malloc)(void* context,
+                                                                                           struct cinn_buffer_t* buf),
+                                                                    int (*external_free)(void* context,
+                                                                                         struct cinn_buffer_t* buf)) {
   if (buffer->memory != NULL) {
     fprintf(stderr, "cinn_buffer_t's memory is not NULL in callback interface.");
     return NULL;
   }
-  cinn_buffer_callback_interface* ret = malloc(sizeof(cinn_buffer_callback_interface));
+  cinn_buffer_callback_interface* ret = (cinn_buffer_callback_interface*)malloc(sizeof(cinn_buffer_callback_interface));
   ret->cinn_buffer_                   = buffer;
   ret->external_malloc_               = external_malloc;
   ret->external_free_                 = external_free;

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -294,15 +294,20 @@ typedef struct cinn_buffer_callback_interface {
 
 #ifdef __cplusplus
   struct cinn_buffer_t* get_cinn_buffer(void* context) {
-    if (cinn_buffer_->memory == NULL) {
+    if (cinn_buffer_ != NULL && cinn_buffer_->memory == NULL) {
       (*external_malloc_)(context, cinn_buffer_);
     }
     return cinn_buffer_;
   }
 
   int free_cinn_buffer(void* context) {
-    if (cinn_buffer_->memory != NULL) {
-      return (*external_free_)(context, cinn_buffer_);
+    if (cinn_buffer_ != NULL && cinn_buffer_->memory != NULL) {
+      int ret = (*external_free_)(context, cinn_buffer_);
+      if (cinn_buffer_ != NULL) {
+        delete cinn_buffer_;
+        cinn_buffer_ = NULL;  // Should we set to NULL or keep as meta info?
+      }
+      return ret;
     }
     return -1;
   }
@@ -313,17 +318,17 @@ typedef struct cinn_buffer_callback_interface {
 // Creates cinn_buffer_callback_interface, used when external framework malloc
 // cinn_buffer_t from its memory. In this case, the input cinn_buffer_t's
 // memory shouldn't be NULL
-cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer);
+cinn_buffer_callback_interface* cinn_buffer_interface_with_mem(struct cinn_buffer_t* buffer);
 
 // Creates cinn_buffer_callback_interface, used when external framework doesn't
 // malloc cinn_buffer_t, but gives the callbacks to let CINN control malloc and
 // free. This function still needs cinn_buffer_t* as an input because
 // cinn_buffer_t contains shape, device, type information and so on.
-cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer,
-                                                                   int (*external_malloc)(void* context,
-                                                                                          struct cinn_buffer_t* buf),
-                                                                   int (*external_free)(void* context,
-                                                                                        struct cinn_buffer_t* buf));
+cinn_buffer_callback_interface* cinn_buffer_interface_with_callback(struct cinn_buffer_t* buffer,
+                                                                    int (*external_malloc)(void* context,
+                                                                                           struct cinn_buffer_t* buf),
+                                                                    int (*external_free)(void* context,
+                                                                                         struct cinn_buffer_t* buf));
 
 #ifdef __cplusplus
 extern "C" {

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -204,13 +204,15 @@ typedef struct cinn_buffer_t {
         dimensions(0),
         lazy(true),
         memory_size(0),
-        align(0) {}
+        align(0),
+        external_malloc(NULL),
+        external_free(NULL) {}
 
   static struct cinn_buffer_t* new_(cinn_device_kind_t device,
                                     cinn_type_t type,
                                     const std::vector<int>& shape,
                                     int align = 0);
-  static void delete_(struct cinn_buffer_t* x) { delete x; }
+  static void delete_(struct cinn_buffer_t* x) { free(x); }
 
   ~cinn_buffer_t() {}
 
@@ -256,11 +258,11 @@ typedef struct cinn_buffer_t {
 
   // The callback to control memory alloc. It is useful in Paddle-CINN
   // where the memory is managed out of CINN.
-  std::function<int(void*, struct cinn_buffer_t*)> external_malloc;
+  std::function<int(void*, struct cinn_buffer_t*)>* external_malloc;
 
   // The callback to control memory free. It is useful in Paddle-CINN
   // where the memory is managed out of CINN.
-  std::function<int(void*, struct cinn_buffer_t*)> external_free;
+  std::function<int(void*, struct cinn_buffer_t*)>* external_free;
 
 #endif  // __cplusplus
 } cinn_buffer_t;

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -284,6 +284,47 @@ inline double cinn_buffer_load_float64(struct cinn_buffer_t* buf, uint32_t index
 }
 #endif  // __cplusplus
 
+// The interface for access cinn_buffer_t, or use callback to control memory.
+// It is useful in Paddle-CINN where the memory is allocated out of CINN, that
+// is, Paddle training framework.
+typedef struct cinn_buffer_callback_interface {
+  struct cinn_buffer_t* cinn_buffer_;
+  int (*external_malloc_)(void* context, struct cinn_buffer_t* buf);
+  int (*external_free_)(void* context, struct cinn_buffer_t* buf);
+
+#ifdef __cplusplus
+  struct cinn_buffer_t* get_cinn_buffer(void* context) {
+    if (cinn_buffer_->memory == NULL) {
+      (*external_malloc_)(context, cinn_buffer_);
+    }
+    return cinn_buffer_;
+  }
+
+  int free_cinn_buffer(void* context) {
+    if (cinn_buffer_->memory != NULL) {
+      return (*external_free_)(context, cinn_buffer_);
+    }
+    return -1;
+  }
+#endif  // __cplusplus
+
+} cinn_buffer_callback_interface;
+
+// Creates cinn_buffer_callback_interface, used when external framework malloc
+// cinn_buffer_t from its memory. In this case, the input cinn_buffer_t's
+// memory shouldn't be NULL
+cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer);
+
+// Creates cinn_buffer_callback_interface, used when external framework doesn't
+// malloc cinn_buffer_t, but gives the callbacks to let CINN control malloc and
+// free. This function still needs cinn_buffer_t* as an input because
+// cinn_buffer_t contains shape, device, type information and so on.
+cinn_buffer_callback_interface* cinn_buffer_callback_interface_new(struct cinn_buffer_t* buffer,
+                                                                   int (*external_malloc)(void* context,
+                                                                                          struct cinn_buffer_t* buf),
+                                                                   int (*external_free)(void* context,
+                                                                                        struct cinn_buffer_t* buf));
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -256,11 +256,11 @@ typedef struct cinn_buffer_t {
 
   // The callback to control memory alloc. It is useful in Paddle-CINN
   // where the memory is managed out of CINN.
-  std::function<int(void*)> external_malloc;
+  std::function<int(void*, struct cinn_buffer_t*)> external_malloc;
 
   // The callback to control memory free. It is useful in Paddle-CINN
   // where the memory is managed out of CINN.
-  std::function<int(void*)> external_free;
+  std::function<int(void*, struct cinn_buffer_t*)> external_free;
 
 #endif  // __cplusplus
 } cinn_buffer_t;

--- a/cinn/runtime/cinn_runtime.h
+++ b/cinn/runtime/cinn_runtime.h
@@ -212,9 +212,16 @@ typedef struct cinn_buffer_t {
                                     cinn_type_t type,
                                     const std::vector<int>& shape,
                                     int align = 0);
-  static void delete_(struct cinn_buffer_t* x) { free(x); }
+  static void delete_(struct cinn_buffer_t* x) { delete x; }
 
-  ~cinn_buffer_t() {}
+  ~cinn_buffer_t() {
+    if (external_malloc != NULL) {
+      delete external_malloc;
+    }
+    if (external_free != NULL) {
+      delete external_free;
+    }
+  }
 
   // NOTE the buffer should be resized first.
   static void alloc(struct cinn_buffer_t*);

--- a/python/tests/test_matmul.py
+++ b/python/tests/test_matmul.py
@@ -39,21 +39,17 @@ class TestMamul(unittest.TestCase):
         self.engine = cinn.ExecutionEngine()
 
     def test_matmul_basic(self):
-        print("Begin test_matmul_basic")
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)
-        print("Got returned data")
         module = create_matmul_basic(self.target, self.m, self.n, self.k)
 
         self.engine.link(module)
         matmul = self.engine.lookup("matmul")
         matmul(args)
-        print("Before getting numpy")
         cd = c.numpy()
         cd_target = c_target.numpy()
         self.assertTrue(np.allclose(cd, cd_target, atol=1e-4))
-        print("After assert")
 
-    def _test_matmul_tile(self):
+    def test_matmul_tile(self):
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)
         module = create_matmul_tile(self.target, self.m, self.n, self.k)
         print('module:\n', module.get_c_code())
@@ -113,7 +109,6 @@ def create_data(m, n, k, bn):
     # call around to lower the numpy's float precision so that it will not vary too much from C's float precision.
     a_init = np.around(np.random.randn(m, k).astype("float32"), 2)
     b_init = np.around(np.random.randn(k, n).astype("float32"), 2)
-    print("In create_data")
     a = runtime.cinn_buffer_t(a_init, runtime.cinn_x86_device)
     b = runtime.cinn_buffer_t(b_init, runtime.cinn_x86_device)
     c = runtime.cinn_buffer_t(
@@ -122,13 +117,11 @@ def create_data(m, n, k, bn):
                                      runtime.cinn_x86_device)
     packed_b = runtime.cinn_buffer_t(
         np.zeros([n // bn, k, bn]).astype("float32"), runtime.cinn_x86_device)
-    print("construct")
+
     a_arg = runtime.cinn_pod_value_t(a)
-    print("cinn_pod_value_t")
     b_arg = runtime.cinn_pod_value_t(b)
     c_arg = runtime.cinn_pod_value_t(c)
     packed_b_arg = runtime.cinn_pod_value_t(packed_b)
-    print("before return")
     return [a, b, c, c_target, a_arg, b_arg, c_arg]
 
 

--- a/python/tests/test_matmul.py
+++ b/python/tests/test_matmul.py
@@ -39,17 +39,21 @@ class TestMamul(unittest.TestCase):
         self.engine = cinn.ExecutionEngine()
 
     def test_matmul_basic(self):
+        print("Begin test_matmul_basic")
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)
+        print("Got returned data")
         module = create_matmul_basic(self.target, self.m, self.n, self.k)
 
         self.engine.link(module)
         matmul = self.engine.lookup("matmul")
         matmul(args)
+        print("Before getting numpy")
         cd = c.numpy()
         cd_target = c_target.numpy()
         self.assertTrue(np.allclose(cd, cd_target, atol=1e-4))
+        print("After assert")
 
-    def test_matmul_tile(self):
+    def _test_matmul_tile(self):
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)
         module = create_matmul_tile(self.target, self.m, self.n, self.k)
         print('module:\n', module.get_c_code())
@@ -109,6 +113,7 @@ def create_data(m, n, k, bn):
     # call around to lower the numpy's float precision so that it will not vary too much from C's float precision.
     a_init = np.around(np.random.randn(m, k).astype("float32"), 2)
     b_init = np.around(np.random.randn(k, n).astype("float32"), 2)
+    print("In create_data")
     a = runtime.cinn_buffer_t(a_init, runtime.cinn_x86_device)
     b = runtime.cinn_buffer_t(b_init, runtime.cinn_x86_device)
     c = runtime.cinn_buffer_t(
@@ -117,11 +122,13 @@ def create_data(m, n, k, bn):
                                      runtime.cinn_x86_device)
     packed_b = runtime.cinn_buffer_t(
         np.zeros([n // bn, k, bn]).astype("float32"), runtime.cinn_x86_device)
-
+    print("construct")
     a_arg = runtime.cinn_pod_value_t(a)
+    print("cinn_pod_value_t")
     b_arg = runtime.cinn_pod_value_t(b)
     c_arg = runtime.cinn_pod_value_t(c)
     packed_b_arg = runtime.cinn_pod_value_t(packed_b)
+    print("before return")
     return [a, b, c, c_target, a_arg, b_arg, c_arg]
 
 


### PR DESCRIPTION
Add callback to `cinn_buffer_t`.

The two callbacks are used to control memory allocation. It is useful in Paddle-CINN where the memory is managed out of CINN. PaddlePaddle training framework would set the callback and in next PRs CINN will use these callbacks to alloc or free the CPU/GPU memory.

