### PR TITLE
add the Netbuilder of base ops which are needed by paddle science

### DIFF
--- a/cinn/frontend/base_builder.cc
+++ b/cinn/frontend/base_builder.cc
@@ -89,5 +89,110 @@ void BaseBuilder::InferShape(Instruction instr) const {
   }
 }
 
+Variable BaseBuilder::Concat(const std::vector<Variable>& input_vars, int axis) {
+  Instruction instr("concat", input_vars);
+  instr.SetAttr("axis", axis);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::Reduce(const Variable& operand, ReduceKind kind, const std::vector<int>& dim, bool keep_dim) {
+  auto reduce_func = [&](const std::string& op_type) {
+    Instruction instr(op_type, {operand});
+    instr.SetAttr("dim", dim);
+    instr.SetAttr("keep_dim", keep_dim);
+    InferShape(instr);
+    AppendInstruction(instr);
+    return instr.GetOutput(0);
+  };
+
+  switch (kind) {
+    case ReduceKind::kSum:
+      return reduce_func("reduce_sum");
+    case ReduceKind::kProd:
+      return reduce_func("reduce_prod");
+    case ReduceKind::kMax:
+      return reduce_func("reduce_max");
+    case ReduceKind::kMin:
+      return reduce_func("reduce_min");
+    default:
+      LOG(FATAL) << "unknown reduction kind";
+  }
+}
+
+Variable BaseBuilder::BroadcastTo(const Variable& operand,
+                                  const std::vector<int>& out_shape,
+                                  const std::vector<int>& broadcast_axes) {
+  Instruction instr("broadcast_to", {operand});
+  instr.SetAttr("out_shape", out_shape);
+  instr.SetAttr("broadcast_axes", broadcast_axes);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::Reshape(const Variable& operand, const std::vector<int>& shape) {
+  Instruction instr("reshape", {operand});
+  instr.SetAttr("shape", shape);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::Transpose(const Variable& operand, const std::vector<int>& axis) {
+  Instruction instr("transpose", {operand});
+  instr.SetAttr("axis", axis);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::Slice(const Variable& operand,
+                            const std::vector<int>& axes,
+                            const std::vector<int>& starts,
+                            const std::vector<int>& ends,
+                            const std::vector<int>& infer_flags,
+                            const std::vector<int>& decrease_axis) {
+  Instruction instr("slice", {operand});
+  instr.SetAttr("axes", axes);
+  instr.SetAttr("starts", starts);
+  instr.SetAttr("ends", ends);
+  instr.SetAttr("infer_flags", infer_flags);
+  instr.SetAttr("decrease_axis", decrease_axis);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::Reverse(const Variable& operand, const std::vector<int>& axis) {
+  Instruction instr("reverse", {operand});
+  instr.SetAttr("axis", axis);
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::Select(const Variable& condition, const Variable& true_value, const Variable& false_value) {
+  Instruction instr("select", {condition, true_value, false_value});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::UnaryOp(const std::string& op_type, const Variable& operand) {
+  Instruction instr(op_type, {operand});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
+Variable BaseBuilder::BinaryOp(const std::string& op_type, const Variable& lhs, const Variable& rhs) {
+  Instruction instr(op_type, {lhs, rhs});
+  InferShape(instr);
+  AppendInstruction(instr);
+  return instr.GetOutput(0);
+}
+
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -43,6 +43,12 @@ enum class ReduceKind : std::int8_t {
   kMin,
 };
 
+/**
+ * WARNING: In BaseBuilder, you should only place the meta op, which are also the common op between NetBuilder and
+ * CinnBuilder!!! That means, you should not place any non-meta op, or the op only belong to NetBuilder or
+ * CinnBuilder!!!
+ * TODO: Reconstruct the BaseBuilder, NetBuilder and CinnBuilder
+ */
 class BaseBuilder {
  public:
   explicit BaseBuilder(const std::string& name);

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -62,8 +62,53 @@ class BaseBuilder {
 
   void AppendInstruction(const Instruction& instr) { instrs_.push_back(instr); }
 
+  Variable Concat(const std::vector<Variable>& input_vars, int axis = 0);
+
+  /**
+   * @brief Reduce array elements over the given dims.
+   *
+   * @param operand The input variable.
+   * @param dim The dims along which a sum is performed. If dim is empty, the operation will sum over all elements
+   * of the input array. If the dim has negative value, it should count from the last dim to the first.
+   * @param keep_dim If it is set true, the axes which are reduced are left in the result as dimensions with size one.
+   * With this option, the result will broadcast correctly against the input array.
+   *
+   * @return The result variable.
+   */
+  Variable Reduce(const Variable& operand, ReduceKind kind, const std::vector<int>& dim, bool keep_dim = false);
+
+  Variable BroadcastTo(const Variable& operand,
+                       const std::vector<int>& out_shape,
+                       const std::vector<int>& broadcast_axes);
+
+  Variable Reshape(const Variable& operand, const std::vector<int>& shape);
+
+  Variable Transpose(const Variable& operand, const std::vector<int>& axis);
+
+  Variable Slice(const Variable& operand,
+                 const std::vector<int>& axes,
+                 const std::vector<int>& starts        = {},
+                 const std::vector<int>& ends          = {},
+                 const std::vector<int>& infer_flags   = {},
+                 const std::vector<int>& decrease_axis = {});
+
+  /**
+   * This API reverses the Variable x along the given axis.
+   * Example 1: x = [[0, 1], [2, 3], [4, 5]], axis = [0]
+   *            output = [[4, 5], [2, 3], [0, 1]]
+   * Example 2: x = [[0, 1], [2, 3], [4, 5]], axis = [0, 1]
+   *            output = [[5, 4], [3, 2], [1, 0]]
+   */
+  Variable Reverse(const Variable& operand, const std::vector<int>& axis);
+
+  Variable Select(const Variable& condition, const Variable& true_value, const Variable& false_value);
+
  protected:
   void InferShape(Instruction instr) const;
+
+  Variable UnaryOp(const std::string& op_type, const Variable& operand);
+
+  Variable BinaryOp(const std::string& op_type, const Variable& lhs, const Variable& rhs);
 
   std::string name_;
   std::vector<Instruction> instrs_;

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -43,12 +43,9 @@ enum class ReduceKind : std::int8_t {
   kMin,
 };
 
-/**
- * WARNING: In BaseBuilder, you should only place the meta op, which are also the common op between NetBuilder and
- * CinnBuilder!!! That means, you should not place any non-meta op, or the op only belong to NetBuilder or
- * CinnBuilder!!!
- * TODO: Reconstruct the BaseBuilder, NetBuilder and CinnBuilder
- */
+// WARNING: In BaseBuilder, you should only place the meta op, which are also the common op between NetBuilder and
+// CinnBuilder! That means, you should not place any non-meta op, or the op only belong to NetBuilder or
+// CinnBuilder in BaseBuilder!
 class BaseBuilder {
  public:
   explicit BaseBuilder(const std::string& name);

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -25,6 +25,24 @@
 namespace cinn {
 namespace frontend {
 
+enum class ComparisonKind : std::int8_t {
+  kUnk = -1,
+  kEq,
+  kNe,
+  kGe,
+  kGt,
+  kLe,
+  kLt,
+};
+
+enum class ReduceKind : std::int8_t {
+  kUnk = -1,
+  kSum,
+  kProd,
+  kMax,
+  kMin,
+};
+
 class BaseBuilder {
  public:
   explicit BaseBuilder(const std::string& name);

--- a/cinn/frontend/cinn_builder.cc
+++ b/cinn/frontend/cinn_builder.cc
@@ -84,14 +84,6 @@ BINARY_OP_DEF(LeftShift, left_shift)
 BINARY_OP_DEF(RightShift, right_shift)
 #undef BINARY_OP_DEF
 
-Variable CinnBuilder::Concat(const std::vector<Variable>& input_vars, int axis) {
-  Instruction instr("concat", input_vars);
-  instr.SetAttr("axis", axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
 Variable CinnBuilder::Conv(const Variable& lhs,
                            const Variable& rhs,
                            const std::vector<int>& strides,
@@ -137,85 +129,6 @@ Variable CinnBuilder::Compare(const Variable& lhs, const Variable& rhs, Comparis
   }
 }
 
-Variable CinnBuilder::Reduce(const Variable& operand, ReduceKind kind, const std::vector<int>& dim, bool keep_dim) {
-  auto reduce_func = [&](const std::string& op_type) {
-    Instruction instr(op_type, {operand});
-    instr.SetAttr("dim", dim);
-    instr.SetAttr("keep_dim", keep_dim);
-    InferShape(instr);
-    AppendInstruction(instr);
-    return instr.GetOutput(0);
-  };
-
-  switch (kind) {
-    case ReduceKind::kSum:
-      return reduce_func("reduce_sum");
-    case ReduceKind::kProd:
-      return reduce_func("reduce_prod");
-    case ReduceKind::kMax:
-      return reduce_func("reduce_max");
-    case ReduceKind::kMin:
-      return reduce_func("reduce_min");
-    default:
-      LOG(FATAL) << "unknown reduction kind";
-  }
-}
-
-Variable CinnBuilder::BroadcastTo(const Variable& operand,
-                                  const std::vector<int>& out_shape,
-                                  const std::vector<int>& broadcast_axes) {
-  Instruction instr("broadcast_to", {operand});
-  instr.SetAttr("out_shape", out_shape);
-  instr.SetAttr("broadcast_axes", broadcast_axes);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable CinnBuilder::Reshape(const Variable& operand, const std::vector<int>& shape) {
-  Instruction instr("reshape", {operand});
-  instr.SetAttr("shape", shape);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable CinnBuilder::Transpose(const Variable& operand, const std::vector<int>& axis) {
-  Instruction instr("transpose", {operand});
-  instr.SetAttr("axis", axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable CinnBuilder::Slice(const Variable& operand,
-                            const std::vector<int>& axes,
-                            const std::vector<int>& starts,
-                            const std::vector<int>& ends) {
-  Instruction instr("slice", {operand});
-  instr.SetAttr("axes", axes);
-  instr.SetAttr("starts", starts);
-  instr.SetAttr("ends", ends);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable CinnBuilder::Select(const Variable& condition, const Variable& true_value, const Variable& false_value) {
-  Instruction instr("select", {condition, true_value, false_value});
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable CinnBuilder::Reverse(const Variable& operand, const std::vector<int>& axis) {
-  Instruction instr("reverse", {operand});
-  instr.SetAttr("axis", axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
 std::vector<Variable> CinnBuilder::BnMeanVariance(const Variable& x) {
   Instruction instr("bn_mean_variance", {x});
   // optimize bn forward reduce computation, set reduce dimension(NCHW suppport only, to be deprecated).
@@ -234,20 +147,6 @@ std::vector<Variable> CinnBuilder::BnGradBiasScale(const Variable& x, const Vari
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutputs();
-}
-
-Variable CinnBuilder::UnaryOp(const std::string& op_type, const Variable& operand) {
-  Instruction instr(op_type, {operand});
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable CinnBuilder::BinaryOp(const std::string& op_type, const Variable& lhs, const Variable& rhs) {
-  Instruction instr(op_type, {lhs, rhs});
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
 }
 
 }  // namespace frontend

--- a/cinn/frontend/cinn_builder.h
+++ b/cinn/frontend/cinn_builder.h
@@ -83,24 +83,6 @@
 namespace cinn {
 namespace frontend {
 
-enum class ComparisonKind : std::int8_t {
-  kUnk = -1,
-  kEq,
-  kNe,
-  kGe,
-  kGt,
-  kLe,
-  kLt,
-};
-
-enum class ReduceKind : std::int8_t {
-  kUnk = -1,
-  kSum,
-  kProd,
-  kMax,
-  kMin,
-};
-
 class CinnBuilder : public BaseBuilder {
  public:
   using BaseBuilder::BaseBuilder;

--- a/cinn/frontend/cinn_builder.h
+++ b/cinn/frontend/cinn_builder.h
@@ -116,8 +116,6 @@ class CinnBuilder : public BaseBuilder {
   BINARY_OP_FOREACH(BINARY_OP_DECL)
 #undef BINARY_OP_DECL
 
-  Variable Concat(const std::vector<Variable>& input_vars, int axis = 0);
-
   Variable Conv(const Variable& lhs,
                 const Variable& rhs,
                 const std::vector<int>& strides      = {1, 1},
@@ -131,44 +129,9 @@ class CinnBuilder : public BaseBuilder {
 
   Variable Compare(const Variable& lhs, const Variable& rhs, ComparisonKind kind);
 
-  /**
-   * @brief Reduce array elements over the given dims.
-   *
-   * @param operand The input variable.
-   * @param dim The dims along which a sum is performed. If dim is empty, the operation will sum over all elements
-   * of the input array. If the dim has negative value, it should count from the last dim to the first.
-   * @param keep_dim If it is set true, the axes which are reduced are left in the result as dimensions with size one.
-   * With this option, the result will broadcast correctly against the input array.
-   *
-   * @return The result variable.
-   */
-  Variable Reduce(const Variable& operand, ReduceKind kind, const std::vector<int>& dim, bool keep_dim = false);
-
-  Variable BroadcastTo(const Variable& operand,
-                       const std::vector<int>& out_shape,
-                       const std::vector<int>& broadcast_axes);
-
-  Variable Reshape(const Variable& operand, const std::vector<int>& shape);
-
-  Variable Transpose(const Variable& operand, const std::vector<int>& axis);
-
-  Variable Slice(const Variable& operand,
-                 const std::vector<int>& axes,
-                 const std::vector<int>& starts = {},
-                 const std::vector<int>& ends   = {});
-
-  Variable Select(const Variable& condition, const Variable& true_value, const Variable& false_value);
-
-  Variable Reverse(const Variable& operand, const std::vector<int>& axis);
-
   std::vector<Variable> BnMeanVariance(const Variable& x);
 
   std::vector<Variable> BnGradBiasScale(const Variable& x, const Variable& x_mean, const Variable& y_grad);
-
- private:
-  Variable UnaryOp(const std::string& op_type, const Variable& operand);
-
-  Variable BinaryOp(const std::string& op_type, const Variable& lhs, const Variable& rhs);
 };
 
 }  // namespace frontend

--- a/cinn/frontend/computation_test.cc
+++ b/cinn/frontend/computation_test.cc
@@ -65,8 +65,8 @@ Program CreateAddProgram() {
   NetBuilder builder("net_builder");
   auto a       = builder.CreateInput(Float(32), {M, N});
   auto b       = builder.CreateInput(Float(32), {M, N});
-  auto c       = builder.relu(a);
-  auto d       = builder.add(b, c);
+  auto c       = builder.Relu(a);
+  auto d       = builder.Add(b, c);
   auto program = builder.Build();
 
   return program;
@@ -79,8 +79,8 @@ TEST(cinn_computation, basic_cpu) {
 
   auto a = builder.CreateInput(Float(32), {M, N}, "A");
   auto b = builder.CreateInput(Float(32), {M, N}, "B");
-  auto c = builder.add(a, b);
-  auto d = builder.add(a, c);
+  auto c = builder.Add(a, b);
+  auto d = builder.Add(a, c);
 
   auto target = common::DefaultHostTarget();
   auto comp   = CinnComputation::BuildAndCompile(target, builder);
@@ -111,8 +111,8 @@ TEST(cinn_computation, basic_gpu) {
 
   auto a = builder.CreateInput(Float(32), {M, N}, "A");
   auto b = builder.CreateInput(Float(32), {M, N}, "B");
-  auto c = builder.add(a, b);
-  auto d = builder.add(a, c);
+  auto c = builder.Add(a, b);
+  auto d = builder.Add(a, c);
 
   auto target = common::DefaultNVGPUTarget();
   auto comp   = CinnComputation::BuildAndCompile(target, builder);

--- a/cinn/frontend/decomposer/activation_test.cc
+++ b/cinn/frontend/decomposer/activation_test.cc
@@ -19,7 +19,7 @@ namespace cinn::frontend {
 TEST(Decomposer, relu) {
   NetBuilder builder("relu");
   auto x   = builder.CreateInput(Float(32), {20, 10}, "x");
-  auto out = builder.relu(x);
+  auto out = builder.Relu(x);
 
   auto relu_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n   = lengths[0];
@@ -41,7 +41,7 @@ TEST(Decomposer, relu_grad) {
   NetBuilder builder("relu_grad");
   auto dout = builder.CreateInput(Float(32), {20, 10}, "dout");
   auto out  = builder.CreateInput(Float(32), {20, 10}, "out");
-  auto dx   = builder.relu_grad(dout, out);
+  auto dx   = builder.ReluGrad(dout, out);
 
   auto relu_grad_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n    = lengths[0];

--- a/cinn/frontend/decomposer/batch_norm_test.cc
+++ b/cinn/frontend/decomposer/batch_norm_test.cc
@@ -158,7 +158,7 @@ TEST(Decomposer, BatchNormTrain) {
     auto moving_variance = net_builder.CreateInput(Float(32), {c}, "moving_variance");
 
     auto outputs =
-        net_builder.Batchnorm(x, scale, bias, moving_mean, moving_variance, epsilon, momentum, data_layout, is_test);
+        net_builder.BatchNorm(x, scale, bias, moving_mean, moving_variance, epsilon, momentum, data_layout, is_test);
     for (auto output : outputs) {
       output_names.push_back(output->id);
     }

--- a/cinn/frontend/decomposer/batch_norm_test.cc
+++ b/cinn/frontend/decomposer/batch_norm_test.cc
@@ -158,7 +158,7 @@ TEST(Decomposer, BatchNormTrain) {
     auto moving_variance = net_builder.CreateInput(Float(32), {c}, "moving_variance");
 
     auto outputs =
-        net_builder.batchnorm(x, scale, bias, moving_mean, moving_variance, epsilon, momentum, data_layout, is_test);
+        net_builder.Batchnorm(x, scale, bias, moving_mean, moving_variance, epsilon, momentum, data_layout, is_test);
     for (auto output : outputs) {
       output_names.push_back(output->id);
     }
@@ -338,7 +338,7 @@ TEST(Decomposer, BatchNormGrad) {
     auto saved_mean     = net_builder.CreateInput(Float(32), {c}, "saved_mean");
     auto saved_variance = net_builder.CreateInput(Float(32), {c}, "saved_variance");
 
-    auto outputs = net_builder.batch_norm_grad(y_grad, x, scale, saved_mean, saved_variance, epsilon);
+    auto outputs = net_builder.BatchNormGrad(y_grad, x, scale, saved_mean, saved_variance, epsilon);
     for (auto output : outputs) {
       output_names.push_back(output->id);
     }

--- a/cinn/frontend/decomposer/broadcast_test.cc
+++ b/cinn/frontend/decomposer/broadcast_test.cc
@@ -20,7 +20,7 @@ TEST(Decomposer, elementwise_add_bcast0) {
   NetBuilder builder("elementwise_add");
   auto x   = builder.CreateInput(Float(32), {4, 1, 20, 10});
   auto y   = builder.CreateInput(Float(32), {10, 20});
-  auto out = builder.elementwise_add(x, y, 1);
+  auto out = builder.ElementwiseAdd(x, y, 1);
 
   std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
   std::vector<std::string> output_names       = {out->id};
@@ -33,7 +33,7 @@ TEST(Decomposer, elementwise_add_grad_bcast0) {
   auto dout      = builder.CreateInput(Float(32), {4, 10, 20, 10});
   auto x         = builder.CreateInput(Float(32), {4, 1, 20, 10});
   auto y         = builder.CreateInput(Float(32), {10, 20});
-  auto out_grads = builder.elementwise_add_grad(dout, x, y, 1);
+  auto out_grads = builder.ElementwiseAddGrad(dout, x, y, 1);
 
   std::vector<std::string> input_names        = {dout.id().data()};
   std::vector<std::string> output_names       = {out_grads[0]->id, out_grads[1]->id};
@@ -45,7 +45,7 @@ TEST(Decomposer, elementwise_add_bcast1) {
   NetBuilder builder("elementwise_add");
   auto x   = builder.CreateInput(Float(32), {32, 64, 32, 32});
   auto y   = builder.CreateInput(Float(32), {64});
-  auto out = builder.elementwise_add(x, y, 1);
+  auto out = builder.ElementwiseAdd(x, y, 1);
 
   auto add_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     float* x   = static_cast<float*>(ptrs[0]);
@@ -71,7 +71,7 @@ TEST(Decomposer, elementwise_add_grad_bcast1) {
   auto dout      = builder.CreateInput(Float(32), {32, 64, 32, 32});
   auto x         = builder.CreateInput(Float(32), {32, 64, 32, 32});
   auto y         = builder.CreateInput(Float(32), {64});
-  auto out_grads = builder.elementwise_add_grad(dout, x, y, 1);
+  auto out_grads = builder.ElementwiseAddGrad(dout, x, y, 1);
 
   auto add_grad_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     float* dout = static_cast<float*>(ptrs[0]);
@@ -100,7 +100,7 @@ TEST(Decomposer, elementwise_add_bcast2) {
   NetBuilder builder("elementwise_add");
   auto x   = builder.CreateInput(Float(32), {32, 16});
   auto y   = builder.CreateInput(Float(32), {1});
-  auto out = builder.elementwise_add(x, y);
+  auto out = builder.ElementwiseAdd(x, y);
 
   auto add_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n     = lengths[0];
@@ -124,7 +124,7 @@ TEST(Decomposer, elementwise_add_grad_bcast2) {
   auto dout      = builder.CreateInput(Float(32), {32, 16});
   auto x         = builder.CreateInput(Float(32), {32, 16});
   auto y         = builder.CreateInput(Float(32), {1});
-  auto out_grads = builder.elementwise_add_grad(dout, x, y);
+  auto out_grads = builder.ElementwiseAddGrad(dout, x, y);
 
   auto add_grad_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n    = lengths[0];
@@ -148,7 +148,7 @@ TEST(Decomposer, elementwise_add_same_dims) {
   NetBuilder builder("elementwise_add");
   auto x   = builder.CreateInput(Float(32), {32, 16});
   auto y   = builder.CreateInput(Float(32), {32, 16});
-  auto out = builder.elementwise_add(x, y);
+  auto out = builder.ElementwiseAdd(x, y);
 
   auto add_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n   = lengths[0];
@@ -171,7 +171,7 @@ TEST(Decomposer, elementwise_add_grad_same_dims) {
   auto dout      = builder.CreateInput(Float(32), {32, 16});
   auto x         = builder.CreateInput(Float(32), {32, 16});
   auto y         = builder.CreateInput(Float(32), {32, 16});
-  auto out_grads = builder.elementwise_add_grad(dout, x, y);
+  auto out_grads = builder.ElementwiseAddGrad(dout, x, y);
 
   auto add_grad_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n    = lengths[0];

--- a/cinn/frontend/decomposer/conv2d_grad_test.cc
+++ b/cinn/frontend/decomposer/conv2d_grad_test.cc
@@ -57,7 +57,7 @@ TEST(nn, CONV_GRAD) {
     auto x      = net_builder.CreateInput(Float(32), {n, ic, h, w}, "x");
     auto weight = net_builder.CreateInput(Float(32), {oc, ic, fh, fw}, "weight");
     // add batch norm train
-    auto outputs = net_builder.conv2d_grad(dy, x, weight, strides, paddings, dilations);
+    auto outputs = net_builder.Conv2dGrad(dy, x, weight, strides, paddings, dilations);
   }
 
   // build program

--- a/cinn/frontend/decomposer/elementwise_test.cc
+++ b/cinn/frontend/decomposer/elementwise_test.cc
@@ -21,7 +21,7 @@ TEST(Decomposer, sum) {
   auto x   = builder.CreateInput(Float(32), {32, 16});
   auto y   = builder.CreateInput(Float(32), {32, 16});
   auto z   = builder.CreateInput(Float(32), {32, 16});
-  auto out = builder.sum({x, y, z});
+  auto out = builder.Sum({x, y, z});
 
   auto sum_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
     size_t n   = lengths[0];

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -23,68 +23,22 @@
 namespace cinn {
 namespace frontend {
 
-Variable NetBuilder::UnaryOp(const std::string& op_type, const Variable& operand) {
-  Instruction instr(op_type, {operand});
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::BinaryOp(const std::string& op_type, const Variable& lhs, const Variable& rhs) {
-  Instruction instr(op_type, {lhs, rhs});
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
 #define NETBUILDER_UNARY_OP_DEF(func_name__, op_type__) \
   Variable NetBuilder::func_name__(const Variable& operand) { return UnaryOp(#op_type__, operand); }
-NETBUILDER_UNARY_OP_DEF(sqrt, sqrt)
-NETBUILDER_UNARY_OP_DEF(tanh, tanh)
-NETBUILDER_UNARY_OP_DEF(relu, relu)
-NETBUILDER_UNARY_OP_DEF(sigmoid, sigmoid)
-NETBUILDER_UNARY_OP_DEF(identity, identity)
+NETBUILDER_UNARY_OP_DEF(Sqrt, sqrt)
+NETBUILDER_UNARY_OP_DEF(Tanh, tanh)
+NETBUILDER_UNARY_OP_DEF(Relu, relu)
+NETBUILDER_UNARY_OP_DEF(Sigmoid, sigmoid)
+NETBUILDER_UNARY_OP_DEF(Identity, identity)
 
 #define NETBUILDER_BINARY_OP_DEF(func_name__, op_type__) \
   Variable NetBuilder::func_name__(const Variable& lhs, const Variable& rhs) { return BinaryOp(#op_type__, lhs, rhs); }
-NETBUILDER_BINARY_OP_DEF(sub, substract)
-NETBUILDER_BINARY_OP_DEF(div, divide)
-NETBUILDER_BINARY_OP_DEF(matmul, matmul)
-NETBUILDER_BINARY_OP_DEF(relu_grad, relu_grad)
+NETBUILDER_BINARY_OP_DEF(Sub, substract)
+NETBUILDER_BINARY_OP_DEF(Div, divide)
+NETBUILDER_BINARY_OP_DEF(Matmul, matmul)
+NETBUILDER_BINARY_OP_DEF(ReluGrad, relu_grad)
 
-Variable NetBuilder::add(const Variable& a, const Variable& b) {
-  Instruction instr("elementwise_add", {a, b});
-  instr.SetAttr("axis", -1);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::reshape(const Variable& operand, const std::vector<int>& shape) {
-  Instruction instr("reshape", {operand});
-  instr.SetAttr("shape", shape);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::transpose(const Variable& operand, const std::vector<int>& axis) {
-  Instruction instr("transpose", {operand});
-  instr.SetAttr("axis", axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::concat(const std::vector<Variable>& inputs, int axis) {
-  Instruction instr("concat", inputs);
-  instr.SetAttr("axis", axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::mul(const Variable& a, const Variable& b, int x_num_col_dims, int y_num_col_dims) {
+Variable NetBuilder::Mul(const Variable& a, const Variable& b, int x_num_col_dims, int y_num_col_dims) {
   Instruction instr("mul", {a, b});
   instr.SetAttr("x_num_col_dims", x_num_col_dims);
   instr.SetAttr("y_num_col_dims", y_num_col_dims);
@@ -93,7 +47,7 @@ Variable NetBuilder::mul(const Variable& a, const Variable& b, int x_num_col_dim
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::mulbias(
+Variable NetBuilder::Mulbias(
     const Variable& a, const Variable& b, const Variable& c, int x_num_col_dims, int y_num_col_dims) {
   Instruction instr("mulbias", {a, b, c});
   instr.SetAttr("x_num_col_dims", x_num_col_dims);
@@ -103,7 +57,9 @@ Variable NetBuilder::mulbias(
   return instr.GetOutput(1);
 }
 
-Variable NetBuilder::elementwise_add(const Variable& a, const Variable& b, int axis) {
+Variable NetBuilder::Add(const Variable& a, const Variable& b) { return ElementwiseAdd(a, b, -1); }
+
+Variable NetBuilder::ElementwiseAdd(const Variable& a, const Variable& b, int axis) {
   Instruction instr("elementwise_add", {a, b});
   instr.SetAttr("axis", axis);
   InferShape(instr);
@@ -111,10 +67,10 @@ Variable NetBuilder::elementwise_add(const Variable& a, const Variable& b, int a
   return instr.GetOutput(0);
 }
 
-const std::vector<Variable>& NetBuilder::elementwise_add_grad(const Variable& dout,
-                                                              const Variable& x,
-                                                              const Variable& y,
-                                                              int axis) {
+const std::vector<Variable>& NetBuilder::ElementwiseAddGrad(const Variable& dout,
+                                                            const Variable& x,
+                                                            const Variable& y,
+                                                            int axis) {
   Instruction instr("elementwise_add_grad", {dout, x, y});
   instr.SetAttr("axis", axis);
   InferShape(instr);
@@ -122,7 +78,7 @@ const std::vector<Variable>& NetBuilder::elementwise_add_grad(const Variable& do
   return instr.GetOutputs();
 }
 
-Variable NetBuilder::elementwise_mul(const Variable& a, const Variable& b, int axis) {
+Variable NetBuilder::ElementwiseMul(const Variable& a, const Variable& b, int axis) {
   Instruction instr("elementwise_mul", {a, b});
   instr.SetAttr("axis", axis);
   InferShape(instr);
@@ -130,7 +86,7 @@ Variable NetBuilder::elementwise_mul(const Variable& a, const Variable& b, int a
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::relu6(const Variable& a, float threshold) {
+Variable NetBuilder::Relu6(const Variable& a, float threshold) {
   Instruction instr("relu6", {a});
   instr.SetAttr("threshold", threshold);
   InferShape(instr);
@@ -138,24 +94,11 @@ Variable NetBuilder::relu6(const Variable& a, float threshold) {
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::reverse(const Variable& x, const std::vector<int>& axis) {
-  Instruction instr("reverse", {x});
-  instr.SetAttr("axis", axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
+Variable NetBuilder::ReduceSum(const Variable& x, const std::vector<int>& dim, bool keep_dim) {
+  return Reduce(x, ReduceKind::kSum, dim, keep_dim);
 }
 
-Variable NetBuilder::reduce_sum(const Variable& x, const std::vector<int>& dim, bool keep_dim) {
-  Instruction instr("reduce_sum", {x});
-  instr.SetAttr("dim", dim);
-  instr.SetAttr("keep_dim", keep_dim);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::conv2d(const Variable& a,
+Variable NetBuilder::Conv2d(const Variable& a,
                             const Variable& b,
                             const std::vector<int>& strides,
                             const std::vector<int>& paddings,
@@ -176,14 +119,14 @@ Variable NetBuilder::conv2d(const Variable& a,
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::depthwise_conv2d(const Variable& a,
-                                      const Variable& b,
-                                      const std::vector<int>& strides,
-                                      const std::vector<int>& paddings,
-                                      const std::vector<int>& dilations,
-                                      int groups,
-                                      const std::string& data_format,
-                                      const std::string& padding_algorithm) {
+Variable NetBuilder::DepthwiseConv2d(const Variable& a,
+                                     const Variable& b,
+                                     const std::vector<int>& strides,
+                                     const std::vector<int>& paddings,
+                                     const std::vector<int>& dilations,
+                                     int groups,
+                                     const std::string& data_format,
+                                     const std::string& padding_algorithm) {
   Instruction instr("depthwise_conv2d");
   instr.SetInputs({a, b});
   instr.SetAttr("stride", strides);
@@ -197,7 +140,7 @@ Variable NetBuilder::depthwise_conv2d(const Variable& a,
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::pool2d(const Variable& a,
+Variable NetBuilder::Pool2d(const Variable& a,
                             const std::string& pooling_type,
                             const std::vector<int>& ksize,
                             const std::vector<int>& strides,
@@ -225,7 +168,7 @@ Variable NetBuilder::pool2d(const Variable& a,
   return instr.GetOutput(0);
 }
 
-std::vector<Variable> NetBuilder::batchnorm(const Variable& a,
+std::vector<Variable> NetBuilder::Batchnorm(const Variable& a,
                                             const Variable& scale,
                                             const Variable& bias,
                                             const Variable& mean,
@@ -250,13 +193,13 @@ std::vector<Variable> NetBuilder::batchnorm(const Variable& a,
 }
 
 // batch norm grad, output(grad_x, grad_scale, grad_bias)
-std::vector<Variable> NetBuilder::batch_norm_grad(const Variable& dy,
-                                                  const Variable& x,
-                                                  const Variable& scale,
-                                                  const Variable& save_mean,
-                                                  const Variable& save_variance,
-                                                  const float epsilon,
-                                                  const std::string& data_layout) {
+std::vector<Variable> NetBuilder::BatchNormGrad(const Variable& dy,
+                                                const Variable& x,
+                                                const Variable& scale,
+                                                const Variable& save_mean,
+                                                const Variable& save_variance,
+                                                const float epsilon,
+                                                const std::string& data_layout) {
   Instruction instr("batch_norm_grad", {dy, x, scale, save_mean, save_variance});
   instr.SetAttr("epsilon", epsilon);
   instr.SetAttr("data_layout", data_layout);
@@ -266,7 +209,7 @@ std::vector<Variable> NetBuilder::batch_norm_grad(const Variable& dy,
   return instr.GetOutputs();
 }
 
-Variable NetBuilder::scale(const Variable& a, float scale, float bias, bool bias_after_scale) {
+Variable NetBuilder::Scale(const Variable& a, float scale, float bias, bool bias_after_scale) {
   Instruction instr("scale", {a});
   instr.SetAttr("scale", scale);
   instr.SetAttr("bias", bias);
@@ -276,7 +219,7 @@ Variable NetBuilder::scale(const Variable& a, float scale, float bias, bool bias
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::softmax(const Variable& a, int axis, const std::string& data_format) {
+Variable NetBuilder::Softmax(const Variable& a, int axis, const std::string& data_format) {
   Instruction instr("softmax", {a});
   instr.SetAttr("axis", axis);
   instr.SetAttr("data_format", data_format);
@@ -285,24 +228,7 @@ Variable NetBuilder::softmax(const Variable& a, int axis, const std::string& dat
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::slice(const Variable& a,
-                           const std::vector<int>& axes,
-                           const std::vector<int>& starts,
-                           const std::vector<int>& ends,
-                           const std::vector<int>& infer_flags,
-                           const std::vector<int>& decrease_axis) {
-  Instruction instr("slice", {a});
-  instr.SetAttr("axes", axes);
-  instr.SetAttr("starts", starts);
-  instr.SetAttr("ends", ends);
-  instr.SetAttr("infer_flags", infer_flags);
-  instr.SetAttr("decrease_axis", decrease_axis);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
-}
-
-Variable NetBuilder::dropout_infer(const Variable& a, float dropout_prob, const std::string& dropout_implementation) {
+Variable NetBuilder::DropoutInfer(const Variable& a, float dropout_prob, const std::string& dropout_implementation) {
   Instruction instr("dropout_infer", {a});
   instr.SetAttr("dropout_prob", dropout_prob);
   instr.SetAttr("dropout_implementation", dropout_implementation);
@@ -311,7 +237,7 @@ Variable NetBuilder::dropout_infer(const Variable& a, float dropout_prob, const 
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::sum(const std::vector<Variable>& inputs) {
+Variable NetBuilder::Sum(const std::vector<Variable>& inputs) {
   Instruction instr("sum", inputs);
   InferShape(instr);
   AppendInstruction(instr);
@@ -319,15 +245,15 @@ Variable NetBuilder::sum(const std::vector<Variable>& inputs) {
 }
 
 // conv2d grad, output(grad_x, grad_w)
-std::vector<Variable> NetBuilder::conv2d_grad(const Variable& dy,
-                                              const Variable& x,
-                                              const Variable& w,
-                                              const std::vector<int>& strides,
-                                              const std::vector<int>& paddings,
-                                              const std::vector<int>& dilations,
-                                              const int groups,
-                                              const std::string& data_format,
-                                              const std::string& padding_algorithm) {
+std::vector<Variable> NetBuilder::Conv2dGrad(const Variable& dy,
+                                             const Variable& x,
+                                             const Variable& w,
+                                             const std::vector<int>& strides,
+                                             const std::vector<int>& paddings,
+                                             const std::vector<int>& dilations,
+                                             const int groups,
+                                             const std::string& data_format,
+                                             const std::string& padding_algorithm) {
   Instruction instr("conv2d_grad", {dy, x, w});
   instr.SetAttr<std::vector<int>>("strides", strides);
   instr.SetAttr<std::vector<int>>("paddings", paddings);
@@ -339,41 +265,6 @@ std::vector<Variable> NetBuilder::conv2d_grad(const Variable& dy,
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutputs();
-}
-
-Variable NetBuilder::reduce(const Variable& a, ReduceKind kind, const std::vector<int>& dim, bool keep_dim) {
-  auto reduce_func = [&](const std::string& op_type) {
-    Instruction instr(op_type, {a});
-    instr.SetAttr("dim", dim);
-    instr.SetAttr("keep_dim", keep_dim);
-    InferShape(instr);
-    AppendInstruction(instr);
-    return instr.GetOutput(0);
-  };
-
-  switch (kind) {
-    case ReduceKind::kSum:
-      return reduce_func("reduce_sum");
-    case ReduceKind::kProd:
-      return reduce_func("reduce_prod");
-    case ReduceKind::kMax:
-      return reduce_func("reduce_max");
-    case ReduceKind::kMin:
-      return reduce_func("reduce_min");
-    default:
-      LOG(FATAL) << "unknown reduction kind";
-  }
-}
-
-Variable NetBuilder::broadcast_to(const Variable& a,
-                                  const std::vector<int>& out_shape,
-                                  const std::vector<int>& broadcast_axes) {
-  Instruction instr("broadcast_to", {a});
-  instr.SetAttr("out_shape", out_shape);
-  instr.SetAttr("broadcast_axes", broadcast_axes);
-  InferShape(instr);
-  AppendInstruction(instr);
-  return instr.GetOutput(0);
 }
 
 }  // namespace frontend

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -47,7 +47,7 @@ Variable NetBuilder::Mul(const Variable& a, const Variable& b, int x_num_col_dim
   return instr.GetOutput(0);
 }
 
-Variable NetBuilder::Mulbias(
+Variable NetBuilder::MulBias(
     const Variable& a, const Variable& b, const Variable& c, int x_num_col_dims, int y_num_col_dims) {
   Instruction instr("mulbias", {a, b, c});
   instr.SetAttr("x_num_col_dims", x_num_col_dims);
@@ -168,7 +168,7 @@ Variable NetBuilder::Pool2d(const Variable& a,
   return instr.GetOutput(0);
 }
 
-std::vector<Variable> NetBuilder::Batchnorm(const Variable& a,
+std::vector<Variable> NetBuilder::BatchNorm(const Variable& a,
                                             const Variable& scale,
                                             const Variable& bias,
                                             const Variable& mean,
@@ -266,27 +266,6 @@ std::vector<Variable> NetBuilder::Conv2dGrad(const Variable& dy,
   AppendInstruction(instr);
   return instr.GetOutputs();
 }
-
-template <typename T>
-Variable NetBuilder::FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu) {
-  Instruction instr("fill_constant");
-  instr.SetInputs({});
-  instr.SetAttr("shape", shape);
-  instr.SetAttr("value", value);
-  instr.SetAttr("force_cpu", force_cpu);
-
-  InferShape(instr);
-  AppendInstruction(instr);
-  auto out = instr.GetOutput(0);
-  out.set_id(name);
-  return out;
-}
-
-#define FILLCONSTANT_TEMPLATE_EXPANDER(TYPE__)        \
-  template Variable NetBuilder::FillConstant<TYPE__>( \
-      const std::vector<int>& shape, float value, const std::string& name, bool force_cpu);
-FILLCONSTANT_SUPPORT_DATATYPE_FOREACH(FILLCONSTANT_TEMPLATE_EXPANDER)
-#undef FILLCONSTANT_TEMPLATE_EXPANDER
 
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -267,5 +267,26 @@ std::vector<Variable> NetBuilder::Conv2dGrad(const Variable& dy,
   return instr.GetOutputs();
 }
 
+template <typename T>
+Variable NetBuilder::FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu) {
+  Instruction instr("fill_constant");
+  instr.SetInputs({});
+  instr.SetAttr("shape", shape);
+  instr.SetAttr("value", value);
+  instr.SetAttr("force_cpu", force_cpu);
+
+  InferShape(instr);
+  AppendInstruction(instr);
+  auto out = instr.GetOutput(0);
+  out.set_id(name);
+  return out;
+}
+
+#define FILLCONSTANT_TEMPLATE_EXPANDER(TYPE__)        \
+  template Variable NetBuilder::FillConstant<TYPE__>( \
+      const std::vector<int>& shape, float value, const std::string& name, bool force_cpu);
+FILLCONSTANT_SUPPORT_DATATYPE_FOREACH(FILLCONSTANT_TEMPLATE_EXPANDER)
+#undef FILLCONSTANT_TEMPLATE_EXPANDER
+
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -344,13 +344,7 @@ std::vector<Variable> NetBuilder::conv2d_grad(const Variable& dy,
 Variable NetBuilder::reduce(const Variable& a, ReduceKind kind, const std::vector<int>& dim, bool keep_dim) {
   auto reduce_func = [&](const std::string& op_type) {
     Instruction instr(op_type, {a});
-    std::vector<int> new_dim(dim);
-    if (dim.empty()) {
-      for (int i = 0; i < a->shape.size(); ++i) {
-        new_dim.push_back(i);
-      }
-    }
-    instr.SetAttr("dim", new_dim);
+    instr.SetAttr("dim", dim);
     instr.SetAttr("keep_dim", keep_dim);
     InferShape(instr);
     AppendInstruction(instr);

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -36,12 +36,8 @@ namespace frontend {
     macro__(Div)                                \
     macro__(Matmul)                             \
     macro__(ReluGrad)
-
-#define FILLCONSTANT_SUPPORT_DATATYPE_FOREACH(macro__)  \
-    macro__(float)                                      \
-    macro__(int)
-
 // clang-format on
+
 class NetBuilder : public BaseBuilder {
  public:
   using BaseBuilder::BaseBuilder;
@@ -62,7 +58,7 @@ class NetBuilder : public BaseBuilder {
   /**
    * Multiply two matrix and add a bias.
    */
-  Variable Mulbias(
+  Variable MulBias(
       const Variable& a, const Variable& b, const Variable& c, int x_num_col_dims = 1, int y_num_col_dims = 1);
 
   /**
@@ -135,7 +131,7 @@ class NetBuilder : public BaseBuilder {
    * is_test(true): batch norm infer (default), output={y}
    * is_test(false): batch norm training, outputs={y, saved_mean, saved_variance, moving_mean, moving_variance}
    */
-  std::vector<Variable> Batchnorm(const Variable& a,
+  std::vector<Variable> BatchNorm(const Variable& a,
                                   const Variable& scale,
                                   const Variable& bias,
                                   const Variable& mean,
@@ -176,7 +172,19 @@ class NetBuilder : public BaseBuilder {
                                    const std::string& padding_algorithm = "EXPLICIT");
 
   template <typename T>
-  Variable FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu = false);
+  Variable FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu = false) {
+    Instruction instr("fill_constant");
+    instr.SetInputs({});
+    instr.SetAttr("shape", shape);
+    instr.SetAttr("value", value);
+    instr.SetAttr("force_cpu", force_cpu);
+
+    InferShape(instr);
+    AppendInstruction(instr);
+    auto out = instr.GetOutput(0);
+    out.set_id(name);
+    return out;
+  }
 };
 
 }  // namespace frontend

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -25,19 +25,19 @@ namespace frontend {
 
 // clang-format off
 #define NETBUILDER_UNARY_OP_FOREACH(macro__)    \
-    macro__(sqrt)                               \
-    macro__(tanh)                               \
-    macro__(relu)                               \
-    macro__(sigmoid)                            \
-    macro__(identity)
+    macro__(Sqrt)                               \
+    macro__(Tanh)                               \
+    macro__(Relu)                               \
+    macro__(Sigmoid)                            \
+    macro__(Identity)
 
 #define NETBUILDER_BINARY_OP_FOREACH(macro__)   \
-    macro__(sub)                                \
-    macro__(div)                                \
-    macro__(matmul)                             \
-    macro__(relu_grad)
-// clang-format on
+    macro__(Sub)                                \
+    macro__(Div)                                \
+    macro__(Matmul)                             \
+    macro__(ReluGrad)
 
+// clang-format on
 class NetBuilder : public BaseBuilder {
  public:
   using BaseBuilder::BaseBuilder;
@@ -51,75 +51,51 @@ class NetBuilder : public BaseBuilder {
 #undef NETBUILDER_BINARY_OP_DECL
 
   /**
-   * Add two variables.
-   */
-  Variable add(const Variable& a, const Variable& b);
-
-  /**
-   * Reshape Variable.
-   */
-  Variable reshape(const Variable& a, const std::vector<int>& shape);
-
-  /**
-   * Transpose matrix.
-   */
-  Variable transpose(const Variable& a, const std::vector<int>& axis);
-
-  /**
-   * Concat tensors among the axis dimension.
-   */
-  Variable concat(const std::vector<Variable>& inputs, int axis = 0);
-
-  /**
    * Multiply two matrix.
    */
-  Variable mul(const Variable& a, const Variable& b, int x_num_col_dims = 1, int y_num_col_dims = 1);
+  Variable Mul(const Variable& a, const Variable& b, int x_num_col_dims = 1, int y_num_col_dims = 1);
 
   /**
    * Multiply two matrix and add a bias.
    */
-  Variable mulbias(
+  Variable Mulbias(
       const Variable& a, const Variable& b, const Variable& c, int x_num_col_dims = 1, int y_num_col_dims = 1);
+
+  /**
+   * Add two matrix(with broadcast).
+   */
+  Variable Add(const Variable& a, const Variable& b);
 
   /**
    * Add two tensors element-wise.
    */
-  Variable elementwise_add(const Variable& a, const Variable& b, int axis = -1);
+  Variable ElementwiseAdd(const Variable& a, const Variable& b, int axis = -1);
 
   /**
    * The gradient of elementwise_add.
    */
-  const std::vector<Variable>& elementwise_add_grad(const Variable& dout,
-                                                    const Variable& x,
-                                                    const Variable& y,
-                                                    int axis = -1);
+  const std::vector<Variable>& ElementwiseAddGrad(const Variable& dout,
+                                                  const Variable& x,
+                                                  const Variable& y,
+                                                  int axis = -1);
 
   /**
    * Multiply two tensors element-wise.
    */
-  Variable elementwise_mul(const Variable& a, const Variable& b, int axis = -1);
+  Variable ElementwiseMul(const Variable& a, const Variable& b, int axis = -1);
 
-  Variable relu6(const Variable& a, float threshold = 6.0f);
-
-  /**
-   * This API reverses the Variable x along the given axis.
-   * Example 1: x = [[0, 1], [2, 3], [4, 5]], axis = [0]
-   *            output = [[4, 5], [2, 3], [0, 1]]
-   * Example 2: x = [[0, 1], [2, 3], [4, 5]], axis = [0, 1]
-   *            output = [[5, 4], [3, 2], [1, 0]]
-   */
-  Variable reverse(const Variable& x, const std::vector<int>& axis);
+  Variable Relu6(const Variable& a, float threshold = 6.0f);
 
   /**
    * Compute the sum of Variable x along the given dim.
    */
-  Variable reduce_sum(const Variable& x, const std::vector<int>& dim, bool keep_dim = false);
+  Variable ReduceSum(const Variable& x, const std::vector<int>& dim, bool keep_dim = false);
 
   /**
    * The convolution2D layer calculates the output based on the input, filter
    * and strides, paddings, dilations, groups parameters.
    */
-  Variable conv2d(const Variable& a,
+  Variable Conv2d(const Variable& a,
                   const Variable& b,
                   const std::vector<int>& strides      = {1, 1},
                   const std::vector<int>& paddings     = {0, 0},
@@ -128,16 +104,16 @@ class NetBuilder : public BaseBuilder {
                   const std::string& data_format       = "NCHW",
                   const std::string& padding_algorithm = "EXPLICIT");
 
-  Variable depthwise_conv2d(const Variable& a,
-                            const Variable& b,
-                            const std::vector<int>& strides      = {1, 1},
-                            const std::vector<int>& paddings     = {0, 0},
-                            const std::vector<int>& dilations    = {1, 1},
-                            int groups                           = 1,
-                            const std::string& data_format       = "NCHW",
-                            const std::string& padding_algorithm = "EXPLICIT");
+  Variable DepthwiseConv2d(const Variable& a,
+                           const Variable& b,
+                           const std::vector<int>& strides      = {1, 1},
+                           const std::vector<int>& paddings     = {0, 0},
+                           const std::vector<int>& dilations    = {1, 1},
+                           int groups                           = 1,
+                           const std::string& data_format       = "NCHW",
+                           const std::string& padding_algorithm = "EXPLICIT");
 
-  Variable pool2d(const Variable& a,
+  Variable Pool2d(const Variable& a,
                   const std::string& pooling_type,
                   const std::vector<int>& ksize,
                   const std::vector<int>& strides      = {1, 1},
@@ -155,7 +131,7 @@ class NetBuilder : public BaseBuilder {
    * is_test(true): batch norm infer (default), output={y}
    * is_test(false): batch norm training, outputs={y, saved_mean, saved_variance, moving_mean, moving_variance}
    */
-  std::vector<Variable> batchnorm(const Variable& a,
+  std::vector<Variable> Batchnorm(const Variable& a,
                                   const Variable& scale,
                                   const Variable& bias,
                                   const Variable& mean,
@@ -166,56 +142,34 @@ class NetBuilder : public BaseBuilder {
                                   bool is_test                   = false);
 
   // batch norm grad, output(x_grad, scale_grad, bias_grad)
-  std::vector<Variable> batch_norm_grad(const Variable& dy,
-                                        const Variable& x,
-                                        const Variable& scale,
-                                        const Variable& save_mean,
-                                        const Variable& save_variance,
-                                        const float epsilon            = 1e-5,
-                                        const std::string& data_layout = "NCHW");
+  std::vector<Variable> BatchNormGrad(const Variable& dy,
+                                      const Variable& x,
+                                      const Variable& scale,
+                                      const Variable& save_mean,
+                                      const Variable& save_variance,
+                                      const float epsilon            = 1e-5,
+                                      const std::string& data_layout = "NCHW");
 
-  Variable scale(const Variable& a, float scale = 1.0f, float bias = 0.0f, bool bias_after_scale = true);
+  Variable Scale(const Variable& a, float scale = 1.0f, float bias = 0.0f, bool bias_after_scale = true);
 
-  Variable softmax(const Variable& a, int axis = -1, const std::string& data_format = "AnyLayout");
+  Variable Softmax(const Variable& a, int axis = -1, const std::string& data_format = "AnyLayout");
 
-  Variable slice(const Variable& a,
-                 const std::vector<int>& axes,
-                 const std::vector<int>& starts        = {},
-                 const std::vector<int>& ends          = {},
-                 const std::vector<int>& infer_flags   = {},
-                 const std::vector<int>& decrease_axis = {});
+  Variable DropoutInfer(const Variable& a,
+                        float dropout_prob                        = 0.5f,
+                        const std::string& dropout_implementation = "downgrade_in_infer");
 
-  Variable dropout_infer(const Variable& a,
-                         float dropout_prob                        = 0.5f,
-                         const std::string& dropout_implementation = "downgrade_in_infer");
-
-  Variable sum(const std::vector<Variable>& inputs);
+  Variable Sum(const std::vector<Variable>& inputs);
 
   // conv2d grad, output(grad_x, grad_w)
-  std::vector<Variable> conv2d_grad(const Variable& dy,
-                                    const Variable& x,
-                                    const Variable& w,
-                                    const std::vector<int>& strides      = {1, 1},
-                                    const std::vector<int>& paddings     = {0, 0},
-                                    const std::vector<int>& dilations    = {1, 1},
-                                    const int groups                     = 1,
-                                    const std::string& data_format       = "NCHW",
-                                    const std::string& padding_algorithm = "EXPLICIT");
-
-  /**
-   * Reduce tensor by the kind operator among the dim.
-   */
-  Variable reduce(const Variable& a,
-                  ReduceKind kind             = ReduceKind::kSum,
-                  const std::vector<int>& dim = std::vector<int>{},
-                  bool keep_dim               = false);
-
-  Variable broadcast_to(const Variable& a, const std::vector<int>& out_shape, const std::vector<int>& broadcast_axes);
-
- private:
-  Variable UnaryOp(const std::string& op_type, const Variable& operand);
-
-  Variable BinaryOp(const std::string& op_type, const Variable& lhs, const Variable& rhs);
+  std::vector<Variable> Conv2dGrad(const Variable& dy,
+                                   const Variable& x,
+                                   const Variable& w,
+                                   const std::vector<int>& strides      = {1, 1},
+                                   const std::vector<int>& paddings     = {0, 0},
+                                   const std::vector<int>& dilations    = {1, 1},
+                                   const int groups                     = 1,
+                                   const std::string& data_format       = "NCHW",
+                                   const std::string& padding_algorithm = "EXPLICIT");
 };
 
 }  // namespace frontend

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -37,6 +37,10 @@ namespace frontend {
     macro__(Matmul)                             \
     macro__(ReluGrad)
 
+#define FILLCONSTANT_SUPPORT_DATATYPE_FOREACH(macro__)  \
+    macro__(float)                                      \
+    macro__(int)
+
 // clang-format on
 class NetBuilder : public BaseBuilder {
  public:
@@ -170,6 +174,9 @@ class NetBuilder : public BaseBuilder {
                                    const int groups                     = 1,
                                    const std::string& data_format       = "NCHW",
                                    const std::string& padding_algorithm = "EXPLICIT");
+
+  template <typename T>
+  Variable FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu = false);
 };
 
 }  // namespace frontend

--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -44,8 +44,8 @@ Program CreateAddProgram() {
   NetBuilder builder("net_builder");
   auto a       = builder.CreateInput(Float(32), {M, N}, "A");
   auto b       = builder.CreateInput(Float(32), {M, N}, "B");
-  auto c       = builder.add(a, b);
-  auto d       = builder.add(a, c);
+  auto c       = builder.Add(a, b);
+  auto d       = builder.Add(a, c);
   auto program = builder.Build();
 
   return program;
@@ -127,8 +127,8 @@ TEST(net_build, program_execute_fc) {
   auto w = builder.CreateInput(Float(32), {N, K}, "W");  // weight
   auto b = builder.CreateInput(Float(32), {N}, "B");     // bias
 
-  auto mul_out = builder.mul(a, w, 2, 1);
-  auto add_out = builder.add(mul_out, b);
+  auto mul_out = builder.Mul(a, w, 2, 1);
+  auto add_out = builder.Add(mul_out, b);
   auto program = builder.Build();
 
 #ifdef CINN_WITH_CUDA
@@ -167,7 +167,7 @@ TEST(net_build, program_execute_reverse) {
 
   NetBuilder builder("net_builder");
   Placeholder input    = builder.CreateInput(Float(32), {B, C, H, W}, "Img");
-  Variable reverse_out = builder.reverse(input, {2, 3});
+  Variable reverse_out = builder.Reverse(input, {2, 3});
   auto program         = builder.Build();
 
 #ifdef CINN_WITH_CUDA

--- a/cinn/frontend/op_mappers/batchnorm.cc
+++ b/cinn/frontend/op_mappers/batchnorm.cc
@@ -58,7 +58,7 @@ void BatchnormOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
     VLOG(4) << "Invoke batch_norm OpMapper with train mode";
   }
 
-  auto outs = ctx.Builder()->Batchnorm(x, scale, bias, mean, variance, epsilon, momentum, data_layout, test_mode);
+  auto outs = ctx.Builder()->BatchNorm(x, scale, bias, mean, variance, epsilon, momentum, data_layout, test_mode);
   CHECK_EQ(outs.size(), output_names.size()) << "batch_norm API's should return" << output_names.size() << "Variables!";
 
   for (int i = 0; i < outs.size(); i++) {

--- a/cinn/frontend/op_mappers/batchnorm.cc
+++ b/cinn/frontend/op_mappers/batchnorm.cc
@@ -58,7 +58,7 @@ void BatchnormOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
     VLOG(4) << "Invoke batch_norm OpMapper with train mode";
   }
 
-  auto outs = ctx.Builder()->batchnorm(x, scale, bias, mean, variance, epsilon, momentum, data_layout, test_mode);
+  auto outs = ctx.Builder()->Batchnorm(x, scale, bias, mean, variance, epsilon, momentum, data_layout, test_mode);
   CHECK_EQ(outs.size(), output_names.size()) << "batch_norm API's should return" << output_names.size() << "Variables!";
 
   for (int i = 0; i < outs.size(); i++) {
@@ -99,7 +99,7 @@ void BatchNormGradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCon
   auto epsilon     = utils::GetAttrOrDefault<float>(op_desc, "epsilon", 1e-5f);
 
   // batch norm grad, output(grad_x, grad_scale, grad_bias)
-  auto outs = ctx.Builder()->batch_norm_grad(dy, x, scale, saved_mean, saved_variance, epsilon, data_layout);
+  auto outs = ctx.Builder()->BatchNormGrad(dy, x, scale, saved_mean, saved_variance, epsilon, data_layout);
   CHECK_EQ(outs.size(), 3ul) << "batch_norm_grad API's should return 3 Variable!";
 
   std::vector<std::string> output_names = {

--- a/cinn/frontend/op_mappers/conv2d.cc
+++ b/cinn/frontend/op_mappers/conv2d.cc
@@ -42,7 +42,7 @@ void Conv2dOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
   auto padding_algorithm = utils::GetAttrOrDefault<std::string>(op_desc, "padding_algorithm", "EXPLICIT");
   auto x                 = ctx.GetVar(x_name);
   Variable y             = ctx.GetVar(y_name);
-  auto out = ctx.Builder()->conv2d(x, y, strides, paddings, dilations, groups, data_format, padding_algorithm);
+  auto out = ctx.Builder()->Conv2d(x, y, strides, paddings, dilations, groups, data_format, padding_algorithm);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -73,9 +73,9 @@ void DepthwiseConv2dOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperC
 
   Variable out;
   if (ctx.Target().arch == Target::Arch::X86) {
-    out = ctx.Builder()->conv2d(x, y, strides, paddings, dilations, groups, data_format, padding_algorithm);
+    out = ctx.Builder()->Conv2d(x, y, strides, paddings, dilations, groups, data_format, padding_algorithm);
   } else {
-    out = ctx.Builder()->depthwise_conv2d(x, y, strides, paddings, dilations, groups, data_format, padding_algorithm);
+    out = ctx.Builder()->DepthwiseConv2d(x, y, strides, paddings, dilations, groups, data_format, padding_algorithm);
   }
 
   ctx.AddVar(out_name, out);
@@ -121,7 +121,7 @@ void Conv2dGradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   auto weight = ctx.GetVar(w_name);
 
   auto out =
-      ctx.Builder()->conv2d_grad(dy, x, weight, strides, paddings, dilations, groups, data_format, padding_algorithm);
+      ctx.Builder()->Conv2dGrad(dy, x, weight, strides, paddings, dilations, groups, data_format, padding_algorithm);
 
   if (has_dx) {
     ctx.AddVar(dx_name, out[0]);

--- a/cinn/frontend/op_mappers/dropout.cc
+++ b/cinn/frontend/op_mappers/dropout.cc
@@ -29,7 +29,7 @@ void DropoutInferOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCont
   auto dropout_implementation =
       utils::GetAttrOrDefault<std::string>(op_desc, "dropout_implementation", "downgrade_in_infer");
   auto x   = ctx.GetVar(x_name);
-  auto out = ctx.Builder()->dropout_infer(x, dropout_prob, dropout_implementation);
+  auto out = ctx.Builder()->DropoutInfer(x, dropout_prob, dropout_implementation);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);

--- a/cinn/frontend/op_mappers/elementwise.cc
+++ b/cinn/frontend/op_mappers/elementwise.cc
@@ -29,7 +29,7 @@ void AddOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx)
 
   auto x   = ctx.GetVar(x_name);
   auto y   = ctx.GetVar(y_name);
-  auto out = ctx.Builder()->add(x, y);
+  auto out = ctx.Builder()->Add(x, y);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -47,7 +47,7 @@ void ElementwiseAddOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCo
 
   auto x   = ctx.GetVar(x_name);
   auto y   = ctx.GetVar(y_name);
-  auto out = ctx.Builder()->elementwise_add(x, y, axis);
+  auto out = ctx.Builder()->ElementwiseAdd(x, y, axis);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -71,7 +71,7 @@ void ElementwiseAddGradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapp
   auto x    = ctx.GetVar(x_name);
   auto y    = ctx.GetVar(y_name);
   auto dout = ctx.GetVar(dout_name);
-  auto outs = ctx.Builder()->elementwise_add_grad(dout, x, y, axis);
+  auto outs = ctx.Builder()->ElementwiseAddGrad(dout, x, y, axis);
   CHECK_EQ(outs.size(), 2) << "elementwise_add_grad should return 2 variables";
 
   auto dx = outs.front();
@@ -94,7 +94,7 @@ void ElementwiseMulOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCo
 
   auto x   = ctx.GetVar(x_name);
   auto y   = ctx.GetVar(y_name);
-  auto out = ctx.Builder()->elementwise_mul(x, y, axis);
+  auto out = ctx.Builder()->ElementwiseMul(x, y, axis);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -109,7 +109,7 @@ void SumOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx)
     xs.emplace_back(ctx.GetVar(name));
   }
 
-  auto out = ctx.Builder()->sum(xs);
+  auto out = ctx.Builder()->Sum(xs);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();

--- a/cinn/frontend/op_mappers/mul.cc
+++ b/cinn/frontend/op_mappers/mul.cc
@@ -43,14 +43,14 @@ void MulOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx)
 #ifdef CINN_WITH_CUDNN
     auto tran_shape = y->shape;
     std::swap(tran_shape[0], tran_shape[1]);
-    tran_y = ctx.Builder()->reshape(y, tran_shape);
+    tran_y = ctx.Builder()->Reshape(y, tran_shape);
     VLOG(4) << "Run with CUDNN and reshape y to" << cinn::utils::Join(tran_y->shape, ",");
 #else
-    tran_y = ctx.Builder()->transpose(y, {1, 0});
+    tran_y = ctx.Builder()->Transpose(y, {1, 0});
     VLOG(4) << "Run Not with CUDNN and transpose y to" << cinn::utils::Join(tran_y->shape, ",");
 #endif
   } else {
-    tran_y = ctx.Builder()->transpose(y, {1, 0});
+    tran_y = ctx.Builder()->Transpose(y, {1, 0});
     VLOG(4) << "Run Not with CUDNN and transpose y to" << cinn::utils::Join(tran_y->shape, ",");
   }
 
@@ -61,7 +61,7 @@ void MulOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx)
   VLOG(4) << "Mul y_num_col_dims: " << y_num_col_dims;
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "y shape: " << cinn::utils::Join(tran_y->shape, ",");
-  auto out = ctx.Builder()->mul(x, tran_y, x_num_col_dims, y_num_col_dims);
+  auto out = ctx.Builder()->Mul(x, tran_y, x_num_col_dims, y_num_col_dims);
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
   ctx.AddVar(out_name, out);
@@ -95,14 +95,14 @@ void MulBiasOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
 #ifdef CINN_WITH_CUDNN
     auto tran_shape = y->shape;
     std::swap(tran_shape[0], tran_shape[1]);
-    tran_y = ctx.Builder()->reshape(y, tran_shape);
+    tran_y = ctx.Builder()->Reshape(y, tran_shape);
     VLOG(4) << "Run with CUDNN and reshape y to" << cinn::utils::Join(tran_y->shape, ",");
 #else
-    tran_y = ctx.Builder()->transpose(y, {1, 0});
+    tran_y = ctx.Builder()->Transpose(y, {1, 0});
     VLOG(4) << "Run Not with CUDNN and transpose y to" << cinn::utils::Join(tran_y->shape, ",");
 #endif
   } else {
-    tran_y = ctx.Builder()->transpose(y, {1, 0});
+    tran_y = ctx.Builder()->Transpose(y, {1, 0});
     VLOG(4) << "Run Not with CUDNN and transpose y to" << cinn::utils::Join(tran_y->shape, ",");
   }
 
@@ -114,7 +114,7 @@ void MulBiasOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "y shape: " << cinn::utils::Join(tran_y->shape, ",");
   VLOG(4) << "z shape: " << cinn::utils::Join(z->shape, ",");
-  auto out = ctx.Builder()->mulbias(x, tran_y, z, x_num_col_dims, y_num_col_dims);
+  auto out = ctx.Builder()->Mulbias(x, tran_y, z, x_num_col_dims, y_num_col_dims);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();

--- a/cinn/frontend/op_mappers/mul.cc
+++ b/cinn/frontend/op_mappers/mul.cc
@@ -114,7 +114,7 @@ void MulBiasOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "y shape: " << cinn::utils::Join(tran_y->shape, ",");
   VLOG(4) << "z shape: " << cinn::utils::Join(z->shape, ",");
-  auto out = ctx.Builder()->Mulbias(x, tran_y, z, x_num_col_dims, y_num_col_dims);
+  auto out = ctx.Builder()->MulBias(x, tran_y, z, x_num_col_dims, y_num_col_dims);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();

--- a/cinn/frontend/op_mappers/pool2d.cc
+++ b/cinn/frontend/op_mappers/pool2d.cc
@@ -45,7 +45,7 @@ void Pool2dOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
   auto adaptive          = utils::GetAttrOrDefault<bool>(op_desc, "adaptive", false);
   auto padding_algorithm = utils::GetAttrOrDefault<std::string>(op_desc, "padding_algorithm", "EXPLICIT");
   auto x                 = ctx.GetVar(x_name);
-  auto out               = ctx.Builder()->pool2d(x,
+  auto out               = ctx.Builder()->Pool2d(x,
                                    pooling_type,
                                    ksize,
                                    strides,

--- a/cinn/frontend/op_mappers/relu.cc
+++ b/cinn/frontend/op_mappers/relu.cc
@@ -25,7 +25,7 @@ void ReluOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
   auto x        = ctx.GetVar(x_name);
-  auto out      = ctx.Builder()->relu(x);
+  auto out      = ctx.Builder()->Relu(x);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -39,7 +39,7 @@ void Relu6OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
 
   auto threshold = utils::GetAttrOrDefault<float>(op_desc, "threshold", 6.0f);
   auto x         = ctx.GetVar(x_name);
-  auto out       = ctx.Builder()->relu6(x, threshold);
+  auto out       = ctx.Builder()->Relu6(x, threshold);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -55,7 +55,7 @@ void ReluGradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext&
 
   auto dout = ctx.GetVar(dout_name);
   auto out  = ctx.GetVar(out_name);
-  auto dx   = ctx.Builder()->relu_grad(dout, out);
+  auto dx   = ctx.Builder()->ReluGrad(dout, out);
 
   ctx.AddVar(dx_name, dx);
   ctx.AddVarModelToProgram(dx_name, dx->id);

--- a/cinn/frontend/op_mappers/reshape.cc
+++ b/cinn/frontend/op_mappers/reshape.cc
@@ -30,7 +30,7 @@ void ReshapeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "reshape to : " << cinn::utils::Join(shape, ",");
 
-  auto out = ctx.Builder()->reshape(x, shape);
+  auto out = ctx.Builder()->Reshape(x, shape);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
@@ -56,7 +56,7 @@ void ReshapeGradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   auto x = get_input_var("X");
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
 
-  auto out = ctx.Builder()->reshape(dout, x->shape);
+  auto out = ctx.Builder()->Reshape(dout, x->shape);
 
   auto out_name = get_output_name(paddle::GradVarName("X"));
   ctx.AddVar(out_name, out);
@@ -73,7 +73,7 @@ void Reshape2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext&
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "reshape to : " << cinn::utils::Join(shape, ",");
 
-  auto out = ctx.Builder()->reshape(x, shape);
+  auto out = ctx.Builder()->Reshape(x, shape);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
@@ -88,7 +88,7 @@ void Reshape2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext&
   CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
   auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->identity(x);
+  auto xshape = ctx.Builder()->Identity(x);
 
   ctx.AddVar(xshape_name, xshape);
   ctx.AddVarModelToProgram(xshape_name, xshape->id);
@@ -112,7 +112,7 @@ void Reshape2GradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCont
   auto xshape = get_input_var("XShape");
   VLOG(4) << "x shape: " << cinn::utils::Join(xshape->shape, ",");
 
-  auto out = ctx.Builder()->reshape(dout, xshape->shape);
+  auto out = ctx.Builder()->Reshape(dout, xshape->shape);
 
   auto out_name = get_output_name(paddle::GradVarName("X"));
   ctx.AddVar(out_name, out);

--- a/cinn/frontend/op_mappers/scale.cc
+++ b/cinn/frontend/op_mappers/scale.cc
@@ -31,7 +31,7 @@ void ScaleOpMapper(const paddle::cpp::OpDesc& op_desc, const cinn::frontend::OpM
   auto bias             = utils::GetAttrOrDefault<float>(op_desc, "bias", 0.0f);
   auto bias_after_scale = utils::GetAttrOrDefault<bool>(op_desc, "bias_after_scale", true);
 
-  auto out = ctx.Builder()->scale(x, scale, bias, bias_after_scale);
+  auto out = ctx.Builder()->Scale(x, scale, bias, bias_after_scale);
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
   ctx.AddVar(out_name, out);

--- a/cinn/frontend/op_mappers/sigmoid.cc
+++ b/cinn/frontend/op_mappers/sigmoid.cc
@@ -26,7 +26,7 @@ void SigmoidOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
   auto out_name = op_desc.Output("Out").front();
 
   auto x   = ctx.GetVar(x_name);
-  auto out = ctx.Builder()->sigmoid(x);
+  auto out = ctx.Builder()->Sigmoid(x);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);

--- a/cinn/frontend/op_mappers/slice.cc
+++ b/cinn/frontend/op_mappers/slice.cc
@@ -35,7 +35,7 @@ void SliceOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
   auto infer_flags   = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "infer_flags");
   auto decrease_axis = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "decrease_axis");
   auto x             = ctx.GetVar(x_name);
-  auto out           = ctx.Builder()->slice(x, axes, starts, ends, infer_flags, decrease_axis);
+  auto out           = ctx.Builder()->Slice(x, axes, starts, ends, infer_flags, decrease_axis);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);

--- a/cinn/frontend/op_mappers/softmax.cc
+++ b/cinn/frontend/op_mappers/softmax.cc
@@ -29,7 +29,7 @@ void SoftmaxOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
   auto data_format = utils::GetAttrOrDefault<std::string>(op_desc, "data_format", "AnyLayout");
 
   auto x   = ctx.GetVar(x_name);
-  auto out = ctx.Builder()->softmax(x, axis, data_format);
+  auto out = ctx.Builder()->Softmax(x, axis, data_format);
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
 }

--- a/cinn/frontend/op_mappers/transpose.cc
+++ b/cinn/frontend/op_mappers/transpose.cc
@@ -30,7 +30,7 @@ void TransposeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "transpose perm : " << cinn::utils::Join(axis, ",");
 
-  auto out = ctx.Builder()->transpose(x, axis);
+  auto out = ctx.Builder()->Transpose(x, axis);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
@@ -48,7 +48,7 @@ void Transpose2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "transpose2 perm : " << cinn::utils::Join(axis, ",");
 
-  auto out = ctx.Builder()->transpose(x, axis);
+  auto out = ctx.Builder()->Transpose(x, axis);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();
@@ -63,7 +63,7 @@ void Transpose2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
   auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->identity(x);
+  auto xshape = ctx.Builder()->Identity(x);
 
   ctx.AddVar(xshape_name, xshape);
   ctx.AddVarModelToProgram(xshape_name, xshape->id);

--- a/cinn/frontend/pass/decomposer_test.cc
+++ b/cinn/frontend/pass/decomposer_test.cc
@@ -37,8 +37,8 @@ Program CreateAddProgram() {
   NetBuilder builder("net_builder");
   auto a       = builder.CreateInput(Float(32), {M, N});
   auto b       = builder.CreateInput(Float(32), {M, N});
-  auto c       = builder.relu(a);
-  auto d       = builder.add(b, c);
+  auto c       = builder.Relu(a);
+  auto d       = builder.Add(b, c);
   auto program = builder.Build();
 
   return program;

--- a/cinn/frontend/pass/remove_identity_test.cc
+++ b/cinn/frontend/pass/remove_identity_test.cc
@@ -51,10 +51,10 @@ void SetRandData(hlir::framework::Tensor tensor, Target target) {
 TEST(RemoveIdentity, can_remove) {
   NetBuilder builder("net_builder");
   auto x          = builder.CreateInput(Float(32), {32, 16});
-  auto identity_1 = builder.identity(x);
-  auto identity_2 = builder.identity(x);
-  auto relu_1     = builder.reduce_sum(x, {0, 1});
-  auto relu_2     = builder.reduce_sum(x, {0, 1});
+  auto identity_1 = builder.Identity(x);
+  auto identity_2 = builder.Identity(x);
+  auto relu_1     = builder.ReduceSum(x, {0, 1});
+  auto relu_2     = builder.ReduceSum(x, {0, 1});
   auto program    = builder.Build();
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
@@ -84,10 +84,10 @@ TEST(RemoveIdentity, can_remove) {
 TEST(RemoveIdentity, cant_remove_by_fetchids) {
   NetBuilder builder("net_builder");
   auto x          = builder.CreateInput(Float(32), {32, 16});
-  auto identity_1 = builder.identity(x);
-  auto identity_2 = builder.identity(x);
-  auto relu_1     = builder.reduce_sum(x, {0, 1});
-  auto relu_2     = builder.reduce_sum(x, {0, 1});
+  auto identity_1 = builder.Identity(x);
+  auto identity_2 = builder.Identity(x);
+  auto relu_1     = builder.ReduceSum(x, {0, 1});
+  auto relu_2     = builder.ReduceSum(x, {0, 1});
   auto program    = builder.Build();
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
@@ -117,9 +117,9 @@ TEST(RemoveIdentity, cant_remove_by_fetchids) {
 TEST(RemoveIdentity, cant_remove_by_pattern) {
   NetBuilder builder("net_builder");
   auto x          = builder.CreateInput(Float(32), {32, 16});
-  auto identity_1 = builder.identity(x);
-  auto identity_2 = builder.identity(x);
-  auto mul        = builder.mul(x, identity_1);
+  auto identity_1 = builder.Identity(x);
+  auto identity_2 = builder.Identity(x);
+  auto mul        = builder.Mul(x, identity_1);
   auto program    = builder.Build();
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();

--- a/cinn/hlir/framework/graph_compiler_test.cc
+++ b/cinn/hlir/framework/graph_compiler_test.cc
@@ -34,8 +34,8 @@ TEST(GraphCompilerTest, TestRemoveInvaildVariables) {
   auto a = builder.CreateInput(Float(32), {1, 64, 112, 112}, "A");
   auto b = builder.CreateInput(Float(32), {64}, "B");
 
-  auto c      = builder.elementwise_add(a, b, 1);
-  auto d      = builder.relu(c);
+  auto c      = builder.ElementwiseAdd(a, b, 1);
+  auto d      = builder.Relu(c);
   auto target = common::DefaultHostTarget();
   auto graph  = std::make_shared<Graph>(builder.Build(), target);
 
@@ -58,8 +58,8 @@ TEST(GraphCompilerTest, TestInsertBufferHandlers) {
   auto a = builder.CreateInput(Float(32), {1, 64, 112, 112}, "A");
   auto b = builder.CreateInput(Float(32), {64}, "B");
 
-  auto c      = builder.elementwise_add(a, b, 1);
-  auto d      = builder.relu(c);
+  auto c      = builder.ElementwiseAdd(a, b, 1);
+  auto d      = builder.Relu(c);
   auto target = common::DefaultHostTarget();
   auto graph  = std::make_shared<Graph>(builder.Build(), target);
   ApplyPass(graph.get(), "OpFusion");

--- a/cinn/hlir/op/reduction.cc
+++ b/cinn/hlir/op/reduction.cc
@@ -316,6 +316,11 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
   bool keep_dim = false;
   if (attrs.attr_store.count("dim")) {
     dim = absl::get<std::vector<int>>(attrs.attr_store.at("dim"));
+    if (dim.empty()) {
+      for (int i = 0; i < inputs[0]->shape.size(); ++i) {
+        dim.push_back(i);
+      }
+    }
     std::sort(dim.begin(), dim.end());
     // check dim
     CHECK_LE(dim.size(), inputs[0]->shape.size());

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -356,12 +356,20 @@ void BindFrontend(pybind11::module *m) {
   // clang-format off
 #define PY_REGISTER_UNARY_FUNC(func_name__) \
   .def(SnakeName(#func_name__), &NetBuilder::func_name__, py::arg("a"))
-     NETBUILDER_UNARY_OP_FOREACH(PY_REGISTER_UNARY_FUNC)
+      NETBUILDER_UNARY_OP_FOREACH(PY_REGISTER_UNARY_FUNC)
 #undef PY_REGISTER_UNARY_FUNC
 #define PY_REGISTER_BINARY_FUNC(func_name__) \
   .def(SnakeName(#func_name__), &NetBuilder::func_name__, py::arg("a"), py::arg("b"))
-     NETBUILDER_BINARY_OP_FOREACH(PY_REGISTER_BINARY_FUNC)
+      NETBUILDER_BINARY_OP_FOREACH(PY_REGISTER_BINARY_FUNC)
 #undef PY_REGISTER_BINARY_FUNC
+#define PY_REGISTER_FILLCONSTANT_OP(TYPE__)                \
+  .def("fill_constant", &NetBuilder::FillConstant<TYPE__>, \
+       py::arg("shape"),                                   \
+       py::arg("value"),                                   \
+       py::arg("name"),                                    \
+       py::arg("force_cpu") = false)
+      FILLCONSTANT_SUPPORT_DATATYPE_FOREACH(PY_REGISTER_FILLCONSTANT_OP)
+#undef PY_REGISTER_FILLCONSTANT_OP
       // clang-format on
       .def("add", &NetBuilder::Add, py::arg("a"), py::arg("b"))
       .def("mul",

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -368,7 +368,10 @@ void BindFrontend(pybind11::module *m) {
        py::arg("value"),                                   \
        py::arg("name"),                                    \
        py::arg("force_cpu") = false)
-      FILLCONSTANT_SUPPORT_DATATYPE_FOREACH(PY_REGISTER_FILLCONSTANT_OP)
+      PY_REGISTER_FILLCONSTANT_OP(double)
+      PY_REGISTER_FILLCONSTANT_OP(float)
+      PY_REGISTER_FILLCONSTANT_OP(int64_t)
+      PY_REGISTER_FILLCONSTANT_OP(int)
 #undef PY_REGISTER_FILLCONSTANT_OP
       // clang-format on
       .def("add", &NetBuilder::Add, py::arg("a"), py::arg("b"))
@@ -379,7 +382,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("x_num_col_dims") = 1,
            py::arg("y_num_col_dims") = 1)
       .def("mulbias",
-           &NetBuilder::Mulbias,
+           &NetBuilder::MulBias,
            py::arg("a"),
            py::arg("b"),
            py::arg("c"),
@@ -429,7 +432,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("adaptive")          = false,
            py::arg("padding_algorithm") = "EXPLICIT")
       .def("batchnorm",
-           &NetBuilder::Batchnorm,
+           &NetBuilder::BatchNorm,
            py::arg("a"),
            py::arg("scale"),
            py::arg("bias"),

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -329,50 +329,66 @@ void BindFrontend(pybind11::module *m) {
       .def("create_input", static_cast<Placeholder (BaseBuilder::*)(const Variable &)>(&BaseBuilder::CreateInput))
       .def("build", &BaseBuilder::Build)
       .def("name", &BaseBuilder::name)
-      .def("append_instruction", &BaseBuilder::AppendInstruction);
+      .def("append_instruction", &BaseBuilder::AppendInstruction)
+      .def("concat", &BaseBuilder::Concat, py::arg("inputs"), py::arg("axis") = 0)
+      .def("reduce",
+           &BaseBuilder::Reduce,
+           py::arg("a"),
+           py::arg("kind")     = ReduceKind::kSum,
+           py::arg("dim")      = std::vector<int>{},
+           py::arg("keep_dim") = false)
+      .def("broadcast_to", &BaseBuilder::BroadcastTo, py::arg("a"), py::arg("out_shape"), py::arg("broadcast_axes"))
+      .def("reshape", &BaseBuilder::Reshape, py::arg("a"), py::arg("shape"))
+      .def("transpose", &BaseBuilder::Transpose, py::arg("a"), py::arg("axis"))
+      .def("slice",
+           &BaseBuilder::Slice,
+           py::arg("a"),
+           py::arg("axes"),
+           py::arg("starts")        = std::vector<int>{},
+           py::arg("ends")          = std::vector<int>{},
+           py::arg("infer_flags")   = std::vector<int>(),
+           py::arg("decrease_axis") = std::vector<int>())
+      .def("reverse", &BaseBuilder::Reverse, py::arg("x"), py::arg("axis"))
+      .def("select", &BaseBuilder::Select, py::arg("condition"), py::arg("true_value"), py::arg("false_value"));
 
   py::class_<NetBuilder, BaseBuilder>(*m, "NetBuilder")
       .def(py::init<const std::string &>(), py::arg("name") = "")
   // clang-format off
 #define PY_REGISTER_UNARY_FUNC(func_name__) \
-  .def(#func_name__, &NetBuilder::func_name__, py::arg("a"))
+  .def(SnakeName(#func_name__), &NetBuilder::func_name__, py::arg("a"))
      NETBUILDER_UNARY_OP_FOREACH(PY_REGISTER_UNARY_FUNC)
 #undef PY_REGISTER_UNARY_FUNC
 #define PY_REGISTER_BINARY_FUNC(func_name__) \
-  .def(#func_name__, &NetBuilder::func_name__, py::arg("a"), py::arg("b"))
+  .def(SnakeName(#func_name__), &NetBuilder::func_name__, py::arg("a"), py::arg("b"))
      NETBUILDER_BINARY_OP_FOREACH(PY_REGISTER_BINARY_FUNC)
 #undef PY_REGISTER_BINARY_FUNC
       // clang-format on
-      .def("add", &NetBuilder::add, py::arg("a"), py::arg("b"))
-      .def("reshape", &NetBuilder::reshape, py::arg("a"), py::arg("shape"))
-      .def("transpose", &NetBuilder::transpose, py::arg("a"), py::arg("axis"))
-      .def("concat", &NetBuilder::concat, py::arg("inputs"), py::arg("axis") = 0)
+      .def("add", &NetBuilder::Add, py::arg("a"), py::arg("b"))
       .def("mul",
-           &NetBuilder::mul,
+           &NetBuilder::Mul,
            py::arg("a"),
            py::arg("b"),
            py::arg("x_num_col_dims") = 1,
            py::arg("y_num_col_dims") = 1)
       .def("mulbias",
-           &NetBuilder::mulbias,
+           &NetBuilder::Mulbias,
            py::arg("a"),
            py::arg("b"),
            py::arg("c"),
            py::arg("x_num_col_dims") = 1,
            py::arg("y_num_col_dims") = 1)
-      .def("elementwise_add", &NetBuilder::elementwise_add, py::arg("a"), py::arg("b"), py::arg("axis") = -1)
+      .def("elementwise_add", &NetBuilder::ElementwiseAdd, py::arg("a"), py::arg("b"), py::arg("axis") = -1)
       .def("elementwise_add_grad",
-           &NetBuilder::elementwise_add_grad,
+           &NetBuilder::ElementwiseAddGrad,
            py::arg("dout"),
            py::arg("x"),
            py::arg("y"),
            py::arg("axis") = -1)
-      .def("elementwise_mul", &NetBuilder::elementwise_mul, py::arg("a"), py::arg("b"), py::arg("axis") = -1)
-      .def("relu6", &NetBuilder::relu6, py::arg("a"), py::arg("threshold") = 6.0f)
-      .def("reverse", &NetBuilder::reverse, py::arg("x"), py::arg("axis"))
-      .def("reduce_sum", &NetBuilder::reduce_sum, py::arg("x"), py::arg("dim"), py::arg("keep_dim") = false)
+      .def("elementwise_mul", &NetBuilder::ElementwiseMul, py::arg("a"), py::arg("b"), py::arg("axis") = -1)
+      .def("relu6", &NetBuilder::Relu6, py::arg("a"), py::arg("threshold") = 6.0f)
+      .def("reduce_sum", &NetBuilder::ReduceSum, py::arg("x"), py::arg("dim"), py::arg("keep_dim") = false)
       .def("conv2d",
-           &NetBuilder::conv2d,
+           &NetBuilder::Conv2d,
            py::arg("a"),
            py::arg("b"),
            py::arg("strides")           = std::vector<int>{1, 1},
@@ -382,7 +398,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("data_format")       = "NCHW",
            py::arg("padding_algorithm") = "EXPLICIT")
       .def("depthwise_conv2d",
-           &NetBuilder::depthwise_conv2d,
+           &NetBuilder::DepthwiseConv2d,
            py::arg("a"),
            py::arg("b"),
            py::arg("strides")           = std::vector<int>{1, 1},
@@ -392,7 +408,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("data_format")       = "NCHW",
            py::arg("padding_algorithm") = "EXPLICIT")
       .def("pool2d",
-           &NetBuilder::pool2d,
+           &NetBuilder::Pool2d,
            py::arg("a"),
            py::arg("polling_type"),
            py::arg("ksize"),
@@ -405,7 +421,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("adaptive")          = false,
            py::arg("padding_algorithm") = "EXPLICIT")
       .def("batchnorm",
-           &NetBuilder::batchnorm,
+           &NetBuilder::Batchnorm,
            py::arg("a"),
            py::arg("scale"),
            py::arg("bias"),
@@ -416,7 +432,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("data_layout") = "NCHW",
            py::arg("is_test")     = true)
       .def("batch_norm_grad",
-           &NetBuilder::batch_norm_grad,
+           &NetBuilder::BatchNormGrad,
            py::arg("dy"),
            py::arg("x"),
            py::arg("scale"),
@@ -425,27 +441,19 @@ void BindFrontend(pybind11::module *m) {
            py::arg("epsilon")     = 1e-5,
            py::arg("data_layout") = "NCHW")
       .def("scale",
-           &NetBuilder::scale,
+           &NetBuilder::Scale,
            py::arg("a"),
            py::arg("scale")            = 1.0f,
            py::arg("bias")             = 0.0f,
            py::arg("bias_after_scale") = true)
-      .def("softmax", &NetBuilder::softmax, py::arg("a"), py::arg("axis") = -1, py::arg("data_format") = "AnyLayout")
-      .def("slice",
-           &NetBuilder::slice,
-           py::arg("a"),
-           py::arg("axes"),
-           py::arg("starts")        = std::vector<int>{},
-           py::arg("ends")          = std::vector<int>{},
-           py::arg("infer_flags")   = std::vector<int>(),
-           py::arg("decrease_axis") = std::vector<int>())
+      .def("softmax", &NetBuilder::Softmax, py::arg("a"), py::arg("axis") = -1, py::arg("data_format") = "AnyLayout")
       .def("dropout_infer",
-           &NetBuilder::dropout_infer,
+           &NetBuilder::DropoutInfer,
            py::arg("a"),
            py::arg("dropout_prob")           = 0.5f,
            py::arg("dropout_implementation") = "downgrade_in_infer")
       .def("conv2d_grad",
-           &NetBuilder::conv2d_grad,
+           &NetBuilder::Conv2dGrad,
            py::arg("dy"),
            py::arg("x"),
            py::arg("w"),
@@ -455,14 +463,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("groups")            = 1,
            py::arg("data_format")       = "NCHW",
            py::arg("padding_algorithm") = "EXPLICIT")
-      .def("sum", &NetBuilder::sum, py::arg("inputs"))
-      .def("reduce",
-           &NetBuilder::reduce,
-           py::arg("a"),
-           py::arg("kind")     = ReduceKind::kSum,
-           py::arg("dim")      = std::vector<int>{},
-           py::arg("keep_dim") = false)
-      .def("broadcast_to", &NetBuilder::broadcast_to, py::arg("a"), py::arg("out_shape"), py::arg("broadcast_axes"));
+      .def("sum", &NetBuilder::Sum, py::arg("inputs"));
 
   py::class_<CinnBuilder, BaseBuilder>(*m, "CinnBuilder")
       .def(py::init<const std::string &>(), py::arg("name") = "")
@@ -475,7 +476,6 @@ void BindFrontend(pybind11::module *m) {
           BINARY_OP_FOREACH(PY_REGISTER_FUNC)
 #undef PY_REGISTER_FUNC
       // clang-format on
-      .def("concat", &CinnBuilder::Concat, py::arg("input_vars"), py::arg("axis") = 0)
       .def("conv",
            &CinnBuilder::Conv,
            py::arg("lhs"),
@@ -489,26 +489,6 @@ void BindFrontend(pybind11::module *m) {
            py::arg("padding_algorithm") = "EXPLICIT",
            py::arg("output_shape")      = std::vector<int>{})
       .def("compare", &CinnBuilder::Compare, py::arg("lhs"), py::arg("rhs"), py::arg("kind") = ComparisonKind::kEq)
-      .def("reduce",
-           &CinnBuilder::Reduce,
-           py::arg("operand"),
-           py::arg("kind")     = ReduceKind::kSum,
-           py::arg("dim")      = std::vector<int>{},
-           py::arg("keep_dim") = false)
-      .def("broadcast_to",
-           &CinnBuilder::BroadcastTo,
-           py::arg("operand"),
-           py::arg("out_shape"),
-           py::arg("broadcast_axes"))
-      .def("reshape", &CinnBuilder::Reshape, py::arg("operand"), py::arg("shape"))
-      .def("slice",
-           &CinnBuilder::Slice,
-           py::arg("operand"),
-           py::arg("axes"),
-           py::arg("starts") = std::vector<int>{},
-           py::arg("ends")   = std::vector<int>{})
-      .def("select", &CinnBuilder::Select, py::arg("condition"), py::arg("true_value"), py::arg("false_value"))
-      .def("reverse", &CinnBuilder::Reverse, py::arg("operand"), py::arg("axis"))
       .def("__str__", [](CinnBuilder &self) { return self.name(); });
 
   auto computation = py::class_<CinnComputation, std::shared_ptr<CinnComputation>>(*m, "Computation");

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -131,11 +131,17 @@ ADD_TEST(NAME test_cinn_real_facedet
 )
 
 file(GLOB CINN_OP_TEST RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "tests/ops/test_*.py")
-set(EXCLUDE_OP test_mul_op)
+set(EXCLUDE_OP test_mul_op test_broadcast_to_op)
 
 ADD_TEST(NAME test_mul_op
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
     python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/ops/test_mul_op.py "${WITH_CUDNN}"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+ADD_TEST(NAME test_broadcast_to_op
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
+    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/ops/test_broadcast_to_op.py "${WITH_CUDNN}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -141,7 +141,7 @@ ADD_TEST(NAME test_mul_op
 
 ADD_TEST(NAME test_broadcast_to_op
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
-    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/ops/test_broadcast_to_op.py "${WITH_CUDNN}"
+    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/ops/test_broadcast_to_op.py "${WITH_CUDA}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 

--- a/python/tests/ops/test_add_op.py
+++ b/python/tests/ops/test_add_op.py
@@ -14,42 +14,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import paddle.nn.functional as F
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestAddOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {
+            "x": np.random.random([32]).astype("float32"),
+            "y": np.random.random([32]).astype("float32")
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=True)
+
+        out = paddle.add(x, y)
+
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("add")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+        out = builder.add(x, y)
 
         prog = builder.build()
-        res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
-                                   [out])
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.inputs["x"], self.inputs["y"]], [out])
+
         self.cinn_outputs = [res[0]]
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestAddCase1(TestAddOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([32, 64]).astype("float32"),
+            "y": np.random.random([32, 64]).astype("float32")
+        }
+
+
+class TestAddCase2(TestAddOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 2, 32]).astype("float32"),
+            "y": np.random.random([32]).astype("float32")
+        }
+
+
+class TestAddCase3(TestAddOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 32]).astype("float32"),
+            "y": np.random.random([1]).astype("float32")
+        }
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_broadcast_to_op.py
+++ b/python/tests/ops/test_broadcast_to_op.py
@@ -14,42 +14,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestBroadcastToOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {"x": np.random.random([6]).astype("float32")}
+        self.out_shape = [4, 5, 6]
+        self.broadcast_axes = [2]
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        out = paddle.broadcast_to(x, shape=self.out_shape)
+
         self.paddle_outputs = [out]
 
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("BroadcastTo")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        out = builder.broadcast_to(
+            x, out_shape=self.out_shape, broadcast_axes=self.broadcast_axes)
 
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
                                    [out])
-        self.cinn_outputs = [res[0]]
+
+        self.cinn_outputs = res
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestBroadcastToCase1(TestBroadcastToOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([1, 1, 3]).astype("float32")}
+        self.out_shape = [4, 5, 3]
+        self.broadcast_axes = [0, 1, 2]
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_broadcast_to_op.py
+++ b/python/tests/ops/test_broadcast_to_op.py
@@ -21,12 +21,17 @@ import paddle
 import cinn
 from cinn.frontend import *
 from cinn.common import *
+import sys
+
+enable_gpu = sys.argv.pop()
 
 
-@OpTestTool.skip_if(not is_compiled_with_cuda(),
-                    "x86 test will be skipped due to timeout.")
 class TestBroadcastToOp(OpTest):
     def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+        else:
+            self.target = DefaultHostTarget()
         self.init_case()
 
     def init_case(self):
@@ -63,6 +68,22 @@ class TestBroadcastToCase1(TestBroadcastToOp):
         self.inputs = {"x": np.random.random([1, 1, 3]).astype("float32")}
         self.out_shape = [4, 5, 3]
         self.broadcast_axes = [0, 1, 2]
+
+
+class TestBroadcastToCase2(TestBroadcastToOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([3, 2]).astype("float32")}
+        self.out_shape = [2, 3, 2]
+        self.broadcast_axes = [1, 2]
+
+
+class TestBroadcastToCase3(TestBroadcastToOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([3, 1, 5, 1, 4]).astype("float32")
+        }
+        self.out_shape = [3, 6, 5, 8, 4]
+        self.broadcast_axes = [0, 1, 2, 3, 4]
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_concat_op.py
+++ b/python/tests/ops/test_concat_op.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestConcatOp1(OpTest):
+    def setUp(self):
+        self.init_case()
+
+    def init_case(self):
+        self.inputs = {
+            "x1": np.random.random([2, 3]).astype("float32"),
+            "x2": np.random.random((2, 3)).astype("float32")
+        }
+        self.axis = 0
+
+    def build_paddle_program(self, target):
+        x1 = paddle.to_tensor(self.inputs["x1"], stop_gradient=True)
+        x2 = paddle.to_tensor(self.inputs["x2"], stop_gradient=True)
+        out = paddle.concat(x=[x1, x2], axis=self.axis)
+
+        self.paddle_outputs = [out]
+
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
+    def build_cinn_program(self, target):
+        builder = NetBuilder("concat")
+        x1 = builder.create_input(Float(32), self.inputs["x1"].shape, "x1")
+        x2 = builder.create_input(Float(32), self.inputs["x2"].shape, "x2")
+        out = builder.concat([x1, x2], axis=self.axis)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x1, x2],
+                                   [self.inputs["x1"], self.inputs["x2"]],
+                                   [out])
+
+        self.cinn_outputs = res
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestConcat2Case1(TestConcatOp1):
+    def init_case(self):
+        self.inputs = {
+            "x1": np.random.random([4, 3]).astype("float32"),
+            "x2": np.random.random((8, 3)).astype("float32")
+        }
+        self.axis = 0
+
+
+class TestConcat2Case2(TestConcatOp1):
+    def init_case(self):
+        self.inputs = {
+            "x1": np.random.random([2, 4, 8]).astype("float32"),
+            "x2": np.random.random((2, 4, 4)).astype("float32")
+        }
+        self.axis = -1
+
+
+class TestConcat2Case3(TestConcatOp1):
+    def init_case(self):
+        self.inputs = {
+            "x1": np.random.random([2, 8, 4]).astype("float32"),
+            "x2": np.random.random((2, 4, 4)).astype("float32")
+        }
+        self.axis = 1
+
+
+class TestConcatOp2(OpTest):
+    def setUp(self):
+        self.init_case()
+
+    def init_case(self):
+        self.inputs = {
+            "x1": np.random.random([1, 16]).astype("float32"),
+            "x2": np.random.random([2, 16]).astype("float32"),
+            "x3": np.random.random([3, 16]).astype("float32"),
+            "x4": np.random.random([4, 16]).astype("float32"),
+            "x5": np.random.random([5, 16]).astype("float32")
+        }
+        self.axis = 0
+
+    def build_paddle_program(self, target):
+        x1 = paddle.to_tensor(self.inputs["x1"], stop_gradient=True)
+        x2 = paddle.to_tensor(self.inputs["x2"], stop_gradient=True)
+        x3 = paddle.to_tensor(self.inputs["x3"], stop_gradient=True)
+        x4 = paddle.to_tensor(self.inputs["x4"], stop_gradient=True)
+        x5 = paddle.to_tensor(self.inputs["x5"], stop_gradient=True)
+        out = paddle.concat(x=[x1, x2, x3, x4, x5], axis=self.axis)
+
+        self.paddle_outputs = [out]
+
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
+    def build_cinn_program(self, target):
+        builder = NetBuilder("concat")
+        x1 = builder.create_input(Float(32), self.inputs["x1"].shape, "x1")
+        x2 = builder.create_input(Float(32), self.inputs["x2"].shape, "x2")
+        x3 = builder.create_input(Float(32), self.inputs["x3"].shape, "x3")
+        x4 = builder.create_input(Float(32), self.inputs["x4"].shape, "x4")
+        x5 = builder.create_input(Float(32), self.inputs["x5"].shape, "x5")
+        out = builder.concat([x1, x2, x3, x4, x5], axis=self.axis)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x1, x2, x3, x4, x5], [
+            self.inputs["x1"], self.inputs["x2"], self.inputs["x3"],
+            self.inputs["x4"], self.inputs["x5"]
+        ], [out])
+
+        self.cinn_outputs = res
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/ops/test_div_op.py
+++ b/python/tests/ops/test_div_op.py
@@ -14,42 +14,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import paddle.nn.functional as F
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestDivOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {
+            "x": np.random.random([32]).astype("float32"),
+            "y": np.random.random([32]).astype("float32")
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=True)
+
+        out = paddle.divide(x, y)
+
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("div")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+        out = builder.div(x, y)
 
         prog = builder.build()
-        res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
-                                   [out])
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.inputs["x"], self.inputs["y"]], [out])
+
         self.cinn_outputs = [res[0]]
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestDivCase1(TestDivOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([32, 64]).astype("float32"),
+            "y": np.random.random([32, 64]).astype("float32")
+        }
+
+
+class TestDivCase2(TestDivOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 2, 32]).astype("float32"),
+            "y": np.random.random([32]).astype("float32")
+        }
+
+
+class TestDivCase3(TestDivOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 32]).astype("float32"),
+            "y": np.random.random([1]).astype("float32")
+        }
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_matmul_op.py
+++ b/python/tests/ops/test_matmul_op.py
@@ -14,42 +14,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import paddle.nn.functional as F
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestMatmulOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {
+            "x": np.random.random([4, 16]).astype("float32"),
+            "y": np.random.random([16, 32]).astype("float32")
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=True)
+
+        out = paddle.matmul(x, y)
+
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("matmul")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+        out = builder.matmul(x, y)
 
         prog = builder.build()
-        res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
-                                   [out])
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.inputs["x"], self.inputs["y"]], [out])
+
         self.cinn_outputs = [res[0]]
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestMatmulCase1(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([16]).astype("float32"),
+            "y": np.random.random([16]).astype("float32")
+        }
+
+
+class TestMatmulCase2(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([5, 4, 16]).astype("float32"),
+            "y": np.random.random([5, 16, 32]).astype("float32")
+        }
+
+
+class TestMatmulCase3(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([16]).astype("float32"),
+            "y": np.random.random([16, 4]).astype("float32")
+        }
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -32,6 +32,7 @@ class TestReduceBaseOp(OpTest):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = [0]
+        self.keep_dim = False
 
     def paddle_func(self, x):
         return paddle.sum(x)
@@ -66,25 +67,35 @@ class TestReduceSumOp(TestReduceBaseOp):
         return paddle.sum(x, axis=self.dim)
 
     def cinn_func(self, builder, x):
-        return builder.reduce(x, ReduceKind.kSum, self.dim)
+        return builder.reduce(x, ReduceKind.kSum, self.dim, self.keep_dim)
 
 
 class TestReduceSumCase1(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = []
+        self.keep_dim = False
 
 
 class TestReduceSumCase2(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = [0, 1]
+        self.keep_dim = False
 
 
 class TestReduceSumCase3(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = [0, 1, 2]
+        self.keep_dim = False
+
+
+class TestReduceSumCase4(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0]
+        self.keep_dim = True
 
 
 class TestReduceProdOp(TestReduceBaseOp):
@@ -92,13 +103,28 @@ class TestReduceProdOp(TestReduceBaseOp):
         return paddle.prod(x, axis=self.dim)
 
     def cinn_func(self, builder, x):
-        return builder.reduce(x, ReduceKind.kProd, self.dim)
+        return builder.reduce(x, ReduceKind.kProd, self.dim, self.keep_dim)
 
 
 class TestReduceProdCase1(TestReduceProdOp):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = [0, 1]
+        self.keep_dim = False
+
+
+class TestReduceProdCase2(TestReduceProdOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+        self.keep_dim = True
+
+
+class TestReduceProdCase3(TestReduceProdOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0]
+        self.keep_dim = False
 
 
 class TestReduceMaxOp(TestReduceBaseOp):
@@ -106,13 +132,28 @@ class TestReduceMaxOp(TestReduceBaseOp):
         return paddle.max(x, axis=self.dim)
 
     def cinn_func(self, builder, x):
-        return builder.reduce(x, ReduceKind.kMax, self.dim)
+        return builder.reduce(x, ReduceKind.kMax, self.dim, self.keep_dim)
 
 
 class TestReduceMaxCase1(TestReduceMaxOp):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = [0, 1]
+        self.keep_dim = False
+
+
+class TestReduceMaxCase2(TestReduceMaxOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+        self.keep_dim = True
+
+
+class TestReduceMaxCase3(TestReduceMaxOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0]
+        self.keep_dim = False
 
 
 class TestReduceMinOp(TestReduceBaseOp):
@@ -120,13 +161,28 @@ class TestReduceMinOp(TestReduceBaseOp):
         return paddle.min(x, axis=self.dim)
 
     def cinn_func(self, builder, x):
-        return builder.reduce(x, ReduceKind.kMin, self.dim)
+        return builder.reduce(x, ReduceKind.kMin, self.dim, self.keep_dim)
 
 
 class TestReduceMinCase1(TestReduceMinOp):
     def init_case(self):
         self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
         self.dim = [0, 1]
+        self.keep_dim = False
+
+
+class TestReduceMinCase2(TestReduceMinOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+        self.keep_dim = True
+
+
+class TestReduceMinCase3(TestReduceMinOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0]
+        self.keep_dim = False
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestReduceBaseOp(OpTest):
+    def setUp(self):
+        self.init_case()
+
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0]
+
+    def paddle_func(self, x):
+        return paddle.sum(x)
+
+    def cinn_func(self, builder, x):
+        return builder.reduce(x)
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
+        out = self.paddle_func(x)
+        self.paddle_outputs = [out]
+
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
+    def build_cinn_program(self, target):
+        builder = NetBuilder("reduce")
+        x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
+        out = self.cinn_func(builder, x)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
+                                   [out])
+
+        self.cinn_outputs = res
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestReduceSumOp(TestReduceBaseOp):
+    def paddle_func(self, x):
+        return paddle.sum(x, axis=self.dim)
+
+    def cinn_func(self, builder, x):
+        return builder.reduce(x, ReduceKind.kSum, self.dim)
+
+
+class TestReduceSumCase1(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = []
+
+
+class TestReduceSumCase2(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+
+
+class TestReduceSumCase3(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1, 2]
+
+
+class TestReduceProdOp(TestReduceBaseOp):
+    def paddle_func(self, x):
+        return paddle.prod(x, axis=self.dim)
+
+    def cinn_func(self, builder, x):
+        return builder.reduce(x, ReduceKind.kProd, self.dim)
+
+
+class TestReduceProdCase1(TestReduceProdOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+
+
+class TestReduceMaxOp(TestReduceBaseOp):
+    def paddle_func(self, x):
+        return paddle.max(x, axis=self.dim)
+
+    def cinn_func(self, builder, x):
+        return builder.reduce(x, ReduceKind.kMax, self.dim)
+
+
+class TestReduceMaxCase1(TestReduceMaxOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+
+
+class TestReduceMinOp(TestReduceBaseOp):
+    def paddle_func(self, x):
+        return paddle.min(x, axis=self.dim)
+
+    def cinn_func(self, builder, x):
+        return builder.reduce(x, ReduceKind.kMin, self.dim)
+
+
+class TestReduceMinCase1(TestReduceMinOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
+        self.dim = [0, 1]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/ops/test_relu_op.py
+++ b/python/tests/ops/test_relu_op.py
@@ -41,34 +41,22 @@ class TestReluOp(OpTest):
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        out = F.relu(x)
+        out = F.sigmoid(x)
 
         self.paddle_outputs = [out]
-        self.paddle_grads = self.get_paddle_grads([out], [x],
-                                                  [self.inputs["dout"]])
 
     # Note: If the forward and backward operators are run in the same program,
     # the forward result will be incorrect.
     def build_cinn_program(self, target):
-        builder = NetBuilder("relu")
+        builder = NetBuilder("sigmoid")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.relu(x)
-        prog = builder.build()
-        forward_res = self.get_cinn_output(prog, target, [x],
-                                           [self.inputs["x"]], [out])
+        out = builder.sigmoid(x)
 
-        builder = NetBuilder("relu_grad")
-        shape = self.inputs["dout"].shape
-        dout = builder.create_input(Float(32), shape, "dout")
-        out = builder.create_input(Float(32), shape, "out")
-        x_grad = builder.relu_grad(dout, out)
         prog = builder.build()
-        backward_res = self.get_cinn_output(
-            prog, target, [dout, out], [self.inputs["dout"], forward_res[0]],
-            [x_grad])
+        res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
+                                   [out])
 
-        self.cinn_outputs = forward_res
-        self.cinn_grads = backward_res
+        self.cinn_outputs = res
 
     def test_check_results(self):
         self.check_outputs_and_grads()

--- a/python/tests/ops/test_reshape_op.py
+++ b/python/tests/ops/test_reshape_op.py
@@ -34,7 +34,7 @@ class TestReshapeOp(OpTest):
         self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
 
     def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
         out = paddle.reshape(x, [3, 2])
         self.paddle_outputs = [out]
 

--- a/python/tests/ops/test_sigmoid_op.py
+++ b/python/tests/ops/test_sigmoid_op.py
@@ -14,39 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import paddle.nn.functional as F
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestSigmoidOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {
+            "x": np.random.random([
+                32,
+                64,
+            ]).astype("float32")
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        out = F.sigmoid(x)
+
         self.paddle_outputs = [out]
 
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("sigmoid")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        out = builder.sigmoid(x)
 
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
                                    [out])
-        self.cinn_outputs = [res[0]]
+
+        self.cinn_outputs = res
 
     def test_check_results(self):
         self.check_outputs_and_grads()

--- a/python/tests/ops/test_sqrt_op.py
+++ b/python/tests/ops/test_sqrt_op.py
@@ -14,39 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestSqrtOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {
+            "x": np.random.random([
+                32,
+                64,
+            ]).astype("float32")
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        out = paddle.sqrt(x)
+
         self.paddle_outputs = [out]
 
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("sqrt")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        out = builder.sqrt(x)
 
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
                                    [out])
-        self.cinn_outputs = [res[0]]
+
+        self.cinn_outputs = res
 
     def test_check_results(self):
         self.check_outputs_and_grads()

--- a/python/tests/ops/test_sum_op.py
+++ b/python/tests/ops/test_sum_op.py
@@ -39,13 +39,12 @@ class TestSumOp(OpTest):
             "x2": np.random.random([
                 32,
                 64,
-            ]).astype("float32"),
-            "dout": np.random.random((32, 64)).astype("float32")
+            ]).astype("float32")
         }
 
     def build_paddle_program(self, target):
-        x1 = paddle.to_tensor(self.inputs["x1"], stop_gradient=False)
-        x2 = paddle.to_tensor(self.inputs["x2"], stop_gradient=False)
+        x1 = paddle.to_tensor(self.inputs["x1"], stop_gradient=True)
+        x2 = paddle.to_tensor(self.inputs["x2"], stop_gradient=True)
         out = paddle.add(x1, x2)
 
         self.paddle_outputs = [out]

--- a/python/tests/ops/test_tanh_op.py
+++ b/python/tests/ops/test_tanh_op.py
@@ -14,39 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestTransposeOp(OpTest):
+class TestTanhOp(OpTest):
     def setUp(self):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([2, 3]).astype("float32")}
+        self.inputs = {
+            "x": np.random.random([
+                32,
+                64,
+            ]).astype("float32")
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
-        out = paddle.transpose(x, [1, 0])
+        out = paddle.tanh(x)
+
         self.paddle_outputs = [out]
 
+    # Note: If the forward and backward operators are run in the same program,
+    # the forward result will be incorrect.
     def build_cinn_program(self, target):
-        builder = NetBuilder("transpose_test")
+        builder = NetBuilder("tanh")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        out = builder.transpose(x, [1, 0])
+        out = builder.tanh(x)
 
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [x], [self.inputs["x"]],
                                    [out])
-        self.cinn_outputs = [res[0]]
+
+        self.cinn_outputs = res
 
     def test_check_results(self):
         self.check_outputs_and_grads()


### PR DESCRIPTION
## 背景：
PaddleScience总结出了17+2个可穷尽无限微分集合的基础算子，Laplace2d模型也准备基于这19个算子进行实现，但目前CINN并不完全支持这19个算子，因此需要尽快完善。

## 简介：
**本PR主要填充了CINN中已有实现的8个基础算子的NetBuilder及其单测**，另外还包括几个Laplace2d尚未用到，但已有实现的算子。其中新增的8个基础算子为：
```
sqrt, tanh, sub, div, matmul, reduce, broadcast_to,fill_constant
```
这些算子基本上都是`CinnBuilder`中的已有算子，因此迁移过来比较容易。至此，CINN已支持如下14个基础算子：
```
fill_constant_p、broadcast_p、add_p、sub_p、div_p、mul_p、sqrt_p、tanh_p、matmul_p、reduce_p、concat_p、reshape_p、transpose_p、slice_select_p
```
剩余5+1个基础算子仍需进一步讨论。

除此之外，本PR还做了如下工作：
1. 将CinnBuilder和NetBuilder中的共用API移到了BaseBuilder中，以此来减少冗余代码。
2. 将NetBuilder的API名由原全小写改为驼峰命名，并替换掉所有用到了NetBuilder API的代码。
3. 原reduce不支持dim参数为空，但paddle原生算子且含义为reduce所有数据，为Builder的reduce实现增加对dim参数为空的支持。

## 测试
所有新增算子均已添加单测，且在本地测试通过，结果与Paddle原生算子结果相同。

## 后续
1. 添加这些算子的OpMapper（已添加，见PR #672 ）
2. 解决reduce_prod、reduce_max、reduce_min在dim为空（即reduce所有数据）的情况下与Paddle原生算子误差很大的问题，经分析原因在于在dim为空的情况下CINN只实现了reduce_sum版本。