### PR TITLE
add get_shape

### DIFF
--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -30,6 +30,13 @@ Variable NetBuilder::identity(const Variable& operand) {
   return instr.GetOutput(0);
 }
 
+Variable NetBuilder::get_shape(const Variable& operand) {
+  Instruction instr("get_shape", {operand});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
 Variable NetBuilder::add(const Variable& a, const Variable& b) {
   Instruction instr("elementwise_add", {a, b});
   instr.SetAttr("axis", -1);

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -27,7 +27,15 @@ class NetBuilder : public BaseBuilder {
  public:
   using BaseBuilder::BaseBuilder;
 
+  /**
+   * Copy variables.
+   */
   Variable identity(const Variable& a);
+
+  /**
+   * Copy variables.
+   */
+  Variable get_shape(const Variable& a);
 
   /**
    * Add two variables.

--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -14,6 +14,7 @@
 
 #include "cinn/frontend/net_builder.h"
 
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -218,8 +219,8 @@ TEST(net_build, program_execute_get_shape) {
   SetRandData(input_tensor, target);
   runtime_program->Execute();
 
-  LOG(INFO) << cinn::utils::Join(get_shape_out->shape, ",");
-  ASSERT_EQ(get_shape_out->shape, {B, C, H, W});
+  LOG(INFO) << "get_shape return " << cinn::utils::Join(get_shape_out->shape, ",");
+  ASSERT_EQ(get_shape_out->shape, std::vector<int>({B, C, H, W}));
 }
 
 }  // namespace frontend

--- a/cinn/frontend/op_mappers/reshape.cc
+++ b/cinn/frontend/op_mappers/reshape.cc
@@ -88,7 +88,7 @@ void Reshape2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext&
   CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
   auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->identity(x);
+  auto xshape = ctx.Builder()->get_shape(x);
 
   ctx.AddVar(xshape_name, xshape);
   ctx.AddVarModelToProgram(xshape_name, xshape->id);

--- a/cinn/frontend/op_mappers/transpose.cc
+++ b/cinn/frontend/op_mappers/transpose.cc
@@ -63,7 +63,7 @@ void Transpose2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
   auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->identity(x);
+  auto xshape = ctx.Builder()->get_shape(x);
 
   ctx.AddVar(xshape_name, xshape);
   ctx.AddVarModelToProgram(xshape_name, xshape->id);

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -488,5 +488,11 @@ CINN_REGISTER_HELPER(elementwise_ops) {
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElemWise)
       .set_support_level(4);
 
+  CINN_REGISTER_OP(get_shape)
+      .describe("get the shape of the input Tensor")
+      .set_num_inputs(1)
+      .set_num_outputs(1)
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForElementwise));
+
   return true;
 }

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -534,7 +534,7 @@ CINN_REGISTER_HELPER(elementwise_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForGetShape)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForElementwise))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForElementwise))
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElemWise);
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque);
 
   return true;
 }


### PR DESCRIPTION
As title. 

诸如`reshape2_grad`、`transpose2_grad`、`elementwise_add_grad`算子中均存在只用到了前向输入的shape，没有用到前向输入的数据的现象。但现有CINN中并不存在只传递shape的机制，这导致我们需要将前向输入完全拷贝一份以供反向算子使用，增加了冗余拷贝的时间。

本PR添加了`get_shape`算子：其输入为x，输出为仅有shape的Variable，该Variable可不含任何数据，因为我们只需要该Variable的shape值，即`Variable->shape`。

由于`elementwise_add`改动太大，此PR暂不修改`elementwise_add`。