### PR TITLE
Close make_doc temporarily

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -273,7 +273,7 @@ function CI {
     run_demo
     prepare_model
     run_test
-    make_doc
+    # make_doc
 }
 
 function CINNRT {


### PR DESCRIPTION
目前发现make_doc这一步骤有时会卡住占用机器资源，且此测试（生成文档）不影响CINN的功能和正确性，因此为了提高ci效率暂时关闭