### PR TITLE
optimize reshape

### DIFF
--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -150,6 +150,7 @@ class GraphCompiler final {
   absl::flat_hash_map<std::string, std::string> reuse_vars_map_;
 
   std::unique_ptr<backends::Compiler> compiler_;
+  CompileOptions compile_options_;
 
   ir::Module::Builder m_builder_;
 

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -146,6 +146,8 @@ class GraphCompiler final {
   std::unordered_set<std::string> fetch_var_ids_;
 
   absl::flat_hash_map<std::string, std::string> prefix2full_namemap_;
+  // map dst reuse var to the src var sharing buffer
+  absl::flat_hash_map<std::string, std::string> reuse_vars_map_;
 
   std::unique_ptr<backends::Compiler> compiler_;
 

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -28,6 +28,7 @@ std::vector<cinn_pod_value_t>& Instruction::PreparePodArgs(
     PreparePodArgs(i - 1, name2podargs);
   common::ArgsBuilder builder;
   std::vector<std::string> all_args(in_args_[i].begin(), in_args_[i].end());
+
   all_args.insert(std::end(all_args), out_args_[i].begin(), out_args_[i].end());
 
   if (name2podargs != nullptr) {
@@ -52,8 +53,8 @@ std::vector<cinn_pod_value_t>& Instruction::PreparePodArgs(
 }
 
 void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podargs, bool dryrun, void* stream) {
-  if (function_name_ == "reshape") {
-    VLOG(2) << "skip reshape";
+  if (function_name_ == "no_run") {
+    VLOG(2) << "skip instruction";
     return;
   }
   if (fn_.size() > 1 && fn_.size() != in_args_.size()) {

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -52,6 +52,10 @@ std::vector<cinn_pod_value_t>& Instruction::PreparePodArgs(
 }
 
 void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podargs, bool dryrun, void* stream) {
+  if (function_name_ == "reshape") {
+    VLOG(2) << "skip reshape";
+    return;
+  }
   if (fn_.size() > 1 && fn_.size() != in_args_.size()) {
     out_args_.back()[0] = out_args_.front()[0];
     out_args_.erase(out_args_.begin());

--- a/cinn/hlir/framework/tensor.h
+++ b/cinn/hlir/framework/tensor.h
@@ -83,6 +83,8 @@ class _Tensor_ : public Object {
   const Type& type() const { return type_; }
 
   cinn_buffer_t* buffer() { return buffer_->data(); }
+  std::shared_ptr<Buffer> get_buffer() { return buffer_; }
+  void set_buffer(std::shared_ptr<Buffer> buffer) { buffer_ = buffer; }
 
   const char* type_info() const override { return __type_info__; }
 


### PR DESCRIPTION
optimize reshape op, which implenmented by sharing buffer without computation or buffer copy.
Currently the optimization only comes into effect when compile option's with_instantiate_variables is true for the reason that we can't control memorys allocated outside.