### PR TITLE
add ScheduleBlock, ScheduleBlockRealize, BufferRange for schedule IR

### DIFF
--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -667,6 +667,9 @@ void CodeGenC::PrintStackVecType(Type type, int lanes) {
 }
 
 void CodeGenC::Visit(const ir::PrimitiveNode *op) { CINN_NOT_IMPLEMENTED }
+void CodeGenC::Visit(const ir::_BufferRange_ *op) { CINN_NOT_IMPLEMENTED }
+void CodeGenC::Visit(const ir::ScheduleBlock *op) { CINN_NOT_IMPLEMENTED }
+void CodeGenC::Visit(const ir::ScheduleBlockRealize *op) { CINN_NOT_IMPLEMENTED }
 
 void CodeGenC::Visit(const ir::IntrinsicOp *op) {
   switch (op->getKind()) {

--- a/cinn/backends/llvm/codegen_llvm.cc
+++ b/cinn/backends/llvm/codegen_llvm.cc
@@ -633,6 +633,9 @@ llvm::Value *CodeGenLLVM::Visit(const ir::Block *op) {
 }
 
 llvm::Value *CodeGenLLVM::Visit(const ir::PrimitiveNode *) { CINN_NOT_IMPLEMENTED return nullptr; }
+llvm::Value *CodeGenLLVM::Visit(const ir::_BufferRange_ *) { CINN_NOT_IMPLEMENTED return nullptr; }
+llvm::Value *CodeGenLLVM::Visit(const ir::ScheduleBlock *) { CINN_NOT_IMPLEMENTED return nullptr; }
+llvm::Value *CodeGenLLVM::Visit(const ir::ScheduleBlockRealize *) { CINN_NOT_IMPLEMENTED return nullptr; }
 
 llvm::Value *CodeGenLLVM::Visit(const ir::Call *op) {
   if (op->name == runtime::intrinsic::debug_log_repr) {

--- a/cinn/ir/buffer.h
+++ b/cinn/ir/buffer.h
@@ -144,5 +144,47 @@ class _Buffer_ : public ExprNode<_Buffer_> {
 
 static bool operator<(const ir::Buffer& a, const ir::Buffer& b) { return a->name < b->name; }
 
+// represents the multi-dimension ranges of the buffer
+struct _BufferRange_ : public ExprNode<_BufferRange_> {
+  Expr buffer;
+  // For every range, it starts from var's lower_bound and ends at var's upper_bound.
+  std::vector<Var> ranges;
+
+  _BufferRange_() = default;
+  _BufferRange_(const Expr& buffer, const std::vector<Var>& ranges)
+      : ExprNode<_BufferRange_>(), buffer(buffer), ranges(ranges) {}
+
+  static Expr Make(const Expr& buffer, const std::vector<Var>& ranges);
+
+  void Verify() const override;
+
+  Expr Copy() const override;
+  static const IrNodeTy _node_type_ = IrNodeTy::_BufferRange_;
+};
+
+struct BufferRange : public IrNodeRef {
+  BufferRange() = default;
+  explicit BufferRange(IrNode* n) : IrNodeRef(n) {}
+  BufferRange(const Expr& buffer, const std::vector<Var>& ranges)
+      : BufferRange(_BufferRange_::Make(buffer, ranges).ptr()) {}
+
+  operator Expr() { return Expr(get()); }
+  operator Expr() const {
+    BufferRange v = *this;
+    return Expr(v);
+  }
+
+  bool operator==(const BufferRange& o) const;
+  bool operator!=(const BufferRange& o) const;
+
+  BufferRange& operator=(_BufferRange_* x);
+  BufferRange& operator=(const _BufferRange_* x);
+
+  const _BufferRange_* operator->() const { return get(); }
+  _BufferRange_* operator->() { return get(); }
+  const _BufferRange_* get() const { return static_cast<const _BufferRange_*>(ptr()); }
+  _BufferRange_* get() { return static_cast<_BufferRange_*>(ptr()); }
+};
+
 }  // namespace ir
 }  // namespace cinn

--- a/cinn/ir/ir.cc
+++ b/cinn/ir/ir.cc
@@ -273,6 +273,60 @@ std::vector<const Expr *> Block::expr_fields() const {
   return res;
 }
 
+Expr ScheduleBlock::Make(const std::vector<Var> &iter_vars,
+                         const std::vector<BufferRange> &read_buffers,
+                         const std::vector<BufferRange> &write_buffers,
+                         const std::string &name,
+                         Expr body) {
+  auto node           = make_shared<ScheduleBlock>();
+  node->iter_vars     = iter_vars;
+  node->read_buffers  = read_buffers;
+  node->write_buffers = write_buffers;
+  node->name          = name;
+  node->body          = body;
+  return Expr(node);
+}
+void ScheduleBlock::Verify() const {
+  CHECK(!name.empty());
+  CHECK(body.defined());
+}
+std::vector<Expr *> ScheduleBlock::expr_fields() {
+  std::vector<Expr *> res;
+  res.push_back(&body);
+  return res;
+}
+std::vector<const Expr *> ScheduleBlock::expr_fields() const {
+  std::vector<const Expr *> res;
+  res.push_back(&body);
+  return res;
+}
+
+Expr ScheduleBlockRealize::Make(const std::vector<Expr> &iter_values, const Expr &schedule_block) {
+  auto node            = make_shared<ScheduleBlockRealize>();
+  node->iter_values    = iter_values;
+  node->schedule_block = schedule_block;
+  return Expr(node);
+}
+void ScheduleBlockRealize::Verify() const {
+  auto *schedule_block_ptr = schedule_block.As<ScheduleBlock>();
+  CHECK(schedule_block_ptr);
+  CHECK_EQ(schedule_block_ptr->iter_vars.size(), iter_values.size());
+}
+std::vector<Expr *> ScheduleBlockRealize::expr_fields() {
+  std::vector<Expr *> res;
+  auto *schedule_block_ptr = schedule_block.As<ScheduleBlock>();
+  CHECK(schedule_block_ptr);
+  res.push_back(&schedule_block_ptr->body);
+  return res;
+}
+std::vector<const Expr *> ScheduleBlockRealize::expr_fields() const {
+  std::vector<const Expr *> res;
+  auto *schedule_block_ptr = schedule_block.As<ScheduleBlock>();
+  CHECK(schedule_block_ptr);
+  res.push_back(&schedule_block_ptr->body);
+  return res;
+}
+
 Expr IfThenElse::Make(Expr condition, Expr true_case, Expr false_case) {
   auto node = make_shared<IfThenElse>(condition, true_case, false_case);
   return Expr(node);

--- a/cinn/ir/ir.h
+++ b/cinn/ir/ir.h
@@ -39,7 +39,8 @@ class Stage;
 }  // namespace poly
 
 namespace ir {
-struct Buffer;
+class Buffer;
+class BufferRange;
 struct LoweredFunc;
 class Module;
 
@@ -858,6 +859,44 @@ struct Block : public ExprNode<Block> {
   std::vector<const Expr*> expr_fields() const override;
 
   static const IrNodeTy _node_type_ = IrNodeTy::Block;
+};
+
+// ScheduleBlock is the unit of schedule IR which represents tensor's computation
+struct ScheduleBlock : public ExprNode<ScheduleBlock> {
+  std::vector<Var> iter_vars;
+  std::vector<BufferRange> read_buffers;
+  std::vector<BufferRange> write_buffers;
+  std::string name;
+  Expr body;
+
+  static Expr Make(const std::vector<Var>& iter_vars,
+                   const std::vector<BufferRange>& read_buffers,
+                   const std::vector<BufferRange>& write_buffers,
+                   const std::string& name,
+                   Expr body);
+
+  void Verify() const override;
+
+  std::vector<Expr*> expr_fields() override;
+  std::vector<const Expr*> expr_fields() const override;
+
+  static const IrNodeTy _node_type_ = IrNodeTy::ScheduleBlock;
+};
+
+// ScheduleBlockRealize is used to execute ScheduleBlock with the binding iter_values
+struct ScheduleBlockRealize : public ExprNode<ScheduleBlockRealize> {
+  // values of the iter_vars
+  std::vector<Expr> iter_values;
+  Expr schedule_block;
+
+  static Expr Make(const std::vector<Expr>& iter_values, const Expr& schedule_block);
+
+  void Verify() const override;
+
+  std::vector<Expr*> expr_fields() override;
+  std::vector<const Expr*> expr_fields() const override;
+
+  static const IrNodeTy _node_type_ = IrNodeTy::ScheduleBlockRealize;
 };
 
 /**

--- a/cinn/ir/ir_base.h
+++ b/cinn/ir/ir_base.h
@@ -45,6 +45,10 @@ class _Tensor_;
 class Tensor;
 class _Var_;
 class Var;
+class _BufferRange_;
+class BufferRange;
+class ScheduleBlock;
+class ScheduleBlockRealize;
 
 // clang-format off
 #define NODETY_PRIMITIVE_TYPE_FOR_EACH(macro__) \
@@ -103,6 +107,10 @@ class Var;
   macro__(Sum)                              \
   macro__(PrimitiveNode)                    \
   macro__(IntrinsicOp)                      \
+  macro__(_BufferRange_)                    \
+  macro__(ScheduleBlock)                    \
+  macro__(ScheduleBlockRealize)             \
+
 
 #define NODETY_FORALL(__m)              \
   NODETY_PRIMITIVE_TYPE_FOR_EACH(__m)   \

--- a/cinn/ir/ir_mutator.h
+++ b/cinn/ir/ir_mutator.h
@@ -289,5 +289,49 @@ void IRMutator<T>::Visit(const IntrinsicOp *expr, T op) {
   }
 }
 
+template <typename T>
+void IRMutator<T>::Visit(const _BufferRange_ *expr, T op) {
+  auto *node = op->template As<_BufferRange_>();
+  CHECK(node);
+  IRVisitorBase<void, T>::Visit(&node->buffer, &node->buffer);
+  for (auto &var : node->ranges) {
+    IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+    IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+  }
+}
+
+template <typename T>
+void IRMutator<T>::Visit(const ScheduleBlock *expr, T op) {
+  auto *node = op->template As<ScheduleBlock>();
+  CHECK(node);
+  for (auto &var : node->iter_vars) {
+    IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+    IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+  }
+  for (auto &buffer_region : node->read_buffers) {
+    for (auto &var : buffer_region->ranges) {
+      IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+      IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+    }
+  }
+  for (auto &buffer_region : node->write_buffers) {
+    for (auto &var : buffer_region->ranges) {
+      IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+      IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+    }
+  }
+  IRVisitorBase<void, T>::Visit(&(node->body), &(node->body));
+}
+
+template <typename T>
+void IRMutator<T>::Visit(const ScheduleBlockRealize *expr, T op) {
+  auto *node = op->template As<ScheduleBlockRealize>();
+  CHECK(node);
+  for (auto &value : node->iter_values) {
+    IRVisitorBase<void, T>::Visit(&value, &value);
+  }
+  IRVisitorBase<void, T>::Visit(&node->schedule_block, &node->schedule_block);
+}
+
 }  // namespace ir
 }  // namespace cinn

--- a/cinn/ir/ir_mutator.h
+++ b/cinn/ir/ir_mutator.h
@@ -137,8 +137,10 @@ void IRMutator<T>::Visit(const _Module_ *expr, T op) {
 template <typename T>
 void IRMutator<T>::Visit(const _Var_ *expr, T op) {
   auto *node = op->template As<ir::_Var_>();
-  if (expr->is_reduce_axis) {
+  if (node->lower_bound.defined()) {
     IRVisitorBase<void, T>::Visit(&node->lower_bound, &node->lower_bound);
+  }
+  if (node->upper_bound.defined()) {
     IRVisitorBase<void, T>::Visit(&node->upper_bound, &node->upper_bound);
   }
 }
@@ -295,8 +297,12 @@ void IRMutator<T>::Visit(const _BufferRange_ *expr, T op) {
   CHECK(node);
   IRVisitorBase<void, T>::Visit(&node->buffer, &node->buffer);
   for (auto &var : node->ranges) {
-    IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
-    IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+    if (var->lower_bound.defined()) {
+      IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+    }
+    if (var->upper_bound.defined()) {
+      IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+    }
   }
 }
 
@@ -305,19 +311,31 @@ void IRMutator<T>::Visit(const ScheduleBlock *expr, T op) {
   auto *node = op->template As<ScheduleBlock>();
   CHECK(node);
   for (auto &var : node->iter_vars) {
-    IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
-    IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+    if (var->lower_bound.defined()) {
+      IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+    }
+    if (var->upper_bound.defined()) {
+      IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+    }
   }
   for (auto &buffer_region : node->read_buffers) {
     for (auto &var : buffer_region->ranges) {
-      IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
-      IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+      if (var->lower_bound.defined()) {
+        IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+      }
+      if (var->upper_bound.defined()) {
+        IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+      }
     }
   }
   for (auto &buffer_region : node->write_buffers) {
     for (auto &var : buffer_region->ranges) {
-      IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
-      IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+      if (var->lower_bound.defined()) {
+        IRVisitorBase<void, T>::Visit(&var->lower_bound, &var->lower_bound);
+      }
+      if (var->upper_bound.defined()) {
+        IRVisitorBase<void, T>::Visit(&var->upper_bound, &var->upper_bound);
+      }
     }
   }
   IRVisitorBase<void, T>::Visit(&(node->body), &(node->body));

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -407,42 +407,49 @@ void IrPrinter::Visit(const ScheduleBlock *x) {}
 
 void IrPrinter::Visit(const ScheduleBlockRealize *x) {
   auto *schedule_block = x->schedule_block.As<ScheduleBlock>();
-  os() << "ScheduleBlock(" << schedule_block->name << ") {\n";
+  os() << "ScheduleBlock(" << schedule_block->name << ")\n";
+  DoIndent();
+  os() << "{\n";
   // print block vars and bindings
   auto iter_vars   = schedule_block->iter_vars;
   auto iter_values = x->iter_values;
   CHECK_EQ(iter_vars.size(), iter_values.size());
   IncIndent();
-  DoIndent();
+  if (!iter_vars.empty()) DoIndent();
   for (int i = 0; i < iter_vars.size(); i++) {
     if (i) os() << ", ";
     os() << iter_vars[i]->name;
   }
-  os() << " = axis.bind(";
+  if (!iter_vars.empty()) os() << " = axis.bind(";
   for (int i = 0; i < iter_values.size(); i++) {
     if (i) os() << ", ";
     os() << iter_values[i];
   }
-  os() << ")\n";
+  if (!iter_vars.empty()) os() << ")\n";
   // print block body
-  DoIndent();
-  os() << "read_buffers(";
-  auto &read_buffers = schedule_block->read_buffers;
-  for (int i = 0; i < read_buffers.size(); i++) {
-    if (i) os() << ", ";
-    Print(read_buffers[i]);
+  if (!schedule_block->read_buffers.empty()) {
+    DoIndent();
+    os() << "read_buffers(";
+    auto &read_buffers = schedule_block->read_buffers;
+    for (int i = 0; i < read_buffers.size(); i++) {
+      if (i) os() << ", ";
+      Print(read_buffers[i]);
+    }
+    os() << ")\n";
   }
-  os() << ")\n";
-  DoIndent();
-  os() << "write_buffers(";
-  auto &write_buffers = schedule_block->write_buffers;
-  for (int i = 0; i < write_buffers.size(); i++) {
-    if (i) os() << ", ";
-    Print(write_buffers[i]);
+  if (!schedule_block->write_buffers.empty()) {
+    DoIndent();
+    os() << "write_buffers(";
+    auto &write_buffers = schedule_block->write_buffers;
+    for (int i = 0; i < write_buffers.size(); i++) {
+      if (i) os() << ", ";
+      Print(write_buffers[i]);
+    }
+    os() << ")\n";
   }
-  os() << ")\n";
   DoIndent();
   Print(schedule_block->body);
+  os() << "\n";
   DecIndent();
   DoIndent();
   os() << "}";

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -389,6 +389,65 @@ void IrPrinter::Visit(const PrimitiveNode *x) {
   os() << ")";
 }
 
+void IrPrinter::Visit(const _BufferRange_ *x) {
+  auto *buffer = x->buffer.As<ir::_Buffer_>();
+  CHECK(buffer);
+  os() << buffer->name << "[";
+  for (int i = 0; i < x->ranges.size(); i++) {
+    if (i) os() << ", ";
+    auto &range = x->ranges[i];
+    CHECK(range->lower_bound.defined());
+    CHECK(range->upper_bound.defined());
+    os() << range->lower_bound << ":" << range->upper_bound;
+  }
+  os() << "]";
+}
+
+void IrPrinter::Visit(const ScheduleBlock *x) {}
+
+void IrPrinter::Visit(const ScheduleBlockRealize *x) {
+  auto *schedule_block = x->schedule_block.As<ScheduleBlock>();
+  os() << "ScheduleBlock(" << schedule_block->name << ") {\n";
+  // print block vars and bindings
+  auto iter_vars   = schedule_block->iter_vars;
+  auto iter_values = x->iter_values;
+  CHECK_EQ(iter_vars.size(), iter_values.size());
+  IncIndent();
+  DoIndent();
+  for (int i = 0; i < iter_vars.size(); i++) {
+    if (i) os() << ", ";
+    os() << iter_vars[i]->name;
+  }
+  os() << " = axis.bind(";
+  for (int i = 0; i < iter_values.size(); i++) {
+    if (i) os() << ", ";
+    os() << iter_values[i];
+  }
+  os() << ")\n";
+  // print block body
+  DoIndent();
+  os() << "read_buffers(";
+  auto &read_buffers = schedule_block->read_buffers;
+  for (int i = 0; i < read_buffers.size(); i++) {
+    if (i) os() << ", ";
+    Print(read_buffers[i]);
+  }
+  os() << ")\n";
+  DoIndent();
+  os() << "write_buffers(";
+  auto &write_buffers = schedule_block->write_buffers;
+  for (int i = 0; i < write_buffers.size(); i++) {
+    if (i) os() << ", ";
+    Print(write_buffers[i]);
+  }
+  os() << ")\n";
+  DoIndent();
+  Print(schedule_block->body);
+  DecIndent();
+  DoIndent();
+  os() << "}";
+}
+
 void IrPrinter::Visit(const IntrinsicOp *x) {
   switch (x->getKind()) {
 #define __(op__)                                \

--- a/cinn/lang/lower.cc
+++ b/cinn/lang/lower.cc
@@ -93,7 +93,8 @@ ir::LoweredFunc Lower(const std::string& name,
                       const std::vector<Var>& scalar_args,
                       const std::vector<Tensor>& temp_tensors,
                       Module::Builder* b,
-                      const Target& target) {
+                      const Target& target,
+                      bool support_ir_schedule) {
   // Init the reduce tensors first before any process.
   for (auto& t : tensor_args) InitReduceTensor(stages, t, target);
   for (auto& t : temp_tensors) InitReduceTensor(stages, t, target);
@@ -102,8 +103,13 @@ ir::LoweredFunc Lower(const std::string& name,
   auto ctrl_deps = CollectTempTensorsFromCtrlDepends(stages, tensor_args);
   ctrl_deps.insert(temp_tensors.begin(), temp_tensors.end());
 
-  auto lower_impl_instance = detail::LowerImpl(
-      name, stages, tensor_args, scalar_args, std::vector<Tensor>(ctrl_deps.begin(), ctrl_deps.end()), target);
+  auto lower_impl_instance = detail::LowerImpl(name,
+                                               stages,
+                                               tensor_args,
+                                               scalar_args,
+                                               std::vector<Tensor>(ctrl_deps.begin(), ctrl_deps.end()),
+                                               target,
+                                               support_ir_schedule);
 
   auto result = lower_impl_instance();
   std::vector<ir::LoweredFunc> return_value;
@@ -148,7 +154,8 @@ std::vector<ir::LoweredFunc> LowerVec(const std::string& name,
                                       const std::vector<Var>& scalar_args,
                                       const std::vector<Tensor>& temp_tensors,
                                       Module::Builder* b,
-                                      const Target& target) {
+                                      const Target& target,
+                                      bool support_ir_schedule) {
   // Init the reduce tensors first before any process.
   for (auto& t : tensor_args) InitReduceTensor(stages, t, target);
   for (auto& t : temp_tensors) InitReduceTensor(stages, t, target);
@@ -157,8 +164,13 @@ std::vector<ir::LoweredFunc> LowerVec(const std::string& name,
   auto ctrl_deps = CollectTempTensorsFromCtrlDepends(stages, tensor_args);
   ctrl_deps.insert(temp_tensors.begin(), temp_tensors.end());
 
-  auto lower_impl_instance = detail::LowerImpl(
-      name, stages, tensor_args, scalar_args, std::vector<Tensor>(ctrl_deps.begin(), ctrl_deps.end()), target);
+  auto lower_impl_instance = detail::LowerImpl(name,
+                                               stages,
+                                               tensor_args,
+                                               scalar_args,
+                                               std::vector<Tensor>(ctrl_deps.begin(), ctrl_deps.end()),
+                                               target,
+                                               support_ir_schedule);
   // return vectorof ir::LoweredFunc.
   auto result = lower_impl_instance();
   std::vector<ir::LoweredFunc> return_value;

--- a/cinn/lang/lower.h
+++ b/cinn/lang/lower.h
@@ -47,7 +47,8 @@ ir::LoweredFunc Lower(const std::string &name,
                       const std::vector<Var> &scalar_args     = {},
                       const std::vector<Tensor> &temp_tensors = {},
                       ir::Module::Builder *b                  = nullptr,
-                      const Target &target                    = common::DefaultHostTarget());
+                      const Target &target                    = common::DefaultHostTarget(),
+                      bool support_ir_schedule                = false);
 
 /**
  * \brief Lower the computation of \p tensor_args and \p scalar_args to a vector of LoweredFuncs. Each schedule group
@@ -66,7 +67,8 @@ std::vector<ir::LoweredFunc> LowerVec(const std::string &name,
                                       const std::vector<Var> &scalar_args     = {},
                                       const std::vector<Tensor> &temp_tensors = {},
                                       ir::Module::Builder *b                  = nullptr,
-                                      const Target &target                    = common::DefaultHostTarget());
+                                      const Target &target                    = common::DefaultHostTarget(),
+                                      bool support_ir_schedule                = false);
 
 }  // namespace lang
 }  // namespace cinn

--- a/cinn/lang/lower_impl.h
+++ b/cinn/lang/lower_impl.h
@@ -111,7 +111,8 @@ class LowerImpl {
             const std::vector<Tensor>& tensor_args,
             const std::vector<Var>& scalar_args,
             const std::vector<Tensor>& temp_tensor_args = {},
-            const Target& target                        = common::DefaultHostTarget());
+            const Target& target                        = common::DefaultHostTarget(),
+            bool support_ir_schedule                    = false);
 
   std::vector<ir::LoweredFunc> operator()();
 
@@ -187,6 +188,8 @@ class LowerImpl {
 
   //! CUDA axis info for this function.
   std::vector<ir::CudaAxisInfo> cuda_axis_info_;
+
+  bool support_ir_schedule_ = false;
 };
 
 /**

--- a/cinn/optim/CMakeLists.txt
+++ b/cinn/optim/CMakeLists.txt
@@ -28,6 +28,7 @@ gather_srcs(cinnapi_src SRCS
     cast_bool_to_int8.cc
     collect_undefined_vars.cc
     var_mod_simplify.cc
+    remove_schedule_block.cc
     )
 
 if (WITH_CUDA)
@@ -45,6 +46,7 @@ cc_test(test_optimize SRCS optimize_test.cc DEPS cinncore)
 cc_test(test_cache_read_write_replace SRCS cache_read_write_replace_test.cc DEPS cinncore)
 cc_test(test_cast_simplify SRCS cast_simplify_test.cc DEPS cinncore)
 cc_test(test_if_simplify SRCS if_simplify_test.cc DEPS cinncore)
+cc_test(test_remove_schedule_block SRCS remove_schedule_block_test.cc DEPS cinncore)
 
 if (WITH_CUDA)
   cc_test(test_transform_gpu_forloop SRCS transform_gpu_forloop_test.cc DEPS cinncore)

--- a/cinn/optim/ir_copy.cc
+++ b/cinn/optim/ir_copy.cc
@@ -344,6 +344,22 @@ struct IRCopyVisitor : public ir::IRVisitorBase<Expr> {
     return Expr(n);
   }
 
+  Expr Visit(const ir::_BufferRange_* op) {
+    std::vector<Var> ranges;
+    for (auto& var : ranges) {
+      ranges.push_back(var);
+    }
+    return ir::_BufferRange_::Make(Visit(&op->buffer), ranges);
+  }
+
+  Expr Visit(const ir::ScheduleBlock* op) {
+    return ir::ScheduleBlock::Make(op->iter_vars, op->read_buffers, op->write_buffers, op->name, op->body);
+  }
+
+  Expr Visit(const ir::ScheduleBlockRealize* op) {
+    return ir::ScheduleBlockRealize::Make(op->iter_values, op->schedule_block);
+  }
+
 #define __(x__) Expr Visit(const ir::intrinsics::x__* op);
   INTRINSIC_KIND_FOR_EACH(__)
 #undef __

--- a/cinn/optim/optimize.cc
+++ b/cinn/optim/optimize.cc
@@ -29,6 +29,7 @@
 #include "cinn/optim/lower_intrin.h"
 #include "cinn/optim/map_extern_call.h"
 #include "cinn/optim/remove_nested_block.h"
+#include "cinn/optim/remove_schedule_block.h"
 #include "cinn/optim/replace_const_param_to_integer.h"
 #include "cinn/optim/transform_gpu_forloop.h"
 #include "cinn/optim/transform_polyfor_to_for.h"
@@ -73,6 +74,7 @@ Expr Optimize(Expr e, Target target, bool runtime_debug_info) {
 ir::Module Optimize(const ir::Module& module, const Target& target) {
   auto copied = IRCopy(Expr(module));
 
+  RemoveScheduleBlock(&copied);
   LowerFunctionCallBindVars(&copied);
   CallArgListToPodValue(&copied);
   LowerIntrin(&copied, target);

--- a/cinn/optim/remove_schedule_block.cc
+++ b/cinn/optim/remove_schedule_block.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/optim/remove_schedule_block.h"
+
+#include "cinn/ir/ir_mutator.h"
+#include "cinn/ir/ir_printer.h"
+#include "cinn/optim/replace_var_with_expr.h"
+
+namespace cinn {
+namespace optim {
+
+struct ScheduleBlockRemover : public ir::IRMutator<Expr*> {
+  void operator()(ir::Expr* expr) { Visit(expr); }
+
+ private:
+  void Visit(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+  void Visit(const ir::ScheduleBlockRealize* op, Expr* expr) override {
+    auto* node = expr->As<ir::ScheduleBlockRealize>();
+    CHECK(node);
+    auto& iter_values    = node->iter_values;
+    auto* schedule_block = node->schedule_block.As<ir::ScheduleBlock>();
+    CHECK(schedule_block);
+    auto& iter_vars = schedule_block->iter_vars;
+    Expr body       = schedule_block->body;
+    CHECK_EQ(iter_vars.size(), iter_values.size());
+    for (int i = 0; i < iter_vars.size(); i++) {
+      optim::ReplaceVarWithExpr(&body, iter_vars[i], iter_values[i]);
+    }
+    *expr = body;
+    IRMutator::Visit(expr, expr);
+  }
+};
+
+void RemoveScheduleBlock(Expr* e) { ScheduleBlockRemover()(e); }
+
+}  // namespace optim
+}  // namespace cinn

--- a/cinn/optim/remove_schedule_block.h
+++ b/cinn/optim/remove_schedule_block.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * This file implements the strategy to remove the unnecessary nested block.
+ */
+#pragma once
+#include <vector>
+
+#include "cinn/common/common.h"
+#include "cinn/ir/ir.h"
+
+namespace cinn {
+namespace optim {
+
+/**
+ * Remove schedule block.
+ */
+void RemoveScheduleBlock(Expr* e);
+
+}  // namespace optim
+}  // namespace cinn

--- a/cinn/optim/remove_schedule_block_test.cc
+++ b/cinn/optim/remove_schedule_block_test.cc
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/optim/remove_schedule_block.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "cinn/cinn.h"
+#include "cinn/ir/ir.h"
+#include "cinn/ir/ir_operators.h"
+#include "cinn/ir/ir_printer.h"
+#include "cinn/utils/string.h"
+
+namespace cinn {
+namespace optim {
+
+TEST(RemovescheduleBlock, basic) {
+  using namespace ir;  // NOLINT
+  Context::Global().ResetNameId();
+  Placeholder<float> A("A", {Expr(100), Expr(20)});
+  Placeholder<float> B("B", {Expr(20), Expr(50)});
+  Target target = common::DefaultHostTarget();
+  Module::Builder builder("matmul", target);
+  // C = A * B
+  Var k(20, "k0");
+  Tensor C = Compute(
+      {Expr(100), Expr(50)}, [&](Var i, Var j) { return lang::ReduceSum(A(i, k) * B(k, j), {k}); }, "C");
+  auto stages = CreateStages({A, B, C});
+  auto func   = Lower("matmul", stages, {A, B, C}, {}, {}, nullptr, target, true);
+  LOG(INFO) << "func\n" << func;
+
+  std::string origin = utils::GetStreamCnt(func);
+  EXPECT_EQ(origin, utils::Trim(R"ROC(
+function matmul (_A, _B, _C)
+{
+  ScheduleBlock(root)
+  {
+    for (i, 0, 100)
+    {
+      for (j, 0, 50)
+      {
+        ScheduleBlock(C__reduce_init)
+        {
+          i0, i1 = axis.bind(i, j)
+          C__reduce_init[i0, i1] = 0
+        }
+        for (k0, 0, 20)
+        {
+          ScheduleBlock(C)
+          {
+            i0, i1, i2 = axis.bind(i, j, k0)
+            C[i0, i1] = (C[i0, i1] + (A[i0, i2] * B[i2, i1]))
+          }
+        }
+      }
+    }
+  }
+}
+)ROC"));
+
+  RemoveScheduleBlock(&func->body);
+
+  std::cout << "after RemovescheduleBlock:\n" << func << std::endl;
+
+  EXPECT_EQ(utils::GetStreamCnt(func), utils::Trim(R"ROC(
+function matmul (_A, _B, _C)
+{
+  for (i, 0, 100)
+  {
+    for (j, 0, 50)
+    {
+      C__reduce_init[i, j] = 0
+      for (k0, 0, 20)
+      {
+        C[i, j] = (C[i, j] + (A[i, k0] * B[k0, j]))
+      }
+    }
+  }
+}
+)ROC"));
+}
+
+}  // namespace optim
+}  // namespace cinn

--- a/cinn/pybind/lang.cc
+++ b/cinn/pybind/lang.cc
@@ -61,10 +61,11 @@ void BindLower(py::module *m) {
          arg("name"),
          arg("stages"),
          arg("tensor_args"),
-         arg("scalar_args")  = std::vector<ir::Var>(),
-         arg("temp_tensors") = std::vector<ir::Tensor>(),
-         arg("b")            = nullptr,
-         arg("target")       = common::DefaultHostTarget());
+         arg("scalar_args")        = std::vector<ir::Var>(),
+         arg("temp_tensors")       = std::vector<ir::Tensor>(),
+         arg("b")                  = nullptr,
+         arg("target")             = common::DefaultHostTarget(),
+         arg("supprt_ir_schedule") = false);
 }
 
 void BindLowerVec(py::module *m) {
@@ -74,10 +75,11 @@ void BindLowerVec(py::module *m) {
          arg("name"),
          arg("stages"),
          arg("tensor_args"),
-         arg("scalar_args")  = std::vector<ir::Var>(),
-         arg("temp_tensors") = std::vector<ir::Tensor>(),
-         arg("b")            = nullptr,
-         arg("target")       = common::DefaultHostTarget());
+         arg("scalar_args")        = std::vector<ir::Var>(),
+         arg("temp_tensors")       = std::vector<ir::Tensor>(),
+         arg("b")                  = nullptr,
+         arg("target")             = common::DefaultHostTarget(),
+         arg("supprt_ir_schedule") = false);
 }
 
 void BindCompute(py::module *m) {


### PR DESCRIPTION
1、add ScheduleBlock, ScheduleBlockRealize, BufferRange nodes for schedule IR 
2、support ir_copy, ir_visiter, ir_mutator, ir_printer of the new nodes，not support codegen because it will not appear in the final IR
3、support lowering schedule ir of computeOps, format as follows:
```
ScheduleBlock("name") 
{
    for (i, 0, 100) {
        for (j, 0, 50) {
           read_buffers(...)
           write_buffers(...)
           i0, i1 = axis.bind(i, j)
           C[i0, i1] = A[i0, i1] + B[i0, i1]
        }
    }
}
```
