### PR TITLE
show bug of elementwise when shape is [10201, 50]

### DIFF
--- a/cinn/frontend/op_mappers/science/transform.cc
+++ b/cinn/frontend/op_mappers/science/transform.cc
@@ -151,7 +151,7 @@ void SliceSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
 
   auto x = ctx.GetVar(x_name);
 
-  VLOG(4) << "Slice " << x_name << "from shape (" << cinn::utils::Join(x->shape, ",") << ") with starts ["
+  VLOG(4) << "SliceSelect " << x_name << " from shape (" << cinn::utils::Join(x->shape, ",") << ") with starts ["
           << cinn::utils::Join(starts, ",") << "], ends [" << cinn::utils::Join(ends, ",") << "], axis ["
           << cinn::utils::Join(axes, ",") << "], strides [" << cinn::utils::Join(strides, ",") << "].";
 
@@ -181,7 +181,7 @@ void SliceAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   auto x      = ctx.GetVar(x_name);
   auto assign = ctx.GetVar(y_name);
 
-  VLOG(4) << "SliceAssign " << x_name << "from shape (" << cinn::utils::Join(x->shape, ",") << ") with starts ["
+  VLOG(4) << "SliceAssign " << x_name << " from shape (" << cinn::utils::Join(x->shape, ",") << ") with starts ["
           << cinn::utils::Join(starts, ",") << "], ends [" << cinn::utils::Join(ends, ",") << "], axis ["
           << cinn::utils::Join(axes, ",") << "], strides [" << cinn::utils::Join(strides, ",") << "].";
 

--- a/cinn/hlir/pe/schedule.cc
+++ b/cinn/hlir/pe/schedule.cc
@@ -2028,7 +2028,7 @@ void CudaScheduleInjective(poly::Stage *stage, const std::vector<int> &output_sh
   }
 
   int num_thread        = target.max_num_threads();
-  int num_block         = 256;
+  int num_block         = 1024;
   int vector_width      = 1;
   int prod_size         = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int>());
   bool need_block_split = prod_size > num_thread * num_block * vector_width ? true : false;

--- a/python/tests/ops/test_sqrt_op.py
+++ b/python/tests/ops/test_sqrt_op.py
@@ -28,10 +28,6 @@ from cinn.common import *
 class TestSqrtOp(OpTest):
     def setUp(self):
         self.init_case()
-        # failed if
-        # self.target = DefaultNVGPUTarget()
-        # correct if
-        # self.target = DefaultHostTarget()
 
     def init_case(self):
         self.inputs = {

--- a/python/tests/ops/test_sqrt_op.py
+++ b/python/tests/ops/test_sqrt_op.py
@@ -28,6 +28,10 @@ from cinn.common import *
 class TestSqrtOp(OpTest):
     def setUp(self):
         self.init_case()
+        # failed if
+        # self.target = DefaultNVGPUTarget()
+        # correct if
+        # self.target = DefaultHostTarget()
 
     def init_case(self):
         self.inputs = {
@@ -58,6 +62,11 @@ class TestSqrtOp(OpTest):
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestSqrtCase1(TestSqrtOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10201, 50]).astype("float32")}
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_tanh_op.py
+++ b/python/tests/ops/test_tanh_op.py
@@ -28,6 +28,10 @@ from cinn.common import *
 class TestTanhOp(OpTest):
     def setUp(self):
         self.init_case()
+        # failed if
+        self.target = DefaultNVGPUTarget()
+        # correct if
+        # self.target = DefaultHostTarget()
 
     def init_case(self):
         self.inputs = {
@@ -58,6 +62,11 @@ class TestTanhOp(OpTest):
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestTanhCase1(TestTanhOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10201, 50]).astype("float32")}
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_tanh_op.py
+++ b/python/tests/ops/test_tanh_op.py
@@ -28,10 +28,6 @@ from cinn.common import *
 class TestTanhOp(OpTest):
     def setUp(self):
         self.init_case()
-        # failed if
-        self.target = DefaultNVGPUTarget()
-        # correct if
-        # self.target = DefaultHostTarget()
 
     def init_case(self):
         self.inputs = {


### PR DESCRIPTION
For `tanh` and `sqrt` or other elementwise op, when shape is [10201, 50]:

- The result wrong when `target = DefaultNVGPUTarget()`, and the error index is from 262144 to 262149.
- The result correct when `target = DefaultHostTarget()`

After further testing, the generated source code error:
![image](https://user-images.githubusercontent.com/31386411/161881477-2d976a1a-322e-4858-93fb-c33c489b752c.png)

Moreover,  the result will be corrected when we change the `num_block` from **256** to **1024** in `CudaScheduleInjective`.

![image](https://user-images.githubusercontent.com/31386411/161881164-43aa00fd-446d-4861-84a4-fc4a82f5f52b.png)
