### PR TITLE
fix cuda kernel argument cannot greater then 30 problem

### DIFF
--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -99,8 +99,8 @@ void cinn_call_cuda_kernel(void *kernel_fn,
   // prepare void**
   VLOG(3) << "In cinn_call_cuda_kernel, grid_dim={" << grid_x << ", " << grid_y << ", " << grid_z << "}, block_dim={"
           << block_x << ", " << block_y << ", " << block_z << "}, num_args=" << num_args << ", stream=" << stream;
-  void *arr[20];
-  CHECK_LT(num_args, 20);
+  void *arr[30];
+  CHECK_LT(num_args, 30);
   for (int i = 0; i < num_args; i++) {
     if (args[i].type_code() == ::cinn_type_code<cinn_buffer_t *>()) {
       arr[i] = &((cinn_buffer_t *)(args[i]))->memory;  // NOLINT


### PR DESCRIPTION
原`cinn_call_cuda_kernel`中限制了cuda kernel的参数数目不得超过20个，但在科学计算模型中，存在融合后的参数数目大于20个，此处修改限制为30个。