### PR TITLE
[Cherry Pick]remove cuda injective optimize (#618)

### DIFF
--- a/cinn/hlir/pe/schedule.cc
+++ b/cinn/hlir/pe/schedule.cc
@@ -1949,15 +1949,32 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
   for (int i = 1; i < dims; i++) {
     stage->Fuse(0, 1);
   }
-  int numel = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
-  if (numel > 512) {
-    // set block size = 256, the number of block is unlimited.
-    // this can increase the number of threads.
-    stage->Split(0, 256);
+
+  int num_thread        = target.max_num_threads();
+  int num_block         = 256;
+  int vector_width      = 1;
+  int prod_size         = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
+  bool need_block_split = prod_size > num_thread * num_block * vector_width ? true : false;
+  if (need_block_split) {
+    auto x_outer_inner = stage->Split(0, num_thread * num_block);
+    auto &X_outer      = std::get<0>(x_outer_inner);
+    auto &X_inner      = std::get<1>(x_outer_inner);
+
+    auto Block_x_Thread_x = stage->Split(X_inner, num_thread);
+    auto &Block_x         = std::get<0>(Block_x_Thread_x);
+    auto &Thread_x        = std::get<1>(Block_x_Thread_x);
+
+    stage->Reorder({Block_x, Thread_x, X_outer});
     stage->Bind(0, "blockIdx.x");
     stage->Bind(1, "threadIdx.x");
   } else {
-    stage->Bind(0, "threadIdx.x");
+    if (prod_size > num_thread) {
+      stage->Split(0, num_thread);
+      stage->Bind(0, "blockIdx.x");
+      stage->Bind(1, "threadIdx.x");
+    } else {
+      stage->Bind(0, "threadIdx.x");
+    }
   }
 }
 


### PR DESCRIPTION
Cherry pick from https://github.com/PaddlePaddle/CINN/pull/618 .
移除对于cuda schedule injective的优化，因为在某些情况下，schedule生成的代码index不正确，会影响模型的计算准确性。目前尚不清楚导致生成代码的错误的原因，移除这个优化将导致gpu性能2~3%的下降。后续解决这个问题之后，会添加新的优化。