### PR TITLE
Entrance of auto schedule

### DIFF
--- a/cinn/auto_schedule/CMakeLists.txt
+++ b/cinn/auto_schedule/CMakeLists.txt
@@ -3,3 +3,9 @@ add_subdirectory(search_space)
 add_subdirectory(search_strategy)
 add_subdirectory(task)
 add_subdirectory(task_scheduler)
+
+core_gather_headers()
+
+gather_srcs(cinnapi_src SRCS auto_tuner.cc)
+
+cc_test(test_auto_tuner SRCS auto_tuner_test.cc DEPS cinncore)

--- a/cinn/auto_schedule/auto_tuner.cc
+++ b/cinn/auto_schedule/auto_tuner.cc
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/auto_tuner.h"
+
+#include <algorithm>
+
+#include "cinn/auto_schedule/task/task_creator.h"
+#include "cinn/auto_schedule/task_scheduler/task_scheduler.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+AutoTuner::AutoTuner(const common::Target& target, hlir::framework::Graph* graph) : target_(target), graph_(graph) {}
+
+void AutoTuner::Initialize(const Config& config, hlir::framework::GraphCompiler* graph_compiler) {
+  // create tasks
+  TaskCreator task_creator;
+  tasks_ = task_creator.CreateTuneTaskOpLevel(graph_);
+  CHECK_GT(tasks_.size(), 0) << "Create tasks failed";
+
+  // create task optimizers
+  task_optimizers_.resize(tasks_.size());
+  std::transform(tasks_.begin(), tasks_.end(), task_optimizers_.begin(), [](const TuneTask& task) {
+    return std::make_unique<TaskOptimizer>(task);
+  });
+
+  // create task scheduler
+  task_scheduler_ = TaskScheduler::Make(tasks_, config.task_schedule_config, config.task_schedule_strategy);
+}
+
+TuningResult AutoTuner::Tune(const TuningOptions& options) {
+  CHECK_GT(options.num_tuning_rounds, 0) << "Invalid config";
+
+  TuningResult result;
+  result.tuned_graphs.resize(tasks_.size());
+  result.optimized_schedules.resize(tasks_.size());
+  // A task only tunes schedule now, so we populate its sub_graph
+  // as default result of graph tuning, and that should be updated
+  // once we support graph tuning.
+  for (auto i = 0; i < tasks_.size(); ++i) {
+    auto&& task                   = tasks_.at(i);
+    result.tuned_graphs[i].groups = task.task_graph();
+  }
+
+  for (int r = 0; r < options.num_tuning_rounds; ++r) {
+    int run_id = -1;
+    task_scheduler_->Reset();
+    while ((run_id = task_scheduler_->NextTaskId()) != -1) {
+      auto* opt               = task_optimizers_.at(run_id).get();
+      auto optimized_schedule = opt->optimize(options);
+      // update the best schedules searched so far.
+      result.optimized_schedules.at(run_id) = optimized_schedule;
+    }
+  }
+
+  return result;
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/auto_tuner.h
+++ b/cinn/auto_schedule/auto_tuner.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cinn/auto_schedule/task/task_optimizer.h"
+#include "cinn/auto_schedule/task/tune_task.h"
+#include "cinn/auto_schedule/task_scheduler/task_scheduler.h"
+#include "cinn/auto_schedule/tuning.h"
+#include "cinn/common/target.h"
+#include "cinn/hlir/framework/graph.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+// This class is entrance of auto-tune, user can use it
+// to tune graph (not supported yet) and search a schedule
+// that maybe more likely to obtain better performance.
+// Internally, it create necessary components and use them to finish tuning.
+class AutoTuner {
+ public:
+  // configure how to perform auto-tune, such as
+  // the way to create tasks, the strategy of scheduling tasks and so on.
+  struct Config {
+    std::string task_schedule_strategy = "round_robin";
+    TaskScheduler::Config task_schedule_config;
+  };
+
+  AutoTuner(const common::Target& target, hlir::framework::Graph* graph);
+
+  // Initialize tuner with specific config and auxiliary objects.
+  void Initialize(const Config& config, hlir::framework::GraphCompiler* graph_compiler);
+
+  // Perform the tuning process and return the final result
+  TuningResult Tune(const TuningOptions& options);
+
+ private:
+  const common::Target& target_;
+  hlir::framework::Graph* graph_;
+
+  // Tasks to tune
+  std::vector<TuneTask> tasks_;
+  // Scheduler that select a task to tune at every turn.
+  std::unique_ptr<TaskScheduler> task_scheduler_;
+  // The actor to perform auto-tune, each optimizer take a task.
+  std::vector<std::unique_ptr<TaskOptimizer>> task_optimizers_;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/auto_tuner_test.cc
+++ b/cinn/auto_schedule/auto_tuner_test.cc
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/auto_tuner.h"
+
+#include <gtest/gtest.h>
+
+#include "cinn/common/target.h"
+#include "cinn/frontend/net_builder.h"
+#include "cinn/frontend/syntax.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+using ::cinn::hlir::framework::BuildScope;
+using ::cinn::hlir::framework::Graph;
+using ::cinn::hlir::framework::GraphCompiler;
+
+frontend::Program CreateAddReluProgram() {
+  frontend::NetBuilder builder("test");
+
+  auto a = builder.CreateInput(Float(32), {1, 64, 112, 112}, "A");
+  auto b = builder.CreateInput(Float(32), {64}, "B");
+  auto c = builder.ElementwiseAdd(a, b, 1);
+  auto d = builder.Relu(c);
+
+  return builder.Build();
+}
+
+TEST(AutoTuner, Basic) {
+  auto target         = common::DefaultHostTarget();
+  auto graph          = std::make_shared<Graph>(CreateAddReluProgram(), target);
+  auto scope          = BuildScope(target, graph);
+  auto graph_compiler = std::make_unique<GraphCompiler>(target, scope, graph);
+
+  auto tuner = std::make_unique<AutoTuner>(target, graph.get());
+  AutoTuner::Config tuning_config;
+  tuning_config.task_schedule_strategy = "round_robin";
+  tuner->Initialize(tuning_config, graph_compiler.get());
+
+  TuningOptions tuning_options;
+  tuning_options.num_tuning_rounds  = 2;
+  tuning_options.num_measure_trials = 1;
+  TuningResult result               = tuner->Tune(tuning_options);
+
+  ASSERT_EQ(2, result.tuned_graphs.size());
+  const auto& sub_graph1 = result.tuned_graphs.front();
+  ASSERT_EQ(1, sub_graph1.groups.size());
+  ASSERT_EQ(sub_graph1.groups[0][0]->op()->name, "elementwise_add");
+  const auto& sub_graph2 = result.tuned_graphs.back();
+  ASSERT_EQ(1, sub_graph2.groups.size());
+  ASSERT_EQ(sub_graph2.groups[0][0]->op()->name, "relu");
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/task/task_optimizer.cc
+++ b/cinn/auto_schedule/task/task_optimizer.cc
@@ -17,7 +17,10 @@
 namespace cinn {
 namespace auto_schedule {
 
-void TaskOptimizer::Tune(const TuningOptions& options) {}
+TuningResult::OptimizedSchedule TaskOptimizer::optimize(const TuningOptions& options) {
+  TuningResult::OptimizedSchedule result;
+  return result;
+}
 
 }  // namespace auto_schedule
 }  // namespace cinn

--- a/cinn/auto_schedule/task/task_optimizer.h
+++ b/cinn/auto_schedule/task/task_optimizer.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "cinn/auto_schedule/task/tune_task.h"
-#include "cinn/auto_schedule/task/tuning_options.h"
+#include "cinn/auto_schedule/tuning.h"
 
 namespace cinn {
 namespace auto_schedule {
@@ -27,7 +27,7 @@ class TaskOptimizer {
  public:
   TaskOptimizer(const TuneTask& task) : task_(&task) {}
 
-  void Tune(const TuningOptions& options);
+  TuningResult::OptimizedSchedule optimize(const TuningOptions& options);
 
  private:
   const TuneTask* task_;

--- a/cinn/auto_schedule/task_scheduler/efficiency_priority.h
+++ b/cinn/auto_schedule/task_scheduler/efficiency_priority.h
@@ -29,7 +29,6 @@ class EfficiencyPriority : public TaskScheduler {
 
   const char* Name() const override { return "efficiency_priority"; };
 
- protected:
   int NextTaskId() override;
 
  private:

--- a/cinn/auto_schedule/task_scheduler/round_robin.h
+++ b/cinn/auto_schedule/task_scheduler/round_robin.h
@@ -29,7 +29,6 @@ class RoundRobin : public TaskScheduler {
 
   const char* Name() const override { return "round_robin"; };
 
- protected:
   int NextTaskId() override;
 };
 

--- a/cinn/auto_schedule/task_scheduler/task_scheduler_test.cc
+++ b/cinn/auto_schedule/task_scheduler/task_scheduler_test.cc
@@ -34,14 +34,23 @@ TEST(TaskScheduler, Make) {
   ASSERT_STREQ(efficiency_priority->Name(), "efficiency_priority");
 }
 
-// TODO(CtfGo): Add tests for member functions (Run, NextTaskId) of
-// a detail TaskScheduler object after we define
-// the callback for returning tuning results in TuningOptions
-TEST(TaskScheduler, Run) {}
+TEST(RoundRobinScheduler, NextTaskId) {
+  std::vector<TuneTask> tasks(3);
+  TaskScheduler::Config config;
+  auto round_robin = TaskScheduler::Make(tasks, config);
+  ASSERT_EQ(0, round_robin->NextTaskId());
+  ASSERT_EQ(1, round_robin->NextTaskId());
+  round_robin->Reset();
+  ASSERT_EQ(0, round_robin->NextTaskId());
+}
 
-TEST(RoundRobinScheduler, NextTaskId) {}
-
-TEST(EfficiencyPriorityScheduler, NextTaskId) {}
+TEST(EfficiencyPriorityScheduler, NextTaskId) {
+  std::vector<TuneTask> tasks(3);
+  TaskScheduler::Config config;
+  config.minimum_gain_threshold = -1.0;
+  auto round_robin              = TaskScheduler::Make(tasks, config);
+  ASSERT_EQ(-1, round_robin->NextTaskId());
+}
 
 }  // namespace auto_schedule
 }  // namespace cinn

--- a/cinn/auto_schedule/task_scheduler/task_scheduler_test.cc
+++ b/cinn/auto_schedule/task_scheduler/task_scheduler_test.cc
@@ -48,8 +48,8 @@ TEST(EfficiencyPriorityScheduler, NextTaskId) {
   std::vector<TuneTask> tasks(3);
   TaskScheduler::Config config;
   config.minimum_gain_threshold = -1.0;
-  auto round_robin              = TaskScheduler::Make(tasks, config);
-  ASSERT_EQ(-1, round_robin->NextTaskId());
+  auto efficiency_priority      = TaskScheduler::Make(tasks, config, "efficiency_priority");
+  ASSERT_EQ(-1, efficiency_priority->NextTaskId());
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/tuning.h
+++ b/cinn/auto_schedule/tuning.h
@@ -14,15 +14,39 @@
 
 #pragma once
 
+#include <vector>
+
+#include "cinn/hlir/framework/node.h"
+#include "cinn/ir/lowered_func.h"
+
 namespace cinn {
 namespace auto_schedule {
 
-// Options for task tuning process
+// Options for tuning process
 struct TuningOptions {
+  // The number of tuning rounds, each round will
+  // involve TuningOptions.num_measure_trials measurements.
+  int num_tuning_rounds = 1;
   // The number of measurement trials, if it is 0,
   // that means the tunner will return the best
   // candidate of schedule config without measurement.
   int num_measure_trials = 0;
+};
+
+// Result of the tuning process
+struct TuningResult {
+  // Result of graph tuning
+  struct TunedGraph {
+    std::vector<std::vector<hlir::framework::Node*>> groups;
+  };
+
+  // Result of schedule tuning in CINN IR
+  struct OptimizedSchedule {
+    std::vector<std::vector<ir::LoweredFunc>> lowered_funcs;
+  };
+
+  std::vector<TunedGraph> tuned_graphs;
+  std::vector<OptimizedSchedule> optimized_schedules;
 };
 
 }  // namespace auto_schedule


### PR DESCRIPTION
1. add `AutoTuner` class as the main interface for user to call auto-schedule to tune graph or schedule.
2. adjust the role of `TaskScheduler`, it will only return the next task id to tune and not responsible for scheduling task to tune.
3. add associated simple unit tests.