### PR TITLE
fuse reduce with specific op

### DIFF
--- a/cinn/frontend/cinn_builder.cc
+++ b/cinn/frontend/cinn_builder.cc
@@ -216,17 +216,17 @@ Variable CinnBuilder::Reverse(const Variable& operand, const std::vector<int>& a
   return instr.GetOutput(0);
 }
 
-std::vector<Variable> CinnBuilder::BNReduceMerge(const Variable& x) {
-  Instruction instr("bn_reduce_merge", {x});
+std::vector<Variable> CinnBuilder::BnMeanVarianceReduce(const Variable& x) {
+  Instruction instr("bn_mean_variance_reduce", {x});
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutputs();
 }
 
-std::vector<Variable> CinnBuilder::BNGradReduceMerge(const Variable& x,
-                                                     const Variable& x_mean,
-                                                     const Variable& y_grad) {
-  Instruction instr("bn_grad_reduce_merge", {x, x_mean, y_grad});
+std::vector<Variable> CinnBuilder::BnGradBiasScaleReduce(const Variable& x,
+                                                         const Variable& x_mean,
+                                                         const Variable& y_grad) {
+  Instruction instr("bn_grad_bias_scale_reduce", {x, x_mean, y_grad});
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutputs();

--- a/cinn/frontend/cinn_builder.cc
+++ b/cinn/frontend/cinn_builder.cc
@@ -216,6 +216,22 @@ Variable CinnBuilder::Reverse(const Variable& operand, const std::vector<int>& a
   return instr.GetOutput(0);
 }
 
+std::vector<Variable> CinnBuilder::BNReduceMerge(const Variable& x) {
+  Instruction instr("bn_reduce_merge", {x});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutputs();
+}
+
+std::vector<Variable> CinnBuilder::BNGradReduceMerge(const Variable& x,
+                                                     const Variable& x_mean,
+                                                     const Variable& y_grad) {
+  Instruction instr("bn_grad_reduce_merge", {x, x_mean, y_grad});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutputs();
+}
+
 Variable CinnBuilder::UnaryOp(const std::string& op_type, const Variable& operand) {
   Instruction instr(op_type, {operand});
   InferShape(instr);

--- a/cinn/frontend/cinn_builder.h
+++ b/cinn/frontend/cinn_builder.h
@@ -179,9 +179,9 @@ class CinnBuilder : public BaseBuilder {
 
   Variable Reverse(const Variable& operand, const std::vector<int>& axis);
 
-  std::vector<Variable> BNReduceMerge(const Variable& x);
+  std::vector<Variable> BnMeanVarianceReduce(const Variable& x);
 
-  std::vector<Variable> BNGradReduceMerge(const Variable& x, const Variable& x_mean, const Variable& y_grad);
+  std::vector<Variable> BnGradBiasScaleReduce(const Variable& x, const Variable& x_mean, const Variable& y_grad);
 
  private:
   Variable UnaryOp(const std::string& op_type, const Variable& operand);

--- a/cinn/frontend/cinn_builder.h
+++ b/cinn/frontend/cinn_builder.h
@@ -179,6 +179,10 @@ class CinnBuilder : public BaseBuilder {
 
   Variable Reverse(const Variable& operand, const std::vector<int>& axis);
 
+  std::vector<Variable> BNReduceMerge(const Variable& x);
+
+  std::vector<Variable> BNGradReduceMerge(const Variable& x, const Variable& x_mean, const Variable& y_grad);
+
  private:
   Variable UnaryOp(const std::string& op_type, const Variable& operand);
 

--- a/cinn/frontend/decomposer/batch_norm.cc
+++ b/cinn/frontend/decomposer/batch_norm.cc
@@ -58,7 +58,11 @@ struct BatchNormHelper {
   }
 
   std::vector<Variable> MeanAndVariance(Variable x) {
-    auto vars               = builder->BNReduceMerge(x);
+#ifdef CINN_WITH_CUDA
+    // To optimize the bn forward by merge the reduce computation of mean and variance,
+    // build a fusion op 'BnMeanVarianceReduce' by hand as the fusion pass is not support now.
+    // When the fusion pass is rebuild, this op is to be removed.
+    auto vars               = builder->BnMeanVarianceReduce(x);
     auto element_count_1d_0 = GetTensorFromScalar<float>(element_count, "element_count", param_shape);
     auto element_count_1d_1 = GetTensorFromScalar<float>(element_count, "element_count", param_shape);
     auto mean = builder->Div(builder->Reduce(vars[0], ReduceKind::kSum, std::vector<int>(1, vars[0]->shape.size() - 1)),
@@ -67,13 +71,30 @@ struct BatchNormHelper {
         builder->Reduce(vars[1], ReduceKind::kSum, std::vector<int>(1, vars[1]->shape.size() - 1)), element_count_1d_1);
 
     auto variance = builder->Sub(mean_squre, builder->Mul(mean, builder->Identity(mean)));
+#else
+    // mean = reduce_sum(x) / nhw, shape = [c]
+    auto mean = Mean(x);
+    // variance = reduce_sum(x * x) / nhw - mean * mean, shape = [c], simplified by equation: E(x^2) - [E(x)]^2
+    auto variance    = Variance(x, mean);
+#endif
     return {mean, variance};
   }
 
-  std::vector<Variable> BNGradReduceMerge(Variable x, Variable x_mean, Variable y_grad) {
-    auto vars = builder->BNGradReduceMerge(x, x_mean, y_grad);
+  std::vector<Variable> GradBiasAndScale(Variable x, Variable x_mean, Variable y_grad) {
+#ifdef CINN_WITH_CUDA
+    // Using fusion op "BnGradBiasScaleReduce" as the same reason with "BnMeanVarianceReduce".
+    // It also will be removed.
+    auto vars = builder->BnGradBiasScaleReduce(x, x_mean, y_grad);
     return {builder->Reduce(vars[0], ReduceKind::kSum, std::vector<int>(1, vars[0]->shape.size() - 1)),
             builder->Reduce(vars[1], ReduceKind::kSum, std::vector<int>(1, vars[1]->shape.size() - 1))};
+#else
+    auto mean_4d     = builder->BroadcastTo(x_mean, x->shape, {channel_dim});
+    auto x_mean_diff = builder->Sub(x, mean_4d);
+    // bias_grad = reduce_sum(y_grad), shape = [c]
+    auto bias_grad                     = Reduce(y_grad);
+    auto sum_of_y_grad_mul_x_mean_diff = Reduce(builder->Mul(y_grad, x_mean_diff));
+    return {bias_grad, sum_of_y_grad_mul_x_mean_diff};
+#endif
   }
 
   // mean = reduce_sum(x) / nhw
@@ -155,16 +176,10 @@ void batch_norm_train(const Instruction& instr, const DecomposerContext& context
   CinnBuilder* builder = context.builder();
   BatchNormHelper helper(builder, x->shape, scale->shape, layout, "batch_norm_train");
 
-#ifdef CINN_WITH_CUDA
   auto mean_variance = helper.MeanAndVariance(x);
   auto mean          = mean_variance[0];
   auto variance      = mean_variance[1];
-#else
-  // mean = reduce_sum(x) / nhw, shape = [c]
-  auto mean = helper.Mean(x);
-  // variance = reduce_sum(x * x) / nhw - mean * mean, shape = [c], simplified by equation: E(x^2) - [E(x)]^2
-  auto variance = helper.Variance(x, mean);
-#endif
+
   auto mean_4d = builder->BroadcastTo(mean, x->shape, {helper.channel_dim});
   // std_variance_inv = rsqrt(variance + epsilon), shape = [c]
   auto std_variance_inv_4d = helper.StdVarianceInv4d(variance, epsilon);
@@ -207,17 +222,9 @@ void batch_norm_grad(const Instruction& instr, const DecomposerContext& context)
   CinnBuilder* builder = context.builder();
   BatchNormHelper helper(builder, x->shape, scale->shape, layout, "batch_norm_grad");
 
-  auto mean_4d     = builder->BroadcastTo(save_mean, x->shape, {helper.channel_dim});
-  auto x_mean_diff = builder->Sub(x, mean_4d);
-#ifdef CINN_WITH_CUDA
-  auto vars                          = helper.BNGradReduceMerge(x, save_mean, y_grad);
+  auto vars                          = helper.GradBiasAndScale(x, save_mean, y_grad);
   auto bias_grad                     = vars[0];
   auto sum_of_y_grad_mul_x_mean_diff = vars[1];
-#else
-  // bias_grad = reduce_sum(y_grad), shape = [c]
-  auto bias_grad                     = helper.Reduce(y_grad);
-  auto sum_of_y_grad_mul_x_mean_diff = helper.Reduce(builder->Mul(y_grad, x_mean_diff));
-#endif
 
   // scale_grad = reduce_sum(y_grad * (x - mean)) * rsqrt(variance + epsilon), shape = [c]
   auto scale_grad = builder->Mul(sum_of_y_grad_mul_x_mean_diff, helper.StdVarianceInv1d(save_variance, epsilon));
@@ -234,6 +241,9 @@ void batch_norm_grad(const Instruction& instr, const DecomposerContext& context)
   auto tmp1             = builder->Mul(y_grad, element_count_4d);
 
   auto tmp2 = builder->BroadcastTo(bias_grad, x->shape, {helper.channel_dim});
+
+  auto mean_4d     = builder->BroadcastTo(save_mean, x->shape, {helper.channel_dim});
+  auto x_mean_diff = builder->Sub(x, mean_4d);
 
   auto sum_of_y_grad_mul_x_mean_diff_4d =
       builder->BroadcastTo(sum_of_y_grad_mul_x_mean_diff, x->shape, {helper.channel_dim});

--- a/cinn/frontend/decomposer/batch_norm_test.cc
+++ b/cinn/frontend/decomposer/batch_norm_test.cc
@@ -143,7 +143,7 @@ void ComputeBatchNormTrainRef(const std::vector<T>& x,
 }
 
 TEST(Decomposer, BatchNormTrain) {
-  int n = 16, c = 32, h = 16, w = 16;
+  int n = 16, c = 128, h = 14, w = 14;
   float epsilon           = 1e-5;
   float momentum          = 0.9f;
   std::string data_layout = "NCHW";
@@ -326,7 +326,7 @@ void ComputeBatchNormGradRef(const std::vector<T>& y_grad,
 }
 
 TEST(Decomposer, BatchNormGrad) {
-  int n = 16, c = 32, h = 16, w = 16;
+  int n = 16, c = 128, h = 14, w = 14;
   int num       = n * c * h * w;
   float epsilon = 1e-5;
   NetBuilder net_builder("batch_norm_grad");

--- a/cinn/frontend/decomposer/broadcast.cc
+++ b/cinn/frontend/decomposer/broadcast.cc
@@ -106,7 +106,11 @@ void elementwise_add_grad(const Instruction& instr, const DecomposerContext& con
 
   Variable dy_t;
   if (dy->shape == dout->shape) {
-    dy_t = builder->Identity(dout);
+    if (dx->shape == dout->shape) {
+      dy_t = dx_t;
+    } else {
+      dy_t = builder->Identity(dout);
+    }
   } else {
     std::vector<int> y_reduce_dims;
     GetReduceDimsForY(dy->shape, dout->shape, axis, &y_reduce_dims);

--- a/cinn/frontend/decomposer/broadcast.cc
+++ b/cinn/frontend/decomposer/broadcast.cc
@@ -106,11 +106,7 @@ void elementwise_add_grad(const Instruction& instr, const DecomposerContext& con
 
   Variable dy_t;
   if (dy->shape == dout->shape) {
-    if (dx->shape == dout->shape) {
-      dy_t = dx_t;
-    } else {
-      dy_t = builder->Identity(dout);
-    }
+    dy_t = builder->Identity(dout);
   } else {
     std::vector<int> y_reduce_dims;
     GetReduceDimsForY(dy->shape, dout->shape, axis, &y_reduce_dims);

--- a/cinn/hlir/framework/cuda_graph_compiler_test.cc
+++ b/cinn/hlir/framework/cuda_graph_compiler_test.cc
@@ -100,9 +100,9 @@ std::vector<float> CudaGetData(const Tensor& tensor, const Target& target) {
 TEST(GraphCompiler, RunModel) {
   using attr_t = hlir::framework::AttrType;
   frontend::Program prog;
-  Expr M(30);
-  Expr K(30);
-  Expr N(30);
+  Expr M(32);
+  Expr K(32);
+  Expr N(32);
   frontend::Variable a("A");
   frontend::Variable b("B");
   Type t   = Float(32);

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -322,7 +322,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const Node* node) {
   for (int i = 0; i < C->size() - 1; i++) {
     ir::Expr temp = C[i];
     // checkout whether the tensor is with buffer.
-    if (!temp.as_tensor_ref()->buffer.defined()) {
+    if (!temp.as_tensor_ref()->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) {
       inputs.push_back(temp.as_tensor_ref());
     }
   }
@@ -499,7 +499,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const std::vector<Node*>& 
   // args order: inputs + final output + fetch outputs + other no_fused outputs
   for (auto& tensor : outputs) {
     // checkout the tensor is with buffer.
-    if (!tensor->buffer.defined()) {
+    if (!tensor->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) {
       inputs.push_back(tensor);
     }
   }

--- a/cinn/hlir/pass/opfusion.cc
+++ b/cinn/hlir/pass/opfusion.cc
@@ -130,7 +130,7 @@ class DomTree {
         auto sink         = out_links[i]->sink();
         bool has_no_links = sink->outlinks().empty();
         if (i) {
-          CHECK(has_no_links) << "only the first out_var of " << node->id() << " links to other op node";
+          // CHECK(has_no_links) << "only the first out_var of " << node->id() << " links to other op node!";
         } else {
           int index = sink->get_index();
           // the first out_var is the parent of the op node

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -201,6 +201,74 @@ Tensor ReduceMin(
   return Reduce(A, axes, lang::ReduceMin, keep_dims, Expr(), output_name);
 }
 
+std::vector<Tensor> WarpReduce(const ir::Tensor& A,
+                               int last_reduce_dim,
+                               const std::string& reduce_type,
+                               const std::string& output_name) {
+  Expr lane(1);
+  for (int idx = A->shape.size() - 1; idx >= (A->shape.size() - last_reduce_dim); --idx) {
+    lane = lane * A->shape[idx].as_int32();
+  }
+
+  std::vector<Expr> tmp_shape(A->shape.begin(), A->shape.begin() + A->shape.size() - last_reduce_dim);
+  tmp_shape.push_back(Expr(32));
+  auto tmp_out = Compute(
+      tmp_shape,
+      [=](const std::vector<Expr>& indexs) -> Expr {
+        std::vector<Expr> tmp_indexs(indexs.begin(), indexs.begin() + indexs.size() - 1);
+        for (int idx = 0; idx < last_reduce_dim; ++idx) {
+          tmp_indexs.push_back(Expr(0));
+        }
+        CHECK_EQ(A->shape.size(), tmp_indexs.size());
+        Expr offset = common::IndiceToAbsOffset(A->shape, tmp_indexs);
+        return lang::CallExtern(reduce_type, {A, offset, lane});
+      },
+      UniqName(output_name + "_" + reduce_type));
+  tmp_out->WithBuffer("local", common::UniqName("warp_reduce_buffer"), A->type());
+
+  std::vector<Expr> out_shape(A->shape.begin(), A->shape.begin() + A->shape.size() - last_reduce_dim);
+  auto out = Compute(
+      out_shape,
+      [=](const std::vector<Expr>& indexs) -> Expr {
+        std::vector<Expr> tmp_indexs(indexs);
+        tmp_indexs.push_back(Expr(0));
+        return tmp_out(tmp_indexs);
+      },
+      UniqName(output_name));
+
+  return {out, tmp_out};
+}
+
+/**
+ * @brief find the max of array elements over the last dimension
+ *
+ * @param A The input Tensor
+ * @param output_name The name of the output Tensor
+ */
+std::vector<ir::Tensor> WarpReduceMax(const ir::Tensor& A, int last_reduce_dim, const std::string& output_name) {
+  return WarpReduce(A, last_reduce_dim, "cinn_warp_reduce_max", output_name);
+}
+
+/**
+ * @brief compute the sum of array elements over the last dimension
+ *
+ * @param A The input Tensor
+ * @param output_name The name of the output Tensor
+ */
+std::vector<ir::Tensor> WarpReduceSum(const ir::Tensor& A, int last_reduce_dim, const std::string& output_name) {
+  return WarpReduce(A, last_reduce_dim, "cinn_warp_reduce_sum", output_name);
+}
+
+/**
+ * @brief compute the average of array elements over the last dimension
+ *
+ * @param A The input Tensor
+ * @param output_name The name of the output Tensor
+ */
+std::vector<ir::Tensor> WarpReduceAvg(const ir::Tensor& A, int last_reduce_dim, const std::string& output_name) {
+  return WarpReduce(A, last_reduce_dim, "cinn_warp_reduce_avg", output_name);
+}
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/reduction.h
+++ b/cinn/hlir/pe/reduction.h
@@ -99,6 +99,36 @@ ir::Tensor ReduceMin(const ir::Tensor& A,
                      Expr initial                   = Expr(),
                      const std::string& output_name = "T_Reduce_Min_out");
 
+/**
+ * @brief find the max of array elements over the last dimension
+ *
+ * @param A The input Tensor
+ * @param output_name The name of the output Tensor
+ */
+std::vector<ir::Tensor> WarpReduceMax(const ir::Tensor& A,
+                                      int last_reduce_dim,
+                                      const std::string& output_name = "T_Warp_Reduce_Max_out");
+
+/**
+ * @brief compute the sum of array elements over the last dimension
+ *
+ * @param A The input Tensor
+ * @param output_name The name of the output Tensor
+ */
+std::vector<ir::Tensor> WarpReduceSum(const ir::Tensor& A,
+                                      int last_reduce_dim,
+                                      const std::string& output_name = "T_Warp_Reduce_Sum_out");
+
+/**
+ * @brief compute the average of array elements over the last dimension
+ *
+ * @param A The input Tensor
+ * @param output_name The name of the output Tensor
+ */
+std::vector<ir::Tensor> WarpReduceAvg(const ir::Tensor& A,
+                                      int last_reduce_dim,
+                                      const std::string& output_name = "T_Warp_Reduce_Avg_out");
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/reduction.h
+++ b/cinn/hlir/pe/reduction.h
@@ -103,30 +103,33 @@ ir::Tensor ReduceMin(const ir::Tensor& A,
  * @brief find the max of array elements over the last dimension
  *
  * @param A The input Tensor
+ * @param last_reduce_dim_num the number of last reduce dimension
  * @param output_name The name of the output Tensor
  */
 std::vector<ir::Tensor> WarpReduceMax(const ir::Tensor& A,
-                                      int last_reduce_dim,
+                                      int last_reduce_dim_num,
                                       const std::string& output_name = "T_Warp_Reduce_Max_out");
 
 /**
  * @brief compute the sum of array elements over the last dimension
  *
  * @param A The input Tensor
+ * @param last_reduce_dim_num the number of last reduce dimension
  * @param output_name The name of the output Tensor
  */
 std::vector<ir::Tensor> WarpReduceSum(const ir::Tensor& A,
-                                      int last_reduce_dim,
+                                      int last_reduce_dim_num,
                                       const std::string& output_name = "T_Warp_Reduce_Sum_out");
 
 /**
  * @brief compute the average of array elements over the last dimension
  *
  * @param A The input Tensor
+ * @param last_reduce_dim_num the number of last reduce dimension
  * @param output_name The name of the output Tensor
  */
 std::vector<ir::Tensor> WarpReduceAvg(const ir::Tensor& A,
-                                      int last_reduce_dim,
+                                      int last_reduce_dim_num,
                                       const std::string& output_name = "T_Warp_Reduce_Avg_out");
 
 }  // namespace pe

--- a/cinn/hlir/pe/schedule.cc
+++ b/cinn/hlir/pe/schedule.cc
@@ -363,6 +363,33 @@ void CudaScheduleReduce(poly::StageMap stages, ir::Tensor output, const common::
   }
 }
 
+void CudaScheduleWarpReduce(poly::StageMap stages, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target) {
+  int sum_out_dim = 1;
+
+  for (int idx = 0; idx < out->shape.size() - 1; ++idx) {
+    stages[out]->Fuse(0, 1);
+    stages[tmp_out]->Fuse(0, 1);
+    sum_out_dim *= out->shape[idx].as_int32();
+  }
+  sum_out_dim *= out->shape.back().as_int32();
+
+  if (sum_out_dim < 16) {
+    stages[out]->Bind(0, "threadIdx.y");
+    stages[tmp_out]->Bind(1, "threadIdx.x");
+    stages[tmp_out]->ComputeAt2(stages[out], 0);
+    stages[tmp_out]->SetBuffer("local");
+  } else {
+    stages[out]->Split(0, 8);
+    stages[out]->Bind(0, "blockIdx.x");
+    stages[out]->Bind(1, "threadIdx.y");
+
+    stages[tmp_out]->Split(0, 8);
+    stages[tmp_out]->Bind(2, "threadIdx.x");
+    stages[tmp_out]->ComputeAt2(stages[out], 1);
+    stages[tmp_out]->SetBuffer("local");
+  }
+}
+
 void SoftmaxScheduleCPU(poly::StageMap stage, const ir::Tensor &output, const ir::Tensor &temp, int axis) {
   if (axis == -1) {
     axis += output->shape.size();
@@ -2036,10 +2063,7 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
   for (int i = 1; i < dims; i++) {
     stage->Fuse(0, 1);
   }
-  int num_thread   = target.max_num_threads();
-  int num_block    = 256;
-  int vector_width = 1;
-  int prod_size    = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
+  int prod_size = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
   if (prod_size > 512) {
     stage->Split(0, 256);
     stage->Bind(0, "blockIdx.x");
@@ -2047,31 +2071,6 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
   } else {
     stage->Bind(0, "threadIdx.x");
   }
-
-  /*
-  bool need_block_split = prod_size > num_thread * num_block * vector_width ? true : false;
-  if (need_block_split) {
-    auto x_outer_inner = stage->Split(0, num_thread * num_block);
-    auto &X_outer      = std::get<0>(x_outer_inner);
-    auto &X_inner      = std::get<1>(x_outer_inner);
-
-    auto Block_x_Thread_x = stage->Split(X_inner, num_thread);
-    auto &Block_x         = std::get<0>(Block_x_Thread_x);
-    auto &Thread_x        = std::get<1>(Block_x_Thread_x);
-
-    stage->Reorder({Block_x, Thread_x, X_outer});
-    stage->Bind(0, "blockIdx.x");
-    stage->Bind(1, "threadIdx.x");
-  } else {
-    if (prod_size > num_thread) {
-      stage->Split(0, num_thread);
-      stage->Bind(0, "blockIdx.x");
-      stage->Bind(1, "threadIdx.x");
-    } else {
-      stage->Bind(0, "threadIdx.x");
-    }
-  }
-  */
 }
 
 void CudaSplitSchedule(poly::Stage *stage, const std::vector<int> &output_shape) {

--- a/cinn/hlir/pe/schedule.cc
+++ b/cinn/hlir/pe/schedule.cc
@@ -2036,10 +2036,19 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
   for (int i = 1; i < dims; i++) {
     stage->Fuse(0, 1);
   }
-  int num_thread        = target.max_num_threads();
-  int num_block         = 256;
-  int vector_width      = 1;
-  int prod_size         = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
+  int num_thread   = target.max_num_threads();
+  int num_block    = 256;
+  int vector_width = 1;
+  int prod_size    = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
+  if (prod_size > 512) {
+    stage->Split(0, 256);
+    stage->Bind(0, "blockIdx.x");
+    stage->Bind(1, "threadIdx.x");
+  } else {
+    stage->Bind(0, "threadIdx.x");
+  }
+
+  /*
   bool need_block_split = prod_size > num_thread * num_block * vector_width ? true : false;
   if (need_block_split) {
     auto x_outer_inner = stage->Split(0, num_thread * num_block);
@@ -2062,6 +2071,7 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
       stage->Bind(0, "threadIdx.x");
     }
   }
+  */
 }
 
 void CudaSplitSchedule(poly::Stage *stage, const std::vector<int> &output_shape) {

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -158,6 +158,8 @@ void CudaScheduleMul(poly::StageMap stages,
 
 void CudaScheduleReduce(poly::StageMap stages, ir::Tensor output, const common::Target &target);
 
+void CudaScheduleWarpReduce(poly::StageMap stages, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target);
+
 void CudaScheduleDepthwiseConv(poly::StageMap stages, ir::Tensor &output, const common::Target &target);
 
 void CudaScheduleConv(poly::StageMap stages,


### PR DESCRIPTION
### 这个PR涉及四个优化点：

1. 定制op  fusion前向和反向 reduce的合并
2. 对定制op的reduce实现进行优化
3. 使用warp reduce优化last dimension参与的优化
4. 优化CudaScheduleInjective实现

### 优化效果

1. reduce的合并：
     - 前向计算合并reduce(x)和reduce(x^2)，优化x的读取和kernel的launch
     - 反向计算合并reduce(y_grad)和reduce(y_grad * (x - broadcast(x_mean))，优化y_grad的读取和kernel launch

     **性能提升 50ms**

2. 对定制op的reduce实现进行优化
    - 引入reshape，对输入数据的shape进行变换，提高reduce计算的并行度。

    **性能提升 25ms**

3. warp reduce同样是优化reduce的计算速度，目前性能提升不明显，主要是为了后面进一步fusion reduce的计算做准备。

4. CudaScheduleInjective的优化主要是提升element-wise类型计算的性能，缩小block size增加block的数量，能够一定程度优化block的切换。

    **性能提升 25ms**

优化的总体性能提升 100ms.
以上的性能提升数据是针对resnet50 batch=32  10次iteration带来的总时间。
