### PR TITLE
Fix unique name bug in matmul

### DIFF
--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -82,7 +82,7 @@ std::vector<Tensor> Matmul(
         }
         return lang::ReduceSum(A(A_indice) * B(B_indice), {reduce_k});
       },
-      "temp_matmul_out");
+      UniqName("temp_matmul_out"));
   if (alpha != 1) {
     auto res = Compute(
         output_shape,


### PR DESCRIPTION
此PR修复了Matmul算子计算时没有对输出tensor的name进行唯一化的bug