### PR TITLE
fix get attr not accept single value problem

### DIFF
--- a/cinn/frontend/op_mappers/science/transform.cc
+++ b/cinn/frontend/op_mappers/science/transform.cc
@@ -202,8 +202,8 @@ void ReduceOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
 
   auto x = ctx.GetVar(x_name);
 
-  VLOG(4) << "Reudce " << x_name << " from shape (" << cinn::utils::Join(x->shape, ",")
-          << "), now only support reduce_sum.";
+  VLOG(4) << "Reudce " << x_name << " from shape (" << cinn::utils::Join(x->shape, ",") << "), with axis "
+          << cinn::utils::Join(axis, ",") << ", keepdim " << keepdim;
 
   // now paddle science only need reduce sum
   auto out = ctx.Builder()->ReduceSum(x, axis, keepdim);

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -1723,8 +1723,8 @@ std::shared_ptr<OpStrategy> StrategyForSliceAssign(const framework::NodeAttr &at
                                                    const Target &target) {
   CHECK_EQ(inputs.size(), 2) << "the number of input tensors must be equal to 2";
   CHECK(!output_shapes.empty() && !output_shapes[0].empty()) << "The shape of output is empty! Please check again.";
-  VLOG(4) << "The output passed in StrategyForIndexSelect: " << utils::Join(output_shapes[0], ", ");
-  CHECK(!out_type.empty()) << "The output type of IndexSelect is empty! Please check again.\n";
+  VLOG(4) << "The output passed in StrategyForSliceAssign: " << utils::Join(output_shapes[0], ", ");
+  CHECK(!out_type.empty()) << "The output type of SliceAssign is empty! Please check again.\n";
 
   std::vector<int> starts, ends, axes, strides;
   if (attrs.attr_store.find("starts") != attrs.attr_store.end()) {
@@ -1740,8 +1740,9 @@ std::shared_ptr<OpStrategy> StrategyForSliceAssign(const framework::NodeAttr &at
     strides = absl::get<std::vector<int>>(attrs.attr_store.at("strides"));
   }
 
-  CHECK(!starts.empty()) << "The Slice op doesn't find [starts] attrbute! It it a mandatory attribute, please check.";
-  CHECK(!ends.empty()) << "The Slice op doesn't find [ends] attrbute! It it a mandatory attribute, please check.";
+  CHECK(!starts.empty())
+      << "The SliceAssign op doesn't find [starts] attrbute! It it a mandatory attribute, please check.";
+  CHECK(!ends.empty()) << "The SliceAssign op doesn't find [ends] attrbute! It it a mandatory attribute, please check.";
   CHECK_EQ(starts.size(), ends.size()) << "The size of [starts] and [ends] must be identical! Please check.";
   if (!axes.empty()) {
     CHECK_EQ(starts.size(), axes.size()) << "The size of [starts] and [axes] must be identical! Please check.";
@@ -1777,7 +1778,7 @@ std::shared_ptr<OpStrategy> StrategyForSliceAssign(const framework::NodeAttr &at
   framework::CINNSchedule slice_assign_schedule{[=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input args are empty! Please check again.";
     CINNValuePack arg_pack = args[0];
-    CHECK_EQ(arg_pack.size(), 2U) << "Expected 2 values in args[0] for index_select_schedule.";
+    CHECK_EQ(arg_pack.size(), 2U) << "Expected 2 values in args[0] for slice_assign_schedule.";
     Expr out              = arg_pack[0];
     poly::StageMap stages = arg_pack[1];
     CHECK(out.as_tensor());


### PR DESCRIPTION
本PR主要解决了如下问题：

1. python端传入OpDesc的属性值为bool类型，但在OpDesc中却变为了int类型，本PR修复了该问题，使得`GetAttrOrDefault`也能获取bool结果即使OpDesc中存储的是int类型的值。
2. 对于`vector<>`类型的属性值，在python端传入时可能只传入了一个值而非一个list，对于该情况paddle也是允许的，因此`GetAttrOrDefault`现也支持在获取`vector<>`类型的属性值时OpDesc只存储了单个值。
3. 修复了注释中的一些问题。