### PR TITLE
Add Reorder primitive

### DIFF
--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -26,6 +26,7 @@
 #include "cinn/ir/ir_printer.h"
 #include "cinn/lang/lower.h"
 #include "cinn/optim/ir_simplify.h"
+#include "cinn/optim/remove_schedule_block.h"
 
 namespace cinn {
 namespace backends {
@@ -44,7 +45,7 @@ TEST(IrSchedule, split_and_fuse1) {
 
   auto stages = CreateStages({A, B});
 
-  auto func     = cinn::lang::LowerVec("test_split_and_fuse1", stages, {A, B});
+  auto func     = cinn::lang::LowerVec("test_split_and_fuse1", stages, {A, B}, {}, {}, nullptr, target, true);
   auto ast_expr = func[0]->body;
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
@@ -61,6 +62,8 @@ TEST(IrSchedule, split_and_fuse1) {
   VLOG(3) << "After split {256, -1}, IR is : " << ir_sch.GetModule().GetExprs().at(0);
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
+
+  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {
@@ -110,7 +113,7 @@ TEST(IrSchedule, split_and_fuse2) {
 
   auto stages = CreateStages({A, B});
 
-  auto func     = cinn::lang::LowerVec("test_split_and_fuse2", stages, {A, B});
+  auto func     = cinn::lang::LowerVec("test_split_and_fuse2", stages, {A, B}, {}, {}, nullptr, target, true);
   auto ast_expr = func[0]->body;
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
@@ -122,6 +125,8 @@ TEST(IrSchedule, split_and_fuse2) {
   VLOG(3) << "After split {-1, 20}, IR is : " << ir_sch.GetModule().GetExprs().at(0);
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
+
+  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {
@@ -173,7 +178,7 @@ TEST(IrSchedule, reorder1) {
 
   auto stages = CreateStages({A, B});
 
-  auto func     = cinn::lang::LowerVec("test_reorder1", stages, {A, B});
+  auto func     = cinn::lang::LowerVec("test_reorder1", stages, {A, B}, {}, {}, nullptr, target, true);
   auto ast_expr = func[0]->body;
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
@@ -187,6 +192,8 @@ TEST(IrSchedule, reorder1) {
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
+  optim::RemoveScheduleBlock(&func[0]->body);
+
   Module::Builder builder("module1", target);
   for (auto& i : func) {
     builder.AddFunction(i);
@@ -196,7 +203,7 @@ TEST(IrSchedule, reorder1) {
   codegen.SetInlineBuiltinCodes(false);
   auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
 
-  LOG(INFO) << "reorder1 source code is :\n" << source_code;
+  VLOG(3) << "reorder1 source code is :\n" << source_code;
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
@@ -241,7 +248,7 @@ TEST(IrSchedule, reorder2) {
 
   auto stages = CreateStages({A, B});
 
-  auto func     = cinn::lang::LowerVec("test_reorder2", stages, {A, B});
+  auto func     = cinn::lang::LowerVec("test_reorder2", stages, {A, B}, {}, {}, nullptr, target, true);
   auto ast_expr = func[0]->body;
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
@@ -255,6 +262,8 @@ TEST(IrSchedule, reorder2) {
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
+  optim::RemoveScheduleBlock(&func[0]->body);
+
   Module::Builder builder("module1", target);
   for (auto& i : func) {
     builder.AddFunction(i);
@@ -264,7 +273,7 @@ TEST(IrSchedule, reorder2) {
   codegen.SetInlineBuiltinCodes(false);
   auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
 
-  LOG(INFO) << "reorder2 source code is :\n" << source_code;
+  VLOG(3) << "reorder2 source code is :\n" << source_code;
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
@@ -309,7 +318,7 @@ TEST(IrSchedule, reorder3) {
 
   auto stages = CreateStages({A, B});
 
-  auto func     = cinn::lang::LowerVec("test_reorder3", stages, {A, B});
+  auto func     = cinn::lang::LowerVec("test_reorder3", stages, {A, B}, {}, {}, nullptr, target, true);
   auto ast_expr = func[0]->body;
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
@@ -323,6 +332,8 @@ TEST(IrSchedule, reorder3) {
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
+  optim::RemoveScheduleBlock(&func[0]->body);
+
   Module::Builder builder("module1", target);
   for (auto& i : func) {
     builder.AddFunction(i);
@@ -332,7 +343,7 @@ TEST(IrSchedule, reorder3) {
   codegen.SetInlineBuiltinCodes(false);
   auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
 
-  LOG(INFO) << "reorder3 source code is :\n" << source_code;
+  VLOG(3) << "reorder3 source code is :\n" << source_code;
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
@@ -379,7 +390,7 @@ TEST(IrSchedule, reorder4) {
 
   auto stages = CreateStages({A, B});
 
-  auto func     = cinn::lang::LowerVec("test_reorder4", stages, {A, B});
+  auto func     = cinn::lang::LowerVec("test_reorder4", stages, {A, B}, {}, {}, nullptr, target, true);
   auto ast_expr = func[0]->body;
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
@@ -393,6 +404,8 @@ TEST(IrSchedule, reorder4) {
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
+  optim::RemoveScheduleBlock(&func[0]->body);
+
   Module::Builder builder("module1", target);
   for (auto& i : func) {
     builder.AddFunction(i);
@@ -402,7 +415,7 @@ TEST(IrSchedule, reorder4) {
   codegen.SetInlineBuiltinCodes(false);
   auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
 
-  LOG(INFO) << "reorder4 source code is :\n" << source_code;
+  VLOG(3) << "reorder4 source code is :\n" << source_code;
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>

--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -158,5 +158,284 @@ void test_split_and_fuse2(void* _args, int32_t num_args)
 )ROC";
   ASSERT_EQ(utils::Trim(target_code), utils::Trim(source_code));
 }
+
+TEST(IrSchedule, reorder1) {
+  Context::Global().ResetNameId();
+  Expr M(32);
+  Expr N(32);
+  Expr P(32);
+
+  Target target = common::DefaultHostTarget();
+
+  Placeholder<float> A("A", {M, N, P});
+  auto B = Compute(
+      {M, N, P}, [&](Var i, Var j, Var k) { return A(i, j, k); }, "B");
+
+  auto stages = CreateStages({A, B});
+
+  auto func     = cinn::lang::LowerVec("test_reorder1", stages, {A, B});
+  auto ast_expr = func[0]->body;
+  std::vector<Expr> vec_ast{ast_expr};
+  ir::ModuleExpr mod_expr(vec_ast);
+  ir::IRSchedule ir_sch(mod_expr);
+  auto loops = ir_sch.GetLoops();
+
+  auto splited = ir_sch.Split(0, {-1, 4});
+  splited      = ir_sch.Split(2, {-1, 2});
+
+  ir_sch.Reorder({4, 0});
+
+  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
+
+  Module::Builder builder("module1", target);
+  for (auto& i : func) {
+    builder.AddFunction(i);
+  }
+  auto module = builder.Build();
+  CodeGenC codegen(target);
+  codegen.SetInlineBuiltinCodes(false);
+  auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
+
+  LOG(INFO) << "reorder1 source code is :\n" << source_code;
+
+  std::string target_code = R"ROC(
+#include <cinn_runtime.h>
+#include <stdio.h>
+
+void test_reorder1(void* _args, int32_t num_args)
+{
+  const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
+  cinn_buffer_t* _B = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[1]));
+  cinn_buffer_malloc((void*)(0), _B);
+  const float* A = ((const float*)(_A->memory));
+  float* B = ((float*)(_B->memory));
+  for (int32_t k = 0; k < 32; k += 1) {
+    for (int32_t i_1 = 0; i_1 < 4; i_1 += 1) {
+      for (int32_t j_0 = 0; j_0 < 16; j_0 += 1) {
+        for (int32_t j_1 = 0; j_1 < 2; j_1 += 1) {
+          for (int32_t i_0 = 0; i_0 < 8; i_0 += 1) {
+            B[((4096 * i_0) + ((1024 * i_1) + ((64 * j_0) + ((32 * j_1) + k))))] = A[((4096 * i_0) + ((1024 * i_1) + ((64 * j_0) + ((32 * j_1) + k))))];
+          };
+        };
+      };
+    };
+  };
+  cinn_buffer_free((void*)(0), _B);
+}
+
+)ROC";
+  ASSERT_EQ(utils::Trim(target_code), utils::Trim(source_code));
+}
+
+TEST(IrSchedule, reorder2) {
+  Context::Global().ResetNameId();
+  Expr M(32);
+  Expr N(32);
+  Expr P(32);
+
+  Target target = common::DefaultHostTarget();
+
+  Placeholder<float> A("A", {M, N, P});
+  auto B = Compute(
+      {M, N, P}, [&](Var i, Var j, Var k) { return A(i, j, k); }, "B");
+
+  auto stages = CreateStages({A, B});
+
+  auto func     = cinn::lang::LowerVec("test_reorder2", stages, {A, B});
+  auto ast_expr = func[0]->body;
+  std::vector<Expr> vec_ast{ast_expr};
+  ir::ModuleExpr mod_expr(vec_ast);
+  ir::IRSchedule ir_sch(mod_expr);
+  auto loops = ir_sch.GetLoops();
+
+  auto splited = ir_sch.Split(0, {-1, 4});
+  splited      = ir_sch.Split(2, {-1, 2});
+
+  ir_sch.Reorder({4, 2, 3, 1, 0});
+
+  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
+
+  Module::Builder builder("module1", target);
+  for (auto& i : func) {
+    builder.AddFunction(i);
+  }
+  auto module = builder.Build();
+  CodeGenC codegen(target);
+  codegen.SetInlineBuiltinCodes(false);
+  auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
+
+  LOG(INFO) << "reorder2 source code is :\n" << source_code;
+
+  std::string target_code = R"ROC(
+#include <cinn_runtime.h>
+#include <stdio.h>
+
+void test_reorder2(void* _args, int32_t num_args)
+{
+  const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
+  cinn_buffer_t* _B = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[1]));
+  cinn_buffer_malloc((void*)(0), _B);
+  const float* A = ((const float*)(_A->memory));
+  float* B = ((float*)(_B->memory));
+  for (int32_t k = 0; k < 32; k += 1) {
+    for (int32_t j_0 = 0; j_0 < 16; j_0 += 1) {
+      for (int32_t j_1 = 0; j_1 < 2; j_1 += 1) {
+        for (int32_t i_1 = 0; i_1 < 4; i_1 += 1) {
+          for (int32_t i_0 = 0; i_0 < 8; i_0 += 1) {
+            B[((4096 * i_0) + ((1024 * i_1) + ((64 * j_0) + ((32 * j_1) + k))))] = A[((4096 * i_0) + ((1024 * i_1) + ((64 * j_0) + ((32 * j_1) + k))))];
+          };
+        };
+      };
+    };
+  };
+  cinn_buffer_free((void*)(0), _B);
+}
+
+)ROC";
+  ASSERT_EQ(utils::Trim(target_code), utils::Trim(source_code));
+}
+
+TEST(IrSchedule, reorder3) {
+  Context::Global().ResetNameId();
+  Expr M(32);
+  Expr N(32);
+  Expr P(32);
+
+  Target target = common::DefaultHostTarget();
+
+  Placeholder<float> A("A", {M, N, P});
+  auto B = Compute(
+      {M, N, P}, [&](Var i, Var j, Var k) { return A(i, j, k); }, "B");
+
+  auto stages = CreateStages({A, B});
+
+  auto func     = cinn::lang::LowerVec("test_reorder3", stages, {A, B});
+  auto ast_expr = func[0]->body;
+  std::vector<Expr> vec_ast{ast_expr};
+  ir::ModuleExpr mod_expr(vec_ast);
+  ir::IRSchedule ir_sch(mod_expr);
+  auto loops = ir_sch.GetLoops();
+
+  auto splited = ir_sch.Split(0, {-1, 5});
+  splited      = ir_sch.Split(2, {-1, 2});
+
+  ir_sch.Reorder({3, 1, 2, 0, 4});
+
+  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
+
+  Module::Builder builder("module1", target);
+  for (auto& i : func) {
+    builder.AddFunction(i);
+  }
+  auto module = builder.Build();
+  CodeGenC codegen(target);
+  codegen.SetInlineBuiltinCodes(false);
+  auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
+
+  LOG(INFO) << "reorder3 source code is :\n" << source_code;
+
+  std::string target_code = R"ROC(
+#include <cinn_runtime.h>
+#include <stdio.h>
+
+void test_reorder3(void* _args, int32_t num_args)
+{
+  const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
+  cinn_buffer_t* _B = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[1]));
+  cinn_buffer_malloc((void*)(0), _B);
+  const float* A = ((const float*)(_A->memory));
+  float* B = ((float*)(_B->memory));
+  for (int32_t j_1 = 0; j_1 < 2; j_1 += 1) {
+    for (int32_t i_1 = 0; i_1 < 5; i_1 += 1) {
+      for (int32_t j_0 = 0; j_0 < 16; j_0 += 1) {
+        for (int32_t i_0 = 0; i_0 < 7; i_0 += 1) {
+          if ((((5 * i_0) + i_1) < 32)) {
+            for (int32_t k = 0; k < 32; k += 1) {
+              B[((5120 * i_0) + ((1024 * i_1) + ((64 * j_0) + ((32 * j_1) + k))))] = A[((5120 * i_0) + ((1024 * i_1) + ((64 * j_0) + ((32 * j_1) + k))))];
+            };
+          };
+        };
+      };
+    };
+  };
+  cinn_buffer_free((void*)(0), _B);
+}
+
+)ROC";
+  ASSERT_EQ(utils::Trim(target_code), utils::Trim(source_code));
+}
+
+TEST(IrSchedule, reorder4) {
+  Context::Global().ResetNameId();
+  Expr M(32);
+  Expr N(32);
+  Expr P(32);
+
+  Target target = common::DefaultHostTarget();
+
+  Placeholder<float> A("A", {M, N, P});
+  auto B = Compute(
+      {M, N, P}, [&](Var i, Var j, Var k) { return A(i, j, k); }, "B");
+
+  auto stages = CreateStages({A, B});
+
+  auto func     = cinn::lang::LowerVec("test_reorder4", stages, {A, B});
+  auto ast_expr = func[0]->body;
+  std::vector<Expr> vec_ast{ast_expr};
+  ir::ModuleExpr mod_expr(vec_ast);
+  ir::IRSchedule ir_sch(mod_expr);
+  auto loops = ir_sch.GetLoops();
+
+  auto splited = ir_sch.Split(0, {-1, 10});
+  splited      = ir_sch.Split(2, {-1, 5});
+
+  ir_sch.Reorder({0, 2, 1, 3, 4});
+
+  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
+
+  Module::Builder builder("module1", target);
+  for (auto& i : func) {
+    builder.AddFunction(i);
+  }
+  auto module = builder.Build();
+  CodeGenC codegen(target);
+  codegen.SetInlineBuiltinCodes(false);
+  auto source_code = codegen.Compile(module, CodeGenC::OutputKind::CImpl);
+
+  LOG(INFO) << "reorder4 source code is :\n" << source_code;
+
+  std::string target_code = R"ROC(
+#include <cinn_runtime.h>
+#include <stdio.h>
+
+void test_reorder4(void* _args, int32_t num_args)
+{
+  const cinn_buffer_t* _A = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[0]));
+  cinn_buffer_t* _B = cinn_pod_value_to_buffer_p(&(((cinn_pod_value_t*)(_args))[1]));
+  cinn_buffer_malloc((void*)(0), _B);
+  const float* A = ((const float*)(_A->memory));
+  float* B = ((float*)(_B->memory));
+  for (int32_t i_0 = 0; i_0 < 4; i_0 += 1) {
+    for (int32_t j_0 = 0; j_0 < 7; j_0 += 1) {
+      for (int32_t i_1 = 0; i_1 < 10; i_1 += 1) {
+        if ((((10 * i_0) + i_1) < 32)) {
+          for (int32_t j_1 = 0; j_1 < 5; j_1 += 1) {
+            if ((((5 * j_0) + j_1) < 32)) {
+              for (int32_t k = 0; k < 32; k += 1) {
+                B[((10240 * i_0) + ((1024 * i_1) + ((160 * j_0) + ((32 * j_1) + k))))] = A[((10240 * i_0) + ((1024 * i_1) + ((160 * j_0) + ((32 * j_1) + k))))];
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  cinn_buffer_free((void*)(0), _B);
+}
+
+)ROC";
+  ASSERT_EQ(utils::Trim(target_code), utils::Trim(source_code));
+}
+
 }  // namespace backends
 }  // namespace cinn

--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -50,15 +50,13 @@ TEST(IrSchedule, split_and_fuse1) {
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
   ir::IRSchedule ir_sch(mod_expr);
-  auto loops = ir_sch.GetLoops();
-
-  auto fused   = ir_sch.Fuse(loops);
+  auto fused   = ir_sch.Fuse("B", {0, 1});
   auto splited = ir_sch.Split(fused, {4, -1});
   VLOG(3) << "After split {4, -1}, IR is : " << ir_sch.GetModule().GetExprs().at(0);
 
-  loops   = ir_sch.GetLoops();
-  fused   = ir_sch.Fuse(loops);
-  splited = ir_sch.Split(fused, {256, -1});
+  auto loops = ir_sch.GetLoops("B");
+  fused      = ir_sch.Fuse(loops);
+  splited    = ir_sch.Split(fused, {256, -1});
   VLOG(3) << "After split {256, -1}, IR is : " << ir_sch.GetModule().GetExprs().at(0);
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
@@ -118,7 +116,7 @@ TEST(IrSchedule, split_and_fuse2) {
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
   ir::IRSchedule ir_sch(mod_expr);
-  auto loops = ir_sch.GetLoops();
+  auto loops = ir_sch.GetLoops("B");
 
   auto fused   = ir_sch.Fuse(loops);
   auto splited = ir_sch.Split(fused, {-1, 20});
@@ -183,12 +181,12 @@ TEST(IrSchedule, reorder1) {
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
   ir::IRSchedule ir_sch(mod_expr);
-  auto loops = ir_sch.GetLoops();
 
-  auto splited = ir_sch.Split(0, {-1, 4});
-  splited      = ir_sch.Split(2, {-1, 2});
+  auto splited = ir_sch.Split("B", 0, {-1, 4});
+  splited      = ir_sch.Split("B", 2, {-1, 2});
 
-  ir_sch.Reorder({4, 0});
+  auto loops = ir_sch.GetLoops("B");
+  ir_sch.Reorder({loops[4], loops[0]});
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
@@ -253,12 +251,11 @@ TEST(IrSchedule, reorder2) {
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
   ir::IRSchedule ir_sch(mod_expr);
-  auto loops = ir_sch.GetLoops();
 
-  auto splited = ir_sch.Split(0, {-1, 4});
-  splited      = ir_sch.Split(2, {-1, 2});
+  auto splited = ir_sch.Split("B", 0, {-1, 4});
+  splited      = ir_sch.Split("B", 2, {-1, 2});
 
-  ir_sch.Reorder({4, 2, 3, 1, 0});
+  ir_sch.Reorder("B", {4, 2, 3, 1, 0});
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
@@ -323,12 +320,13 @@ TEST(IrSchedule, reorder3) {
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
   ir::IRSchedule ir_sch(mod_expr);
-  auto loops = ir_sch.GetLoops();
+  auto all_blocks = ir_sch.GetAllBlocks();
+  auto loops      = ir_sch.GetLoops(all_blocks[0]);
 
-  auto splited = ir_sch.Split(0, {-1, 5});
-  splited      = ir_sch.Split(2, {-1, 2});
+  auto splited = ir_sch.Split(loops[0], {-1, 5});
+  splited      = ir_sch.Split("B", 2, {-1, 2});
 
-  ir_sch.Reorder({3, 1, 2, 0, 4});
+  ir_sch.Reorder("B", {3, 1, 2, 0, 4});
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 
@@ -395,12 +393,15 @@ TEST(IrSchedule, reorder4) {
   std::vector<Expr> vec_ast{ast_expr};
   ir::ModuleExpr mod_expr(vec_ast);
   ir::IRSchedule ir_sch(mod_expr);
-  auto loops = ir_sch.GetLoops();
 
-  auto splited = ir_sch.Split(0, {-1, 10});
-  splited      = ir_sch.Split(2, {-1, 5});
+  auto all_blocks = ir_sch.GetAllBlocks();
+  auto block_b    = ir_sch.GetBlock("B");
+  auto loops      = ir_sch.GetLoops(block_b);
 
-  ir_sch.Reorder({0, 2, 1, 3, 4});
+  auto splited = ir_sch.Split("B", 0, {-1, 10});
+  splited      = ir_sch.Split("B", 2, {-1, 5});
+
+  ir_sch.Reorder("B", {0, 2, 1, 3, 4});
 
   func[0]->body = ir_sch.GetModule().GetExprs().at(0);
 

--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -59,10 +59,6 @@ TEST(IrSchedule, split_and_fuse1) {
   splited    = ir_sch.Split(fused, {256, -1});
   VLOG(3) << "After split {256, -1}, IR is : " << ir_sch.GetModule().GetExprs().at(0);
 
-  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
-
-  optim::RemoveScheduleBlock(&func[0]->body);
-
   Module::Builder builder("module1", target);
   for (auto& i : func) {
     builder.AddFunction(i);
@@ -121,10 +117,6 @@ TEST(IrSchedule, split_and_fuse2) {
   auto fused   = ir_sch.Fuse(loops);
   auto splited = ir_sch.Split(fused, {-1, 20});
   VLOG(3) << "After split {-1, 20}, IR is : " << ir_sch.GetModule().GetExprs().at(0);
-
-  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
-
-  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {
@@ -187,10 +179,6 @@ TEST(IrSchedule, reorder1) {
 
   auto loops = ir_sch.GetLoops("B");
   ir_sch.Reorder({loops[4], loops[0]});
-
-  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
-
-  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {
@@ -256,10 +244,6 @@ TEST(IrSchedule, reorder2) {
   splited      = ir_sch.Split("B", 2, {-1, 2});
 
   ir_sch.Reorder("B", {4, 2, 3, 1, 0});
-
-  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
-
-  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {
@@ -327,10 +311,6 @@ TEST(IrSchedule, reorder3) {
   splited      = ir_sch.Split("B", 2, {-1, 2});
 
   ir_sch.Reorder("B", {3, 1, 2, 0, 4});
-
-  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
-
-  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {
@@ -402,10 +382,6 @@ TEST(IrSchedule, reorder4) {
   splited      = ir_sch.Split("B", 2, {-1, 5});
 
   ir_sch.Reorder("B", {0, 2, 1, 3, 4});
-
-  func[0]->body = ir_sch.GetModule().GetExprs().at(0);
-
-  optim::RemoveScheduleBlock(&func[0]->body);
 
   Module::Builder builder("module1", target);
   for (auto& i : func) {

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -89,11 +89,38 @@ class IRSchedule {
   std::vector<Expr> Split(Expr& loop, const std::vector<int>& factors);
 
   /**
+   * \brief Split a for loop into multiple loops, based on the factors.
+   * @param loop_index Index of the loop to be splited.
+   * @param factors The factors we used to split the loop.
+   * @return The splited loops.
+   */
+  std::vector<Expr> Split(int loop_index, const std::vector<int>& factors);
+
+  /**
    * \brief Fuse for loops and return the fused loop.
    * @param loops All the loops to be fused, stored in ascending order.
    * @return The fused loop.
    */
   Expr Fuse(std::vector<Expr>& loops);
+
+  /**
+   * \brief Fuse for loops and return the fused loop.
+   * @param loops_index Indices of the loops to be fused, stored in ascending order.
+   * @return The fused loop.
+   */
+  Expr Fuse(std::vector<int>& loops_index);
+
+  /**
+   * \brief Reorder the loops in the order of vector.
+   * @param loops The loops to be reordered.
+   */
+  void Reorder(std::vector<Expr>& loops);
+
+  /**
+   * \brief Reorder the loops in the order of vector elements.
+   * @param loops_index Indices of loops to be reordered.
+   */
+  void Reorder(const std::vector<int>& loops_index);
 
   //! Get the ModuleExpr stored in ScheduleHelper.
   ModuleExpr GetModule() { return helper_.GetModule(); }

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -28,16 +28,16 @@ namespace ir {
 class ModuleExpr {
  public:
   ModuleExpr() = default;
-  explicit ModuleExpr(const std::vector<Expr>& init_exprs) : init_exprs_(init_exprs) {}
+  explicit ModuleExpr(const std::vector<Expr>& exprs) : exprs_(exprs) {}
 
   //! Get all the Expr in this ModuleExpr.
-  std::vector<Expr> GetExprs() { return init_exprs_; }
+  std::vector<Expr> GetExprs() { return exprs_; }
 
-  std::vector<Expr> GetExprs() const { return init_exprs_; }
+  std::vector<Expr> GetExprs() const { return exprs_; }
 
  private:
   //! Exprs stored in ModuleExpr. Each one is an AST, representing a computation kernel.
-  std::vector<Expr> init_exprs_;
+  std::vector<Expr> exprs_;
 };
 
 /**

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -31,6 +31,8 @@ class ModuleExpr {
   explicit ModuleExpr(const std::vector<Expr>& init_exprs) : init_exprs_(init_exprs) {}
 
   //! Get all the Expr in this ModuleExpr.
+  std::vector<Expr> GetExprs() { return init_exprs_; }
+
   std::vector<Expr> GetExprs() const { return init_exprs_; }
 
  private:
@@ -55,10 +57,27 @@ class ScheduleHelper {
    * @param src_sref The IR node to be replaced.
    * @param tgt_stmt The IR node to replace the original one.
    */
-  void Replace(Expr& src_sref, const Expr& tgt_stmt);
+  void Replace(const Expr& src_sref, const Expr& tgt_stmt);
 
-  //! Get all the loops in AST stored in ModuleExpr.
-  std::vector<Expr> GetLoops() const;
+  /**
+   * \brief Get all the loops of specific Block stored in ModuleExpr.
+   * @param block The block we find loop in.
+   * @return Loops of the block.
+   */
+  std::vector<Expr> GetLoops(const Expr& block) const;
+
+  /**
+   * \brief Get all the loops of specific Block stored in ModuleExpr.
+   * @param block_name Name of the block.
+   * @return Loops of the block.
+   */
+  std::vector<Expr> GetLoops(const std::string& block_name) const;
+
+  //! Get all blocks stored in this ModuleExpr.
+  std::vector<Expr> GetAllBlocks() const;
+
+  //! Get a block with the specific name.
+  Expr GetBlock(const std::string& block_name) const;
 
   //! Get the ModuleExpr stored in ScheduleHelper.
   ModuleExpr GetModule() const { return module_expr_; }
@@ -77,8 +96,25 @@ class IRSchedule {
   IRSchedule() = default;
   explicit IRSchedule(const ModuleExpr& modexpr, bool debug_flag = false);
 
-  //! Get all the loops in IR(Expr)/AST stored in ModuleExpr.
-  std::vector<Expr> GetLoops() const { return helper_.GetLoops(); }
+  /**
+   * \brief Get all the loops of specific Block stored in ModuleExpr.
+   * @param block The block we find loop in.
+   * @return Loops of the block.
+   */
+  std::vector<Expr> GetLoops(const Expr& block) const { return helper_.GetLoops(block); }
+
+  /**
+   * \brief Get all the loops of specific Block stored in ModuleExpr.
+   * @param block_name Name of the block.
+   * @return Loops of the block.
+   */
+  std::vector<Expr> GetLoops(const std::string& block_name) const { return helper_.GetLoops(block_name); }
+
+  //! Get all blocks stored in this ModuleExpr.
+  std::vector<Expr> GetAllBlocks() const { return helper_.GetAllBlocks(); }
+
+  //! Get a block with the specific name.
+  Expr GetBlock(const std::string& block_name) const { return helper_.GetBlock(block_name); }
 
   /**
    * \brief Split a for loop into multiple loops, based on the factors.
@@ -86,41 +122,44 @@ class IRSchedule {
    * @param factors The factors we used to split the loop.
    * @return The splited loops.
    */
-  std::vector<Expr> Split(Expr& loop, const std::vector<int>& factors);
+  std::vector<Expr> Split(const Expr& loop, const std::vector<int>& factors);
 
   /**
    * \brief Split a for loop into multiple loops, based on the factors.
+   * @param block_name Name of the block we want to modify.
    * @param loop_index Index of the loop to be splited.
    * @param factors The factors we used to split the loop.
    * @return The splited loops.
    */
-  std::vector<Expr> Split(int loop_index, const std::vector<int>& factors);
+  std::vector<Expr> Split(const std::string& block_name, int loop_index, const std::vector<int>& factors);
 
   /**
    * \brief Fuse for loops and return the fused loop.
    * @param loops All the loops to be fused, stored in ascending order.
    * @return The fused loop.
    */
-  Expr Fuse(std::vector<Expr>& loops);
+  Expr Fuse(const std::vector<Expr>& loops);
 
   /**
    * \brief Fuse for loops and return the fused loop.
+   * @param block_name Name of the block we want to modify.
    * @param loops_index Indices of the loops to be fused, stored in ascending order.
    * @return The fused loop.
    */
-  Expr Fuse(std::vector<int>& loops_index);
+  Expr Fuse(const std::string& block_name, const std::vector<int>& loops_index);
 
   /**
    * \brief Reorder the loops in the order of vector.
    * @param loops The loops to be reordered.
    */
-  void Reorder(std::vector<Expr>& loops);
+  void Reorder(const std::vector<Expr>& loops);
 
   /**
    * \brief Reorder the loops in the order of vector elements.
+   * @param block_name Name of the block we want to modify.
    * @param loops_index Indices of loops to be reordered.
    */
-  void Reorder(const std::vector<int>& loops_index);
+  void Reorder(const std::string& block_name, const std::vector<int>& loops_index);
 
   //! Get the ModuleExpr stored in ScheduleHelper.
   ModuleExpr GetModule() { return helper_.GetModule(); }


### PR DESCRIPTION
此pr做了三点修改：
1.添加Reorder原语和对应的测试
2.根据#685 新加入的ScheduleBlock IR节点，修改了之前的原语和辅助函数
3. 修正了Replace函数，不再直接修改传入的IR节点，而是在类内部成员module_expr的语法树中查找替换