### PR TITLE
add slice_assign single test to avoid simplify bad case

### DIFF
--- a/cinn/backends/codegen_cuda_dev_test.cc
+++ b/cinn/backends/codegen_cuda_dev_test.cc
@@ -2976,5 +2976,110 @@ TEST(Cudnn, external_function_cudnn3) {
   runtime::cuda::cinn_gpu_cudnn_softmax({2, 1000, -1}, dev_bufs[0], dev_bufs[1]);
 }
 #endif
+
+TEST(CodeGenCUDA2, test_of_slice_assign) {
+  Context::Global().ResetNameId();
+
+  Target target = common::DefaultNVGPUTarget();
+  CodeGenCUDA_Dev codegen(target);
+
+  Placeholder<float> input("input", {121, 2});
+  Placeholder<float> assign("assign", {121, 1});
+
+  std::vector<int> axes        = {1};
+  std::vector<int> new_starts  = {0};
+  std::vector<int> new_ends    = {1};
+  std::vector<int> strides     = {1};
+  std::vector<int> new_strides = {1};
+
+  auto output = Compute(
+      input->shape,
+      [=](const std::vector<Expr>& indice) {
+        ir::Expr is_assigned             = ir::Expr(true);
+        std::vector<ir::Expr> tmp_indice = indice;
+        for (int idx = 0; idx < axes.size(); ++idx) {
+          // get input axis to be assigned
+          auto tmp_axis = indice[axes[idx]];
+          // get assign axis
+          Expr out_axis;
+          if (strides[idx] > 0) {
+            out_axis = tmp_axis - ir::Expr(new_starts[idx]);
+          } else {
+            // when strides < 0, reverse input to output.
+            // the value of ends is not contained in slice, so `ends - 1`
+            out_axis = ir::Expr(new_ends[idx] - 1) - tmp_axis;
+          }
+          // axis >= start
+          auto ge = ir::GE::Make(tmp_axis, ir::Expr(new_starts[idx]));
+          // axis < ends
+          auto lt = ir::LT::Make(tmp_axis, ir::Expr(new_ends[idx]));
+          // check start <= axis < ends
+          auto inside = ir::And::Make(ge, lt);
+          // check (axis - starts) % strides == 0
+          auto mod = ir::EQ::Make(ir::Mod::Make(out_axis, Expr(new_strides[idx])), Expr(0));
+          // check start <= axis < ends and (axis - starts) % strides == 0
+          is_assigned = ir::And::Make(is_assigned, ir::And::Make(inside, mod));
+          // update axis for assign tensor
+          tmp_indice[axes[idx]] = out_axis / Expr(new_strides[idx]);
+        }
+        return ir::Select::Make(is_assigned, assign(tmp_indice), input(indice));
+      },
+      "output");
+
+  auto stages = CreateStages({output});
+
+  if (target.arch == Target::Arch::NVGPU) {
+    hlir::pe::CudaScheduleInjective(stages[output], std::vector<int>{121, 2}, target);
+  } else if (target.arch == Target::Arch::X86) {
+    hlir::pe::ScheduleInjectiveCPU(stages[output], std::vector<int>{121, 2}, target);
+  }
+
+  auto func = Lower("slice_assign", stages, {input, assign, output});
+
+  Module::Builder builder("module", target);
+  builder.AddFunction(func);
+
+  auto source_code = codegen.Compile(builder.Build());
+
+  LOG(INFO) << "compiled test_of_cacheread code:\n\n\n" << source_code;
+
+  using runtime::cuda::CUDAModule;
+
+  backends::NVRTC_Compiler compiler;
+
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+
+  CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
+
+  CUDA_CALL(cudaDeviceSynchronize());
+
+  CUdeviceptr input_d, assign_d, output_d;
+  cuMemAlloc(&input_d, 121 * 2 * sizeof(float));
+  cuMemAlloc(&assign_d, 121 * 1 * sizeof(float));
+  cuMemAlloc(&output_d, 121 * 2 * sizeof(float));
+
+  std::vector<float> input_h(121 * 2, 0);
+  std::vector<float> assign_h(121 * 1, 0);
+  for (float& v : assign_h) v = static_cast<float>(rand()) / INT_MAX;  // NOLINT
+
+  CUDA_CALL(cudaMemset(reinterpret_cast<void*>(input_d), 0, 121 * 2 * sizeof(float)));
+  CUDA_CALL(
+      cudaMemcpy(reinterpret_cast<void*>(assign_d), assign_h.data(), 121 * 1 * sizeof(float), cudaMemcpyHostToDevice));
+
+  // launch the kernel
+
+  void* args[] = {&input_d, &assign_d, &output_d};
+
+  dim3 grid(1, 1, 1);
+  dim3 block(242, 1, 1);
+  cuda_module.LaunchKernel(0, "slice_assign", grid, block, args);
+  CUDA_CALL(cudaDeviceSynchronize());
+
+  cuMemFree(input_d);
+  cuMemFree(assign_d);
+  cuMemFree(output_d);
+}
+
 }  // namespace backends
 }  // namespace cinn

--- a/python/tests/ops/test_slice_assign_op.py
+++ b/python/tests/ops/test_slice_assign_op.py
@@ -148,5 +148,102 @@ class TestSliceAssignCase4(TestSliceAssignOp):
         self.strides = [-1, -2]
 
 
+class TestSliceAssignAxes1Op(TestSliceAssignOp):
+    def init_case(self):
+        self.inputs = {
+            "inputs": np.random.random([121, 2]).astype("float32"),
+            "assign": np.zeros([121, 1]).astype("float32")
+        }
+        self.axes = [1]
+        self.starts = [0]
+        self.ends = [1]
+        self.strides = [1]
+
+    def build_paddle_program(self, target):
+        res = self.inputs["inputs"].copy()
+
+        for row_id in range(self.inputs["inputs"].shape[0]):
+            res[row_id][self.starts[0]:self.ends[0]:self.
+                        strides[0]] = self.inputs["assign"][row_id]
+
+        pd_res = paddle.to_tensor(res, stop_gradient=True)
+        self.paddle_outputs = [pd_res]
+
+
+class TestSliceAssignAxes1Case1(TestSliceAssignAxes1Op):
+    def init_case(self):
+        self.inputs = {
+            "inputs": np.random.random([121, 2]).astype("float32"),
+            "assign": np.zeros([121, 1]).astype("float32")
+        }
+        self.axes = [1]
+        self.starts = [1]
+        self.ends = [2]
+        self.strides = [1]
+
+
+class TestSliceAssignAxes1Case2(TestSliceAssignAxes1Op):
+    def init_case(self):
+        self.inputs = {
+            "inputs": np.random.random([121, 2]).astype("float32"),
+            "assign": np.zeros([121, 1]).astype("float32")
+        }
+        self.axes = [1]
+        self.starts = [1]
+        self.ends = [0]
+        self.strides = [-1]
+
+
+class TestSliceAssignAxes2Op(TestSliceAssignOp):
+    def init_case(self):
+        self.inputs = {
+            "inputs": np.random.random([121, 2, 2]).astype("float32"),
+            "assign": np.zeros([121, 2, 1]).astype("float32")
+        }
+        self.axes = [2]
+        self.starts = [0]
+        self.ends = [1]
+        self.strides = [1]
+
+    def build_paddle_program(self, target):
+        res = self.inputs["inputs"].copy()
+
+        row_len = self.num_of_slice(self.starts[0], self.ends[0],
+                                    self.strides[0])
+
+        for row_id in range(self.inputs["inputs"].shape[0]):
+            for col_id in range(self.inputs["inputs"].shape[1]):
+                res[row_id][col_id][self.starts[0]:self.ends[0]:self.
+                                    strides[0]] = self.inputs["assign"][
+                                        row_id][col_id]
+
+        pd_res = paddle.to_tensor(res, stop_gradient=True)
+        self.paddle_outputs = [pd_res]
+
+
+class TestSliceAssignAxes2Case1(TestSliceAssignAxes2Op):
+    def init_case(self):
+        self.inputs = {
+            "inputs": np.random.random([121, 2, 2]).astype("float32"),
+            "assign": np.zeros([121, 2, 1]).astype("float32")
+        }
+        self.axes = [2]
+        self.starts = [1]
+        self.ends = [2]
+        self.strides = [1]
+
+
+class TestSliceAssignAxes2Case2(TestSliceAssignAxes2Op):
+    def init_case(self):
+        self.inputs = {
+            "inputs": np.random.random([121, 2, 2]).astype("float32"),
+            "assign": np.zeros([121, 2, 1]).astype("float32")
+        }
+        self.axes = [2]
+        self.starts = [1]
+        self.ends = [0]
+        self.strides = [-1]
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
之前`SliceAssign`算子在参数`input[121, 2], assign[121, 1], axes[1], starts[0], ends[1]`下生成的代码是错误的，如图，assign取值存在访存越界问题：
![af1ff057937cc3038f5571482e46cc54](https://user-images.githubusercontent.com/31386411/160091609-a0d31c5b-fe91-46e8-aaab-8a9da43a2943.png)

正确代码应该是这样的：
![8af9d899ae2ef4544dd105f98e7b3d27](https://user-images.githubusercontent.com/31386411/160091758-4c8dc73f-d0d3-46cd-804d-f36d721e3bd6.png)

https://github.com/PaddlePaddle/CINN/pull/721 修复了该问题，现在生成的代码如图：
![image](https://user-images.githubusercontent.com/31386411/160092030-7344135a-231c-4f0d-b3f2-2c34b8ff9400.png)


本PR的作用是添加了相应单测，确保以后不会出现该问题了。