### PR TITLE
fix cannot find opmapper header bug

### DIFF
--- a/cinn/frontend/op_mappers/CMakeLists.txt
+++ b/cinn/frontend/op_mappers/CMakeLists.txt
@@ -1,2 +1,4 @@
+core_gather_headers()
+
 add_subdirectory(paddle)
 add_subdirectory(science)


### PR DESCRIPTION
# 起因
在添加OpMapper的PR中（[#672](https://github.com/PaddlePaddle/CINN/pull/672)），将paddle和science分隔开后忘了在原OpMapper目录下添加core_gather_headers()，导致Paddle中找不到该目录下的头文件，本PR用于修复该bug。