### PR TITLE
add basic classes for schedule measurement

### DIFF
--- a/cinn/auto_schedule/CMakeLists.txt
+++ b/cinn/auto_schedule/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(cost_model)
+add_subdirectory(measure)
 add_subdirectory(search_space)
 add_subdirectory(search_strategy)
 add_subdirectory(task)

--- a/cinn/auto_schedule/measure/CMakeLists.txt
+++ b/cinn/auto_schedule/measure/CMakeLists.txt
@@ -1,0 +1,6 @@
+core_gather_headers()
+
+gather_srcs(cinnapi_src SRCS schedule_measurer.cc simple_builder.cc simple_runner.cc)
+
+cc_test(test_simple_runner SRCS simple_runner_test.cc DEPS cinncore)
+cc_test(test_measurer SRCS measurer_test.cc DEPS cinncore)

--- a/cinn/auto_schedule/measure/measure.h
+++ b/cinn/auto_schedule/measure/measure.h
@@ -61,7 +61,7 @@ class ScheduleBuilder {
   virtual BuildResult Build(const MeasureInput& input) = 0;
 };
 
-// This interface defines how to run the build result. Like above ScheduleBuilder,
+// This interface defines how to run the built result. Like above ScheduleBuilder,
 // a runner shoule be implemented with not bound to a specific task.
 class ScheduleRunner {
  public:

--- a/cinn/auto_schedule/measure/measure.h
+++ b/cinn/auto_schedule/measure/measure.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "cinn/auto_schedule/task/tune_task.h"
+#include "cinn/hlir/framework/instruction.h"
+#include "cinn/runtime/cinn_runtime.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+// The input to a measurer
+struct MeasureInput {
+  // The task object releated to this measurement.
+  TuneTask* task;
+  // It is used to pass for some arguments that maybe
+  // specified value in advance. default is null
+  const std::map<std::string, cinn_pod_value_t>* execution_args = nullptr;
+};
+
+// The result of a measurement
+struct MeasureResult {
+  // The time cost of execution in average of running
+  // with a specific repeated times.
+  double execution_cost;  // unit: us
+  // The time cost of the whole measurement process including
+  // building and running
+  double elapsed_time;  // unit: us
+};
+
+// The result of building with input schedule
+struct BuildResult {
+  // The scope that owns detail infos of parameters of all instructions
+  const hlir::framework::Scope* compiled_scope;
+  // The executable instructions built with the measurement input
+  std::vector<std::unique_ptr<hlir::framework::Instruction>> instructions;
+};
+
+// This interface defines how to generate executable objects
+// with input schedule. A builer should not contain stateful data
+// releated to any task so it can be called parallelly among multiple
+// processes of task tuning.
+class ScheduleBuilder {
+ public:
+  virtual BuildResult Build(const MeasureInput& input) = 0;
+};
+
+// This interface defines how to run the build result. Like above ScheduleBuilder,
+// a runner shoule be implemented with not bound to a specific task.
+class ScheduleRunner {
+ public:
+  virtual MeasureResult Run(const MeasureInput& input, const BuildResult& build_result) = 0;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/measurer_test.cc
+++ b/cinn/auto_schedule/measure/measurer_test.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "cinn/auto_schedule/measure/schedule_measurer.h"
+#include "cinn/auto_schedule/measure/simple_builder.h"
+#include "cinn/auto_schedule/measure/simple_runner.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+TEST(ScheduleMeasurer, Basic) {
+  auto builder  = std::make_unique<SimpleBuilder>(nullptr);
+  auto runner   = std::make_unique<SimpleRunner>(1);
+  auto measurer = std::make_unique<ScheduleMeasurer>(builder.get(), runner.get());
+  std::vector<MeasureInput> inputs(2);
+  std::vector<MeasureResult> results = measurer->Measure(inputs);
+  ASSERT_EQ(2, results.size());
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/schedule_measurer.cc
+++ b/cinn/auto_schedule/measure/schedule_measurer.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/measure/schedule_measurer.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+ScheduleMeasurer::ScheduleMeasurer(ScheduleBuilder* builder, ScheduleRunner* runner)
+    : builder_(builder), runner_(runner) {}
+
+std::vector<MeasureResult> ScheduleMeasurer::Measure(const std::vector<MeasureInput>& inputs) {
+  std::vector<MeasureResult> results;
+  for (auto i = 0; i < inputs.size(); ++i) {
+    auto m_start = std::chrono::steady_clock::now();
+    auto&& input = inputs.at(i);
+
+    BuildResult build_res = builder_->Build(input);
+    MeasureResult res     = runner_->Run(input, build_res);
+
+    auto time_span = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_start);
+    // use the time span counted in measurer
+    res.elapsed_time = static_cast<double>(time_span.count());
+    VLOG(5) << "Measurement-" << i << " cost " << res.elapsed_time << "us";
+    results.emplace_back(std::move(res));
+  }
+
+  VLOG(4) << "Measure " << inputs.size() << " tests";
+  return results;
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/schedule_measurer.h
+++ b/cinn/auto_schedule/measure/schedule_measurer.h
@@ -21,7 +21,7 @@
 namespace cinn {
 namespace auto_schedule {
 
-// This class performs schedule measurement, it mainly includes two processes,
+// Entrance of schedule measurement, it mainly includes two processes:
 // which are building the input schedules and running the generated codes.
 class ScheduleMeasurer {
  public:

--- a/cinn/auto_schedule/measure/schedule_measurer.h
+++ b/cinn/auto_schedule/measure/schedule_measurer.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "cinn/auto_schedule/measure/measure.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+// This class performs schedule measurement, it mainly includes two processes,
+// which are building the input schedules and running the generated codes.
+class ScheduleMeasurer {
+ public:
+  ScheduleMeasurer(ScheduleBuilder* builder, ScheduleRunner* runner);
+
+  // Measure a batch of inputs and return all results once.
+  std::vector<MeasureResult> Measure(const std::vector<MeasureInput>& inputs);
+
+ private:
+  // The handle to implemented ScheduleBuilder
+  ScheduleBuilder* builder_;
+  // The handle to implemented ScheduleRunner
+  ScheduleRunner* runner_;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/simple_builder.cc
+++ b/cinn/auto_schedule/measure/simple_builder.cc
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/measure/simple_builder.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+SimpleBuilder::SimpleBuilder(hlir::framework::GraphCompiler* graph_compiler) : graph_compiler_(graph_compiler) {}
+
+BuildResult SimpleBuilder::Build(const MeasureInput& input) {
+  BuildResult result;
+  return result;
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/simple_builder.h
+++ b/cinn/auto_schedule/measure/simple_builder.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/auto_schedule/measure/measure.h"
+#include "cinn/hlir/framework/graph_compiler.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+// This class utilize the GraphCompiler bound to the graph to build
+// the input schedule as executable objects
+class SimpleBuilder : public ScheduleBuilder {
+ public:
+  SimpleBuilder(hlir::framework::GraphCompiler* graph_compiler);
+
+  // Build and pack the result
+  BuildResult Build(const MeasureInput& input) override;
+
+ private:
+  hlir::framework::GraphCompiler* graph_compiler_;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/simple_runner.cc
+++ b/cinn/auto_schedule/measure/simple_runner.cc
@@ -1,0 +1,173 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/measure/simple_runner.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <random>
+
+#include "cinn/common/target.h"
+#include "cinn/hlir/framework/buffer.h"
+#include "cinn/hlir/framework/scope.h"
+#include "cinn/hlir/framework/tensor.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+using hlir::framework::Buffer;
+using hlir::framework::Shape;
+using hlir::framework::Tensor;
+
+// Generate random value and populate them to the output address of memeory
+static void PopulateRandomValue(const common::Type& type, const int numel, void* raw_ptr) {
+  std::random_device seed;
+  std::default_random_engine engine(seed());
+
+  if (type == common::Bool()) {
+    auto* fmt_ptr = reinterpret_cast<bool*>(raw_ptr);
+    std::bernoulli_distribution dist(0.5);
+    std::generate_n(fmt_ptr, numel, [&engine, &dist]() { return dist(engine); });
+  } else if (type == common::I32()) {
+    auto* fmt_ptr = reinterpret_cast<int*>(raw_ptr);
+    std::uniform_int_distribution<int> dist(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    std::generate_n(fmt_ptr, numel, [&engine, &dist]() { return dist(engine); });
+  } else if (type == common::F32()) {
+    auto* fmt_ptr = reinterpret_cast<float*>(raw_ptr);
+    std::uniform_real_distribution<float> dist(std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
+    std::generate_n(fmt_ptr, numel, [&engine, &dist]() { return dist(engine); });
+  } else {
+    LOG(FATAL) << "Unsupported type:" << type;
+  }
+}
+
+// Alloc a new buffer in specificed target with initial infos.
+static std::shared_ptr<Buffer> AllocBuffer(const common::Target& target,
+                                           const common::Type& type,
+                                           const Shape& shape,
+                                           bool fill_random_value = true) {
+  static constexpr int default_alignment = 1024;
+  auto buffer                            = std::make_shared<Buffer>(target);
+
+  const uint32_t bytes_of_ele = static_cast<uint32_t>(std::floor(static_cast<float>(type.bits() + 1) / 8.0));
+  CHECK_GT(bytes_of_ele, 0) << "The number bytes of each element is invalid";
+
+  if (target == common::DefaultHostTarget()) {
+    buffer->ResizeLazy(default_alignment, shape.numel() * bytes_of_ele);
+  } else {
+    buffer->ResizeLazy(shape.numel() * bytes_of_ele);
+  }
+
+  if (fill_random_value) {
+    PopulateRandomValue(type, shape.numel(), buffer->data()->memory);
+  }
+  return buffer;
+}
+
+SimpleRunner::SimpleRunner(int repeat_times) : repeat_times_(repeat_times) {
+  CHECK_GT(repeat_times_, 0) << "repeat_times can't less than 0";
+}
+
+// Prepare execution arguments of all instructions to run, a argument
+// may be obtained from the input of measurement or allocating new buffer
+// with random value.
+std::map<std::string, cinn_pod_value_t> SimpleRunner::PrepareArgs(const MeasureInput& input,
+                                                                  const BuildResult& build_result,
+                                                                  hlir::framework::Scope* temp_scope) {
+  std::map<std::string, cinn_pod_value_t> result;
+
+  const auto& target         = input.task->tune_context().target;
+  const auto* input_args     = input.execution_args;
+  const auto* compiled_scope = build_result.compiled_scope;
+  auto&& instructions        = build_result.instructions;
+
+  auto fill_arg_fn = [&](const std::string& param) {
+    // the argument is duplicated and has been prepared.
+    if (result.count(param)) {
+      return;
+    }
+
+    // if the input of measurement specifies this argument,
+    // we should use it firstly.
+    if (input_args && input_args->count(param)) {
+      VLOG(6) << "Argument[" << param << "] use input value";
+      result.emplace(param, input_args->at(param));
+      return;
+    }
+
+    if (temp_scope->FindVar(param)) {
+      auto temp_tensor = temp_scope->GetTensor(param);
+      result.emplace(param, temp_tensor->buffer());
+      return;
+    }
+
+    // allocate a new buffer for this argument and store it in
+    // the temporary scope to be released at proper time.
+    auto compiled_tensor = compiled_scope->GetTensor(param);
+    auto buffer          = AllocBuffer(target, compiled_tensor->type(), compiled_tensor->shape());
+    temp_scope->Var<Tensor>(param);
+    auto temp_tensor = temp_scope->GetTensor(param);
+    temp_tensor->set_buffer(buffer);
+    result.emplace(param, temp_tensor->buffer());
+  };
+
+  for (auto&& instr : instructions) {
+    for (auto&& args : instr->GetInArgs()) {
+      std::for_each(args.begin(), args.end(), fill_arg_fn);
+    }
+
+    for (auto&& args : instr->GetOutArgs()) {
+      std::for_each(args.begin(), args.end(), fill_arg_fn);
+    }
+  }
+  return result;
+}
+
+MeasureResult SimpleRunner::Run(const MeasureInput& input, const BuildResult& build_result) {
+  MeasureResult result;
+  auto t_start = std::chrono::steady_clock::now();
+  // prepare execution arguments
+  VLOG(4) << "SimpleRunner prepare execution arguments";
+  hlir::framework::Scope temp_scope;  // used for store temporary allocated data
+  auto execution_args = PrepareArgs(input, build_result, &temp_scope);
+
+  // Execute each instruction repeatedly and take the average as cost.
+  result.execution_cost = 0;
+  auto&& instructions   = build_result.instructions;
+  for (auto ct = 0; ct < instructions.size(); ++ct) {
+    auto&& instr = instructions.at(ct);
+    VLOG(5) << "Start running instruction-" << ct;
+    auto run_start = std::chrono::steady_clock::now();
+    for (int i = 0; i < repeat_times_; ++i) {
+      instr->Run(&execution_args);
+    }
+    auto time_span =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - run_start);
+    auto cost_avg = static_cast<double>(time_span.count()) / repeat_times_;
+    result.execution_cost += cost_avg;
+  }
+
+  auto time_span = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t_start);
+  result.elapsed_time = static_cast<double>(time_span.count());
+
+  VLOG(4) << "A measurement done:repeat_times[" << repeat_times_ << "]total_elapsed_time[" << result.elapsed_time
+          << "]us,execution_cost[" << result.execution_cost << "]us";
+  return result;
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/measure/simple_runner.h
+++ b/cinn/auto_schedule/measure/simple_runner.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/auto_schedule/measure/measure.h"
+#include "cinn/hlir/framework/instruction.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+// This class utilize the built instructions to execute the generated
+// kernels and count the elapsed time as the measurement of performance
+class SimpleRunner : public ScheduleRunner {
+ public:
+  SimpleRunner(int repeat_times);
+
+  MeasureResult Run(const MeasureInput& input, const BuildResult& build_result) override;
+
+ private:
+  std::map<std::string, cinn_pod_value_t> PrepareArgs(const MeasureInput& input,
+                                                      const BuildResult& build_result,
+                                                      hlir::framework::Scope* temp_scope);
+
+ private:
+  // The repeat times of running instructions,
+  // this runner will return the average time
+  const int repeat_times_;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn


### PR DESCRIPTION
1. `ScheduleMeasurer`: Entrance of schedule measurement, it mainly includes two processes, building the input schedules and running the generated codes.
2. `ScheduleBuilder`:  This base class defines how to generate executable objects with input schedule. Now a simple derived class is implemented that will just call `GraphCompiler::Build` to finish building and I will complete it after updating the function.
3. `ScheduleRunner`:  This base class defines how to run the built result. Now a simple derived class is implemented that wrap `Instruction::Run` with necessary arguments preparation and running timers.
4. add basic tests for `SimpleRunner` and `ScheduleMeasurer`