### PR TITLE
Use cublas gemm instead of matmul.

### DIFF
--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -14,6 +14,8 @@
 
 #include "cinn/hlir/framework/graph_compiler.h"
 
+#include <absl/container/flat_hash_map.h>
+
 #include <memory>
 #include <unordered_set>
 
@@ -744,6 +746,36 @@ void GraphCompiler::SetSubKernels(Instruction* instr, const std::string& func_na
   }
 }
 
+void GraphCompiler::BuildCublasInstr(const Node& node, Instruction* instr) const {
+  auto& shape_dict = graph_->GetAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+  std::vector<int> input_sizes;
+  // input info
+  input_sizes.reserve(node.inlinks_in_order().size());
+  for (auto& in_node : node.inlinks_in_order()) {
+    std::string in_id = in_node->source()->safe_as<NodeData>()->id();
+    auto in_shape     = shape_dict.at(in_id);
+    instr->attrs.insert(instr->attrs.end(), in_shape.begin(), in_shape.end());
+    input_sizes.push_back(in_shape.size());
+  }
+  instr->attrs.insert(instr->attrs.end(), input_sizes.begin(), input_sizes.end());
+  // attribute info
+  bool trans_a = false;
+  if (node.attrs.attr_store.contains("trans_a")) {
+    trans_a = absl::get<bool>(node.attrs.attr_store.at("trans_a"));
+  }
+  instr->attrs.push_back(static_cast<int>(trans_a));
+  bool trans_b = false;
+  if (node.attrs.attr_store.contains("trans_b")) {
+    trans_b = absl::get<bool>(node.attrs.attr_store.at("trans_b"));
+  }
+  instr->attrs.push_back(static_cast<int>(trans_b));
+  float alpha = 1.f;
+  if (node.attrs.attr_store.contains("alpha")) {
+    alpha = absl::get<float>(node.attrs.attr_store.at("alpha"));
+  }
+  instr->attrs.push_back(*reinterpret_cast<int*>(&alpha));
+}
+
 std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
     const std::vector<std::vector<Node*>>& groups) {
   std::vector<std::unique_ptr<Instruction>> instructions;
@@ -902,54 +934,8 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
           } else {
             instr->attrs.push_back(1);
           }
-        } else if (node->op()->name == "cublas_gemm") {
-          auto& shape_dict = graph_->GetAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
-          std::vector<int> input_sizes;
-          input_sizes.reserve(node->inlinks_in_order().size());
-          for (auto& in_node : node->inlinks_in_order()) {
-            std::string in_id = in_node->source()->safe_as<NodeData>()->id();
-            auto in_shape     = shape_dict.at(in_id);
-            instr->attrs.insert(instr->attrs.end(), in_shape.begin(), in_shape.end());
-            input_sizes.push_back(in_shape.size());
-          }
-          instr->attrs.insert(instr->attrs.end(), input_sizes.begin(), input_sizes.end());
-          CHECK(node->attrs.attr_store.contains("trans_a"));
-          CHECK(node->attrs.attr_store.contains("trans_b"));
-          CHECK(node->attrs.attr_store.contains("alpha"));
-          bool trans_a = absl::get<bool>(node->attrs.attr_store.at("trans_a"));
-          instr->attrs.push_back(static_cast<int>(trans_a));
-          bool trans_b = absl::get<bool>(node->attrs.attr_store.at("trans_b"));
-          instr->attrs.push_back(static_cast<int>(trans_b));
-          float alpha = absl::get<float>(node->attrs.attr_store.at("alpha"));
-          instr->attrs.push_back(*reinterpret_cast<int*>(&alpha));
-        } else if (node->op()->name == "cublas_matmul") {
-          auto& shape_dict = graph_->GetAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
-          std::vector<int> input_sizes;
-          // input info
-          input_sizes.reserve(node->inlinks_in_order().size());
-          for (auto& in_node : node->inlinks_in_order()) {
-            std::string in_id = in_node->source()->safe_as<NodeData>()->id();
-            auto in_shape     = shape_dict.at(in_id);
-            instr->attrs.insert(instr->attrs.end(), in_shape.begin(), in_shape.end());
-            input_sizes.push_back(in_shape.size());
-          }
-          instr->attrs.insert(instr->attrs.end(), input_sizes.begin(), input_sizes.end());
-          // attribute info
-          bool trans_a = false;
-          if (node->attrs.attr_store.contains("trans_a")) {
-            trans_a = absl::get<bool>(node->attrs.attr_store.at("trans_a"));
-          }
-          instr->attrs.push_back(static_cast<int>(trans_a));
-          bool trans_b = false;
-          if (node->attrs.attr_store.contains("trans_b")) {
-            trans_b = absl::get<bool>(node->attrs.attr_store.at("trans_b"));
-          }
-          instr->attrs.push_back(static_cast<int>(trans_b));
-          float alpha = 1.f;
-          if (node->attrs.attr_store.contains("alpha")) {
-            alpha = absl::get<float>(node->attrs.attr_store.at("alpha"));
-          }
-          instr->attrs.push_back(*reinterpret_cast<int*>(&alpha));
+        } else if (node->op()->name == "cublas_gemm" || node->op()->name == "cublas_matmul") {
+          BuildCublasInstr(*node, instr.get());
         }
       }
       std::string op_func_name = GetOrGenFullFuncName(GenOpFuncName(node));

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -919,6 +919,29 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
           instr->attrs.push_back(static_cast<int>(trans_a));
           bool trans_b = absl::get<bool>(node->attrs.attr_store.at("trans_b"));
           instr->attrs.push_back(static_cast<int>(trans_b));
+        } else if (node->op()->name == "matmul") {
+          auto& shape_dict = graph_->GetAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+          std::vector<int> input_sizes;
+          // input info
+          input_sizes.reserve(node->inlinks_in_order().size());
+          for (auto& in_node : node->inlinks_in_order()) {
+            std::string in_id = in_node->source()->safe_as<NodeData>()->id();
+            auto in_shape     = shape_dict.at(in_id);
+            instr->attrs.insert(instr->attrs.end(), in_shape.begin(), in_shape.end());
+            input_sizes.push_back(in_shape.size());
+          }
+          instr->attrs.insert(instr->attrs.end(), input_sizes.begin(), input_sizes.end());
+          // transpose info
+          bool trans_a = false;
+          if (node->attrs.attr_store.contains("trans_a")) {
+            trans_a = absl::get<bool>(node->attrs.attr_store.at("trans_a"));
+          }
+          instr->attrs.push_back(static_cast<int>(trans_a));
+          bool trans_b = false;
+          if (node->attrs.attr_store.contains("trans_b")) {
+            trans_b = absl::get<bool>(node->attrs.attr_store.at("trans_b"));
+          }
+          instr->attrs.push_back(static_cast<int>(trans_b));
         }
       }
       std::string op_func_name = GetOrGenFullFuncName(GenOpFuncName(node));

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -144,6 +144,9 @@ class GraphCompiler final {
   // TODO(haozech) add implementation
   std::vector<std::string> OpGetOutputNames(const Node* node) const;
 
+  // Build an instruction used to call the cublas gemm
+  void BuildCublasInstr(const Node& node, Instruction* instr) const;
+
   std::vector<std::unique_ptr<Instruction>> BuildInstructions(const std::vector<std::vector<Node*>>& groups);
 
   // some variables are eliminated by optimized passes(such as OpFusion),

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -88,7 +88,7 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
     VLOG(3) << "The pod_args size of cublas_gemm: " << pod_args.size();
     runtime::cuda::cinn_gpu_cublas_gemm(
         attrs, pod_args[0], pod_args[1], pod_args[2], pod_args[3], static_cast<cudaStream_t>(stream));
-  } else if (function_name_ == "matmul" && target_.arch == Target::Arch::NVGPU) {
+  } else if (function_name_ == "cublas_matmul" && target_.arch == Target::Arch::NVGPU) {
     auto& pod_args = PreparePodArgs(0, name2podargs);
     VLOG(3) << "The pod_args size of cublas_matmul: " << pod_args.size();
     runtime::cuda::cinn_gpu_cublas_matmul(
@@ -157,7 +157,7 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
     VLOG(3) << "The pod_args size of cublas_gemm: " << pod_args.size();
     runtime::cuda::cinn_gpu_cublas_gemm(
         attrs, pod_args[0], pod_args[1], pod_args[2], pod_args[3], static_cast<cudaStream_t>(stream));
-  } else if (function_name_ == "matmul" && target_.arch == Target::Arch::NVGPU) {
+  } else if (function_name_ == "cublas_matmul" && target_.arch == Target::Arch::NVGPU) {
     auto& pod_args = PreparePodArgs(0, name2podargs);
     VLOG(3) << "The pod_args size of cublas_matmul: " << pod_args.size();
     runtime::cuda::cinn_gpu_cublas_matmul(

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -88,6 +88,11 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
     VLOG(3) << "The pod_args size of cublas_gemm: " << pod_args.size();
     runtime::cuda::cinn_gpu_cublas_gemm(
         attrs, pod_args[0], pod_args[1], pod_args[2], pod_args[3], static_cast<cudaStream_t>(stream));
+  } else if (function_name_ == "matmul" && target_.arch == Target::Arch::NVGPU) {
+    auto& pod_args = PreparePodArgs(0, name2podargs);
+    VLOG(3) << "The pod_args size of cublas_matmul: " << pod_args.size();
+    runtime::cuda::cinn_gpu_cublas_matmul(
+        attrs, pod_args[0], pod_args[1], pod_args[2], static_cast<cudaStream_t>(stream));
   } else {
     int i = 0;
     VLOG(2) << "Runing extern function " << function_name_;
@@ -145,13 +150,18 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
   } else if (function_name_ == "softmax" && target_.arch == Target::Arch::NVGPU) {
     CHECK_EQ(pod_args.size(), 3);
     runtime::cuda::cinn_gpu_cudnn_softmax(attrs, pod_args[0], pod_args[1], static_cast<cudaStream_t>(stream));
+  } else if (function_name_ == "mul" && target_.arch == Target::Arch::NVGPU) {
+    CHECK_EQ(pod_args.size(), 4);
+    runtime::cuda::cinn_gpu_cublas_mul(attrs, pod_args[0], pod_args[1], pod_args[2], static_cast<cudaStream_t>(stream));
   } else if (function_name_ == "cublas_gemm" && target_.arch == Target::Arch::NVGPU) {
     VLOG(3) << "The pod_args size of cublas_gemm: " << pod_args.size();
     runtime::cuda::cinn_gpu_cublas_gemm(
         attrs, pod_args[0], pod_args[1], pod_args[2], pod_args[3], static_cast<cudaStream_t>(stream));
-  } else if (function_name_ == "mul" && target_.arch == Target::Arch::NVGPU) {
-    CHECK_EQ(pod_args.size(), 4);
-    runtime::cuda::cinn_gpu_cublas_mul(attrs, pod_args[0], pod_args[1], pod_args[2], static_cast<cudaStream_t>(stream));
+  } else if (function_name_ == "matmul" && target_.arch == Target::Arch::NVGPU) {
+    auto& pod_args = PreparePodArgs(0, name2podargs);
+    VLOG(3) << "The pod_args size of cublas_matmul: " << pod_args.size();
+    runtime::cuda::cinn_gpu_cublas_matmul(
+        attrs, pod_args[0], pod_args[1], pod_args[2], static_cast<cudaStream_t>(stream));
   } else {
     int i = 0;
     VLOG(2) << "Runing extern function " << function_name_;

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -2002,6 +2002,16 @@ CINN_REGISTER_HELPER(transform_ops) {
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForCublasGemm))
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
       .set_support_level(4);
+
+  CINN_REGISTER_OP(cublas_matmul)
+      .describe("This operator uses cublas to compute the matmul.")
+      .set_num_inputs(2)
+      .set_num_outputs(2)
+      .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForMatMul)
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForMatMul))
+      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForMatMul))
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOpaque)
+      .set_support_level(4);
 #endif
 
   CINN_REGISTER_OP(layout_transform)

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -208,11 +208,13 @@ void cinn_gpu_cublas_matmul(const std::vector<int> &attrs,
   const float *rhs_data = reinterpret_cast<const float *>(rhs->memory);
   float *output_data    = reinterpret_cast<float *>(output->memory);
 
-  CHECK_GE(attrs.size(), 8);
-  int lhs_dim_size = attrs[attrs.size() - 4];
-  int rhs_dim_size = attrs[attrs.size() - 3];
-  bool lhs_trans   = static_cast<bool>(attrs[attrs.size() - 2]);
-  bool rhs_trans   = static_cast<bool>(attrs[attrs.size() - 1]);
+  CHECK_GE(attrs.size(), 9);
+  int lhs_dim_size  = attrs[attrs.size() - 5];
+  int rhs_dim_size  = attrs[attrs.size() - 4];
+  bool lhs_trans    = static_cast<bool>(attrs[attrs.size() - 3]);
+  bool rhs_trans    = static_cast<bool>(attrs[attrs.size() - 2]);
+  const float alpha = *reinterpret_cast<const float *>(&attrs[attrs.size() - 1]);
+  VLOG(4) << "The alpha value used by cublas_matmul: " << alpha;
   CHECK_EQ(lhs_dim_size, rhs_dim_size);
   CHECK((lhs_dim_size == 2 || lhs_dim_size == 3));
 
@@ -226,7 +228,7 @@ void cinn_gpu_cublas_matmul(const std::vector<int> &attrs,
     details::Gemm(cublas,
                   lhs_trans,
                   rhs_trans,
-                  1.f,
+                  alpha,
                   lhs_data,
                   lhs_row,
                   lhs_col,
@@ -252,7 +254,7 @@ void cinn_gpu_cublas_matmul(const std::vector<int> &attrs,
     details::GemmStridedBatched(cublas,
                                 lhs_trans,
                                 rhs_trans,
-                                1.f,
+                                alpha,
                                 lhs_data,
                                 lhs_bs,
                                 lhs_row,
@@ -285,12 +287,14 @@ void cinn_gpu_cublas_gemm(const std::vector<int> &attrs,
   const float *bias_data = reinterpret_cast<const float *>(bias->memory);
   float *output_data     = reinterpret_cast<float *>(output->memory);
 
-  CHECK_GE(attrs.size(), 11);
-  int lhs_dim_size  = attrs[attrs.size() - 5];
-  int rhs_dim_size  = attrs[attrs.size() - 4];
-  int bias_dim_size = attrs[attrs.size() - 3];
-  bool lhs_trans    = static_cast<bool>(attrs[attrs.size() - 2]);
-  bool rhs_trans    = static_cast<bool>(attrs[attrs.size() - 1]);
+  CHECK_GE(attrs.size(), 12);
+  int lhs_dim_size  = attrs[attrs.size() - 6];
+  int rhs_dim_size  = attrs[attrs.size() - 5];
+  int bias_dim_size = attrs[attrs.size() - 4];
+  bool lhs_trans    = static_cast<bool>(attrs[attrs.size() - 3]);
+  bool rhs_trans    = static_cast<bool>(attrs[attrs.size() - 2]);
+  const float alpha = *reinterpret_cast<const float *>(&attrs[attrs.size() - 1]);
+  VLOG(4) << "The alpha value used by cublas_gemm: " << alpha;
   CHECK_EQ(lhs_dim_size, rhs_dim_size);
   CHECK_EQ(lhs_dim_size, bias_dim_size);
   CHECK((lhs_dim_size == 2 || lhs_dim_size == 3));
@@ -305,7 +309,7 @@ void cinn_gpu_cublas_gemm(const std::vector<int> &attrs,
     details::Gemm(cublas,
                   lhs_trans,
                   rhs_trans,
-                  1.f,
+                  alpha,
                   lhs_data,
                   lhs_row,
                   lhs_col,
@@ -331,7 +335,7 @@ void cinn_gpu_cublas_gemm(const std::vector<int> &attrs,
     details::GemmStridedBatched(cublas,
                                 lhs_trans,
                                 rhs_trans,
-                                1.f,
+                                alpha,
                                 lhs_data,
                                 lhs_bs,
                                 lhs_row,

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -34,25 +34,24 @@ namespace details {
 void Gemm(const cublasHandle_t &cublas,
           bool lhs_trans,
           bool rhs_trans,
+          const float alpha,
           const float *lhs_data,
+          int lhs_row,
+          int lhs_col,
           const float *rhs_data,
+          int rhs_row,
+          int rhs_col,
           const float *bias_data,
+          const float beta,
           float *output_data,
-          const std::vector<int> &attrs,
+          int output_row,
+          int output_col,
           const cudaStream_t &stream) {
-  CHECK_EQ(attrs.size(), 11);
-  int lhs_row    = attrs[0];
-  int lhs_col    = attrs[1];
-  int rhs_row    = attrs[2];
-  int rhs_col    = attrs[3];
-  int output_row = attrs[4];
-  int output_col = attrs[5];
-
   // copy values of bias_data to the output_data
-  cudaMemcpyAsync(output_data, bias_data, output_row * output_col * sizeof(float), cudaMemcpyDeviceToDevice, stream);
+  if (bias_data != nullptr) {
+    cudaMemcpyAsync(output_data, bias_data, output_row * output_col * sizeof(float), cudaMemcpyDeviceToDevice, stream);
+  }
 
-  float alpha          = 1.f;
-  float beta           = 1.f;
   int contracting_size = lhs_trans ? lhs_row : lhs_col;
   CHECK_EQ(contracting_size, (rhs_trans ? rhs_col : rhs_row))
       << "The contracting dimension value of lhs matrix should be equal to the one of rhs matrix.";
@@ -77,31 +76,31 @@ void Gemm(const cublasHandle_t &cublas,
 void GemmStridedBatched(const cublasHandle_t &cublas,
                         bool lhs_trans,
                         bool rhs_trans,
+                        const float alpha,
                         const float *lhs_data,
+                        int lhs_bs,
+                        int lhs_row,
+                        int lhs_col,
                         const float *rhs_data,
+                        int rhs_bs,
+                        int rhs_row,
+                        int rhs_col,
                         const float *bias_data,
+                        const float beta,
                         float *output_data,
-                        const std::vector<int> &attrs,
+                        int output_bs,
+                        int output_row,
+                        int output_col,
                         const cudaStream_t &stream) {
-  CHECK_EQ(attrs.size(), 14);
-  int lhs_bs     = attrs[0];
-  int lhs_row    = attrs[1];
-  int lhs_col    = attrs[2];
-  int rhs_bs     = attrs[3];
-  int rhs_row    = attrs[4];
-  int rhs_col    = attrs[5];
-  int output_bs  = attrs[6];
-  int output_row = attrs[7];
-  int output_col = attrs[8];
   CHECK_EQ(lhs_bs, rhs_bs);
   CHECK_EQ(lhs_bs, output_bs);
 
   // copy values of bias_data to the output_data
-  cudaMemcpyAsync(
-      output_data, bias_data, output_bs * output_row * output_col * sizeof(float), cudaMemcpyDeviceToDevice, stream);
+  if (bias_data != nullptr) {
+    cudaMemcpyAsync(
+        output_data, bias_data, output_bs * output_row * output_col * sizeof(float), cudaMemcpyDeviceToDevice, stream);
+  }
 
-  float alpha          = 1.f;
-  float beta           = 1.f;
   int contracting_size = lhs_trans ? lhs_row : lhs_col;
   CHECK_EQ(contracting_size, (rhs_trans ? rhs_col : rhs_row))
       << "The contracting dimension value of lhs matrix should be equal to the one of rhs matrix.";
@@ -197,6 +196,81 @@ void cinn_gpu_cublas_mul(const std::vector<int> &attrs,
   cublasSgemm(cublas, CUBLAS_OP_N, CUBLAS_OP_N, K, M, N, &alpha, y_data, K, x_data, N, &beta, out_data, K);
 }
 
+void cinn_gpu_cublas_matmul(const std::vector<int> &attrs,
+                            cinn_buffer_t *lhs,
+                            cinn_buffer_t *rhs,
+                            cinn_buffer_t *output,
+                            const cudaStream_t &stream) {
+  cublasHandle_t &cublas = CublasHandle::get_instance().GetCublasHandle();
+  cublasSetStream(cublas, stream);
+
+  const float *lhs_data = reinterpret_cast<const float *>(lhs->memory);
+  const float *rhs_data = reinterpret_cast<const float *>(rhs->memory);
+  float *output_data    = reinterpret_cast<float *>(output->memory);
+
+  CHECK_GE(attrs.size(), 8);
+  int lhs_dim_size = attrs[attrs.size() - 4];
+  int rhs_dim_size = attrs[attrs.size() - 3];
+  bool lhs_trans   = static_cast<bool>(attrs[attrs.size() - 2]);
+  bool rhs_trans   = static_cast<bool>(attrs[attrs.size() - 1]);
+  CHECK_EQ(lhs_dim_size, rhs_dim_size);
+  CHECK((lhs_dim_size == 2 || lhs_dim_size == 3));
+
+  if (lhs_dim_size == 2) {
+    int lhs_row    = attrs[0];
+    int lhs_col    = attrs[1];
+    int rhs_row    = attrs[2];
+    int rhs_col    = attrs[3];
+    int output_row = lhs_trans ? lhs_col : lhs_row;
+    int output_col = rhs_trans ? rhs_row : rhs_col;
+    details::Gemm(cublas,
+                  lhs_trans,
+                  rhs_trans,
+                  1.f,
+                  lhs_data,
+                  lhs_row,
+                  lhs_col,
+                  rhs_data,
+                  rhs_row,
+                  rhs_col,
+                  nullptr,
+                  0.f,
+                  output_data,
+                  output_row,
+                  output_col,
+                  stream);
+  } else {
+    int lhs_bs     = attrs[0];
+    int lhs_row    = attrs[1];
+    int lhs_col    = attrs[2];
+    int rhs_bs     = attrs[3];
+    int rhs_row    = attrs[4];
+    int rhs_col    = attrs[5];
+    int output_bs  = lhs_bs;
+    int output_row = lhs_trans ? lhs_col : lhs_row;
+    int output_col = rhs_trans ? rhs_row : rhs_col;
+    details::GemmStridedBatched(cublas,
+                                lhs_trans,
+                                rhs_trans,
+                                1.f,
+                                lhs_data,
+                                lhs_bs,
+                                lhs_row,
+                                lhs_col,
+                                rhs_data,
+                                rhs_bs,
+                                rhs_row,
+                                rhs_col,
+                                nullptr,
+                                0.f,
+                                output_data,
+                                output_bs,
+                                output_row,
+                                output_col,
+                                stream);
+  }
+}
+
 void cinn_gpu_cublas_gemm(const std::vector<int> &attrs,
                           cinn_buffer_t *lhs,
                           cinn_buffer_t *rhs,
@@ -222,10 +296,57 @@ void cinn_gpu_cublas_gemm(const std::vector<int> &attrs,
   CHECK((lhs_dim_size == 2 || lhs_dim_size == 3));
 
   if (lhs_dim_size == 2) {
-    details::Gemm(cublas, lhs_trans, rhs_trans, lhs_data, rhs_data, bias_data, output_data, attrs, stream);
+    int lhs_row    = attrs[0];
+    int lhs_col    = attrs[1];
+    int rhs_row    = attrs[2];
+    int rhs_col    = attrs[3];
+    int output_row = attrs[4];
+    int output_col = attrs[5];
+    details::Gemm(cublas,
+                  lhs_trans,
+                  rhs_trans,
+                  1.f,
+                  lhs_data,
+                  lhs_row,
+                  lhs_col,
+                  rhs_data,
+                  rhs_row,
+                  rhs_col,
+                  bias_data,
+                  1.f,
+                  output_data,
+                  output_row,
+                  output_col,
+                  stream);
   } else {
-    details::GemmStridedBatched(
-        cublas, lhs_trans, rhs_trans, lhs_data, rhs_data, bias_data, output_data, attrs, stream);
+    int lhs_bs     = attrs[0];
+    int lhs_row    = attrs[1];
+    int lhs_col    = attrs[2];
+    int rhs_bs     = attrs[3];
+    int rhs_row    = attrs[4];
+    int rhs_col    = attrs[5];
+    int output_bs  = attrs[6];
+    int output_row = attrs[7];
+    int output_col = attrs[8];
+    details::GemmStridedBatched(cublas,
+                                lhs_trans,
+                                rhs_trans,
+                                1.f,
+                                lhs_data,
+                                lhs_bs,
+                                lhs_row,
+                                lhs_col,
+                                rhs_data,
+                                rhs_bs,
+                                rhs_row,
+                                rhs_col,
+                                bias_data,
+                                1.f,
+                                output_data,
+                                output_bs,
+                                output_row,
+                                output_col,
+                                stream);
   }
 }
 

--- a/cinn/runtime/cuda/cuda_util.h
+++ b/cinn/runtime/cuda/cuda_util.h
@@ -84,6 +84,13 @@ void cinn_gpu_cublas_mul(const std::vector<int>& attrs,
                          cinn_buffer_t* input2,
                          cinn_buffer_t* output,
                          const cudaStream_t& stream = nullptr);
+
+void cinn_gpu_cublas_matmul(const std::vector<int>& attrs,
+                            cinn_buffer_t* lhs,
+                            cinn_buffer_t* rhs,
+                            cinn_buffer_t* output,
+                            const cudaStream_t& stream = nullptr);
+
 void cinn_gpu_cublas_gemm(const std::vector<int>& attrs,
                           cinn_buffer_t* lhs,
                           cinn_buffer_t* rhs,


### PR DESCRIPTION
Rewrite the single matmul, namely use the cublas call instead. This function is controlled by `GemmRewriterPass`.

| Original | Transformed |
|:---:|:---:|
|transpose+matmul / matmul|cublas_matmul|
|transpose+matmul+add / matmul+add|cublas_gemm|
|![graphviz](https://user-images.githubusercontent.com/17102274/164977342-418ab05c-bdd7-4675-bb91-ad38e1c74ac5.png)|![graphviz (1)](https://user-images.githubusercontent.com/17102274/164977370-d7cb15e5-3cae-4c2f-9f2e-686274bf21ad.png)|