### PR TITLE
rename index_assign to scatter_assign

### DIFF
--- a/cinn/frontend/base_builder.cc
+++ b/cinn/frontend/base_builder.cc
@@ -272,8 +272,8 @@ Variable BaseBuilder::IndexSelect(const Variable& operand, const Variable& index
   return instr.GetOutput(0);
 }
 
-Variable BaseBuilder::ScatterAssign(const Variable& operand, const Variable& assign, const Variable& index, int axis) {
-  Instruction instr("scatter_assign", {operand, assign, index});
+Variable BaseBuilder::ScatterAssign(const Variable& operand, const Variable& updates, const Variable& index, int axis) {
+  Instruction instr("scatter_assign", {operand, updates, index});
   instr.SetAttr("axis", axis);
   InferShape(instr);
   AppendInstruction(instr);

--- a/cinn/frontend/base_builder.cc
+++ b/cinn/frontend/base_builder.cc
@@ -272,8 +272,8 @@ Variable BaseBuilder::IndexSelect(const Variable& operand, const Variable& index
   return instr.GetOutput(0);
 }
 
-Variable BaseBuilder::IndexAssign(const Variable& operand, const Variable& assign, const Variable& index, int axis) {
-  Instruction instr("index_assign", {operand, assign, index});
+Variable BaseBuilder::ScatterAssign(const Variable& operand, const Variable& assign, const Variable& index, int axis) {
+  Instruction instr("scatter_assign", {operand, assign, index});
   instr.SetAttr("axis", axis);
   InferShape(instr);
   AppendInstruction(instr);

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -111,7 +111,7 @@ class BaseBuilder {
 
   Variable IndexSelect(const Variable& operand, const Variable& index, int axis = 0);
 
-  Variable IndexAssign(const Variable& operand, const Variable& assign, const Variable& index, int axis = 0);
+  Variable ScatterAssign(const Variable& operand, const Variable& assign, const Variable& index, int axis = 0);
 
   Variable SliceAssign(const Variable& input,
                        const Variable& assign,

--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -111,7 +111,7 @@ class BaseBuilder {
 
   Variable IndexSelect(const Variable& operand, const Variable& index, int axis = 0);
 
-  Variable ScatterAssign(const Variable& operand, const Variable& assign, const Variable& index, int axis = 0);
+  Variable ScatterAssign(const Variable& operand, const Variable& updates, const Variable& index, int axis = 0);
 
   Variable SliceAssign(const Variable& input,
                        const Variable& assign,

--- a/cinn/frontend/op_mappers/science/transform.cc
+++ b/cinn/frontend/op_mappers/science/transform.cc
@@ -235,7 +235,7 @@ void IndexSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   ctx.AddVarModelToProgram(out_name, out->id);
 }
 
-void IndexAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+void ScatterAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
   CHECK_EQ(op_desc.Input("X").size(), 1UL);
   auto x_name = op_desc.Input("X").front();
   CHECK_EQ(op_desc.Input("Y").size(), 1UL);
@@ -251,9 +251,9 @@ void IndexAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   auto assign = ctx.GetVar(assign_name);
   auto index  = ctx.GetVar(index_name);
 
-  auto out = ctx.Builder()->IndexAssign(x, assign, index, axis);
+  auto out = ctx.Builder()->ScatterAssign(x, assign, index, axis);
 
-  VLOG(4) << "IndexAssign " << assign_name << " (" << cinn::utils::Join(assign->shape, ",") << ") to " << x_name
+  VLOG(4) << "ScatterAssign " << assign_name << " (" << cinn::utils::Join(assign->shape, ",") << ") to " << x_name
           << " shape (" << cinn::utils::Join(x->shape, ",") << ") "
           << "at dimension " << axis;
 
@@ -273,7 +273,7 @@ CINN_REGISTER_HELPER(science_transform) {
   CINN_REGISTER_OP_MAPPER(slice_select_p, cinn::frontend::science_mappers::SliceSelectOpMapper)
   CINN_REGISTER_OP_MAPPER(slice_assign_p, cinn::frontend::science_mappers::SliceAssignOpMapper)
   CINN_REGISTER_OP_MAPPER(index_select_p, cinn::frontend::science_mappers::IndexSelectOpMapper)
-  CINN_REGISTER_OP_MAPPER(index_assign_p, cinn::frontend::science_mappers::IndexAssignOpMapper)
+  CINN_REGISTER_OP_MAPPER(scatter_assign_p, cinn::frontend::science_mappers::ScatterAssignOpMapper)
   CINN_REGISTER_OP_MAPPER(reduce_p, cinn::frontend::science_mappers::ReduceOpMapper)
   return true;
 }

--- a/cinn/frontend/op_mappers/science/transform.cc
+++ b/cinn/frontend/op_mappers/science/transform.cc
@@ -235,11 +235,11 @@ void IndexSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   ctx.AddVarModelToProgram(out_name, out->id);
 }
 
-void ScatterAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+void IndexAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
   CHECK_EQ(op_desc.Input("X").size(), 1UL);
   auto x_name = op_desc.Input("X").front();
   CHECK_EQ(op_desc.Input("Y").size(), 1UL);
-  auto assign_name = op_desc.Input("Y").front();
+  auto updates_name = op_desc.Input("Y").front();
   CHECK_EQ(op_desc.Input("IndexTensor").size(), 1UL);
   auto index_name = op_desc.Input("IndexTensor").front();
   CHECK_EQ(op_desc.Output("Z").size(), 1UL);
@@ -247,13 +247,13 @@ void ScatterAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCon
 
   auto axis = utils::GetAttrOrDefault<int>(op_desc, "axis", 0);
 
-  auto x      = ctx.GetVar(x_name);
-  auto assign = ctx.GetVar(assign_name);
-  auto index  = ctx.GetVar(index_name);
+  auto x       = ctx.GetVar(x_name);
+  auto updates = ctx.GetVar(updates_name);
+  auto index   = ctx.GetVar(index_name);
 
-  auto out = ctx.Builder()->ScatterAssign(x, assign, index, axis);
+  auto out = ctx.Builder()->ScatterAssign(x, updates, index, axis);
 
-  VLOG(4) << "ScatterAssign " << assign_name << " (" << cinn::utils::Join(assign->shape, ",") << ") to " << x_name
+  VLOG(4) << "IndexAssign " << updates_name << " (" << cinn::utils::Join(updates->shape, ",") << ") to " << x_name
           << " shape (" << cinn::utils::Join(x->shape, ",") << ") "
           << "at dimension " << axis;
 
@@ -273,7 +273,7 @@ CINN_REGISTER_HELPER(science_transform) {
   CINN_REGISTER_OP_MAPPER(slice_select_p, cinn::frontend::science_mappers::SliceSelectOpMapper)
   CINN_REGISTER_OP_MAPPER(slice_assign_p, cinn::frontend::science_mappers::SliceAssignOpMapper)
   CINN_REGISTER_OP_MAPPER(index_select_p, cinn::frontend::science_mappers::IndexSelectOpMapper)
-  CINN_REGISTER_OP_MAPPER(scatter_assign_p, cinn::frontend::science_mappers::ScatterAssignOpMapper)
+  CINN_REGISTER_OP_MAPPER(index_assign_p, cinn::frontend::science_mappers::IndexAssignOpMapper)
   CINN_REGISTER_OP_MAPPER(reduce_p, cinn::frontend::science_mappers::ReduceOpMapper)
   return true;
 }

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -1503,17 +1503,17 @@ std::shared_ptr<OpStrategy> StrategyForScatterAssign(const framework::NodeAttr &
     CHECK(expr_input.as_tensor());
     auto tensor_input = expr_input.as_tensor_ref();
 
-    Expr expr_assign = arg_pack[1];
-    CHECK(expr_assign.as_tensor());
-    auto tensor_assign = expr_assign.as_tensor_ref();
+    Expr expr_updates = arg_pack[1];
+    CHECK(expr_updates.as_tensor());
+    auto tensor_updates = expr_updates.as_tensor_ref();
 
     Expr expr_index = arg_pack[2];
     CHECK(expr_index.as_tensor());
     auto tensor_index = expr_index.as_tensor_ref();
 
-    auto stages = CreateStages({tensor_input, tensor_assign, tensor_index});
+    auto stages = CreateStages({tensor_input, tensor_updates, tensor_index});
     auto out =
-        pe::ScatterAssign(tensor_input, tensor_assign, tensor_index, target, axis, UniqName("scatter_assign_output"));
+        pe::ScatterAssign(tensor_input, tensor_updates, tensor_index, target, axis, UniqName("scatter_assign_output"));
 
     std::vector<CINNValue> res;
     stages->InsertLazily(out);

--- a/cinn/hlir/pe/pe_transform_test.cc
+++ b/cinn/hlir/pe/pe_transform_test.cc
@@ -101,7 +101,7 @@ TEST(MatmulPE, MatmulCase1) {
   }
 }
 
-TEST(IndexAssign, IndexAssign) {
+TEST(ScatterAssign, ScatterAssign) {
   int m = 128;
   int n = 32;
   int k = 32;
@@ -118,13 +118,13 @@ TEST(IndexAssign, IndexAssign) {
   auto target = common::DefaultHostTarget();
 #endif
 
-  auto output = hlir::pe::IndexAssign(input.tensor(), assign.tensor(), indexs.tensor(), target, axis);
+  auto output = hlir::pe::ScatterAssign(input.tensor(), assign.tensor(), indexs.tensor(), target, axis);
   auto stages = CreateStages({input, assign, indexs, output});
   auto func   = Lower("fn", stages, {input, assign, indexs, output});
   LOG(INFO) << "func:\n" << func;
 
 #ifdef CINN_WITH_CUDA
-  Module::Builder builder("IndexAssign_Builder", target);
+  Module::Builder builder("ScatterAssign_Builder", target);
   builder.AddFunction(func);
 
   auto module                    = builder.Build();

--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -908,20 +908,20 @@ ir::Tensor IndexSelect(const ir::Tensor& x,
   return output_tensor;
 }
 
-ir::Tensor IndexAssign(const ir::Tensor& input,
-                       const ir::Tensor& assign,
-                       const ir::Tensor& index,
-                       const common::Target& target,
-                       const int axis,
-                       const std::string& output_name) {
-  CHECK_EQ(index->type(), common::Int(32)) << "Param [Index] of IndexAssign only support int32 ! Please Check.\n";
+ir::Tensor ScatterAssign(const ir::Tensor& input,
+                         const ir::Tensor& assign,
+                         const ir::Tensor& index,
+                         const common::Target& target,
+                         const int axis,
+                         const std::string& output_name) {
+  CHECK_EQ(index->type(), common::Int(32)) << "Param [Index] of ScatterAssign only support int32 ! Please Check.\n";
   std::string extern_fun_name;
   if (target.arch == common::Target::Arch::NVGPU) {
     extern_fun_name.assign("cinn_cuda_find_int");
   } else if (target.arch == common::Target::Arch::X86) {
     extern_fun_name.assign("cinn_host_find_int");
   } else {
-    LOG(FATAL) << "IndexAssign only support X86 and NVGPU ! Please Check.\n";
+    LOG(FATAL) << "ScatterAssign only support X86 and NVGPU ! Please Check.\n";
   }
 
   auto pos_axis = axis;

--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -909,7 +909,7 @@ ir::Tensor IndexSelect(const ir::Tensor& x,
 }
 
 ir::Tensor ScatterAssign(const ir::Tensor& input,
-                         const ir::Tensor& assign,
+                         const ir::Tensor& updates,
                          const ir::Tensor& index,
                          const common::Target& target,
                          const int axis,
@@ -935,11 +935,11 @@ ir::Tensor ScatterAssign(const ir::Tensor& input,
         // else return -1
         auto id = lang::CallExtern(extern_fun_name, {index, index->shape[0], indice[pos_axis]});
 
-        std::vector<Expr> indice_assign = indice;
-        indice_assign[pos_axis]         = id;
+        std::vector<Expr> indice_updates = indice;
+        indice_updates[pos_axis]         = id;
 
         // check wheter Index[id] == cur_index and return by check result
-        return ir::Select::Make(ir::EQ::Make(id, Expr(-1)), input(indice), assign(indice_assign));
+        return ir::Select::Make(ir::EQ::Make(id, Expr(-1)), input(indice), updates(indice_updates));
       },
       UniqName(output_name));
   return res;

--- a/cinn/hlir/pe/transform.h
+++ b/cinn/hlir/pe/transform.h
@@ -199,18 +199,18 @@ ir::Tensor IndexSelect(const ir::Tensor& x,
                        const std::string& name = UniqName("T_Transform_IndexSelect_out"));
 
 /**
- * @brief Perform meta op IndexAssign
+ * @brief Perform meta op ScatterAssign
  * @param input The input tensor
  * @param assign The assign tensor
  * @param indexs The indexs tensor
  * @param output_name the name of the output tensor
  */
-ir::Tensor IndexAssign(const ir::Tensor& input,
-                       const ir::Tensor& assign,
-                       const ir::Tensor& index,
-                       const common::Target& target,
-                       const int axis                 = 0,
-                       const std::string& output_name = UniqName("T_Transform_IndexAssign_out"));
+ir::Tensor ScatterAssign(const ir::Tensor& input,
+                         const ir::Tensor& assign,
+                         const ir::Tensor& index,
+                         const common::Target& target,
+                         const int axis                 = 0,
+                         const std::string& output_name = UniqName("T_Transform_ScatterAssign_out"));
 
 }  // namespace pe
 }  // namespace hlir

--- a/cinn/hlir/pe/transform.h
+++ b/cinn/hlir/pe/transform.h
@@ -206,7 +206,7 @@ ir::Tensor IndexSelect(const ir::Tensor& x,
  * @param output_name the name of the output tensor
  */
 ir::Tensor ScatterAssign(const ir::Tensor& input,
-                         const ir::Tensor& assign,
+                         const ir::Tensor& updates,
                          const ir::Tensor& index,
                          const common::Target& target,
                          const int axis                 = 0,

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -370,8 +370,8 @@ void BindFrontend(pybind11::module *m) {
            py::arg("starts"),
            py::arg("ends"),
            py::arg("strides") = std::vector<int>{})
-      .def("index_assign",
-           &BaseBuilder::IndexAssign,
+      .def("scatter_assign",
+           &BaseBuilder::ScatterAssign,
            py::arg("x"),
            py::arg("assign"),
            py::arg("index"),

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -373,7 +373,7 @@ void BindFrontend(pybind11::module *m) {
       .def("scatter_assign",
            &BaseBuilder::ScatterAssign,
            py::arg("x"),
-           py::arg("assign"),
+           py::arg("updates"),
            py::arg("index"),
            py::arg("axis") = 0);
   ;

--- a/python/tests/ops/test_scatter_assign_op.py
+++ b/python/tests/ops/test_scatter_assign_op.py
@@ -26,7 +26,7 @@ from cinn.common import *
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestIndexAssignOp(OpTest):
+class TestScatterAssignOp(OpTest):
     def setUp(self):
         self.init_case()
         self.target = DefaultNVGPUTarget()
@@ -67,12 +67,12 @@ class TestIndexAssignOp(OpTest):
         self.paddle_outputs = [pd_out]
 
     def build_cinn_program(self, target):
-        builder = NetBuilder("index_assign")
+        builder = NetBuilder("scatter_assign")
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
         y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
         index = builder.create_input(
             Int(32), self.inputs["index"].shape, "index")
-        out = builder.index_assign(x, y, index, self.axis)
+        out = builder.scatter_assign(x, y, index, self.axis)
 
         prog = builder.build()
         res = self.get_cinn_output(
@@ -85,7 +85,7 @@ class TestIndexAssignOp(OpTest):
         self.check_outputs_and_grads()
 
 
-class TestIndexAssignCase1(TestIndexAssignOp):
+class TestScatterAssignCase1(TestScatterAssignOp):
     def init_case(self):
         self.inputs = {
             "x": np.random.random([10, 5]).astype("float32"),
@@ -95,7 +95,7 @@ class TestIndexAssignCase1(TestIndexAssignOp):
         self.axis = 1
 
 
-class TestIndexAssignCase2(TestIndexAssignOp):
+class TestScatterAssignCase2(TestScatterAssignOp):
     def init_case(self):
         self.inputs = {
             "x": np.random.random([10, 5, 5]).astype("float32"),
@@ -105,7 +105,7 @@ class TestIndexAssignCase2(TestIndexAssignOp):
         self.axis = -1
 
 
-class TestIndexAssignCase3(TestIndexAssignOp):
+class TestScatterAssignCase3(TestScatterAssignOp):
     def init_case(self):
         self.inputs = {
             "x": np.random.random([10]).astype("float32"),
@@ -115,7 +115,7 @@ class TestIndexAssignCase3(TestIndexAssignOp):
         self.axis = -1
 
 
-class TestIndexAssignCase4(TestIndexAssignOp):
+class TestScatterAssignCase4(TestScatterAssignOp):
     def init_case(self):
         self.inputs = {
             "x": np.random.random([10, 5]).astype("float32"),


### PR DESCRIPTION
As title.

考虑到paddle中并不存在`index_assign`算子，且语义与`paddle.scatter`更类似。此外，与新的元算子`scatter_add`相比，两者的唯一区别在于`assign`变为了`add`，因此决定将`index_assign`重命名为`scatter_add`。

本PR除了重命名外没做任何其它修改。