### PR TITLE
add gather/scatter_add opmapper and change attr dtype to int64

### DIFF
--- a/cinn/frontend/op_mappers/common_utils.h
+++ b/cinn/frontend/op_mappers/common_utils.h
@@ -79,13 +79,13 @@ inline bool GetAttrOrDefault(const paddle::cpp::OpDesc& op_desc, const std::stri
 }
 
 template <typename T>
-inline utils::ShapeType ToShapeType(const std::vector<T>& shape) {
-  return utils::ShapeType(shape.begin(), shape.end());
+inline cinn::utils::ShapeType ToShapeType(const std::vector<T>& shape) {
+  return cinn::utils::ShapeType(shape.begin(), shape.end());
 }
 
 template <typename T>
-inline utils::DimType ToDimType(const T& val) {
-  return static_cast<utils::DimType>(val);
+inline cinn::utils::DimType ToDimType(const T& val) {
+  return static_cast<cinn::utils::DimType>(val);
 }
 
 }  // namespace utils

--- a/cinn/frontend/op_mappers/common_utils.h
+++ b/cinn/frontend/op_mappers/common_utils.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "cinn/frontend/paddle/cpp/op_desc.h"
+#include "cinn/utils/type_defs.h"
 
 namespace cinn {
 namespace frontend {
@@ -75,6 +76,16 @@ inline bool GetAttrOrDefault(const paddle::cpp::OpDesc& op_desc, const std::stri
     }
   }
   return default_value;
+}
+
+template <typename T>
+inline utils::ShapeType ToShapeType(const std::vector<T>& shape) {
+  return utils::ShapeType(shape.begin(), shape.end());
+}
+
+template <typename T>
+inline utils::DimType ToDimType(const T& val) {
+  return static_cast<utils::DimType>(val);
 }
 
 }  // namespace utils

--- a/cinn/frontend/op_mappers/science/broadcast.cc
+++ b/cinn/frontend/op_mappers/science/broadcast.cc
@@ -23,7 +23,7 @@ void FillConstantOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCont
   CHECK_EQ(op_desc.Output("Y").size(), 1UL);
   auto y_name = op_desc.Output("Y").front();
 
-  auto shape = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "shape");
+  auto shape = utils::ToShapeType(utils::GetAttrOrDefault<std::vector<int64_t>>(op_desc, "shape"));
   // TODO(jiangcheng): value support different datatype, not just float
   auto value = utils::GetAttrOrDefault<float>(op_desc, "value");
 
@@ -70,7 +70,7 @@ void BroadcastOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
   CHECK(op_desc.HasAttr("shape")) << "The broadcast_p operator should has 'shape' attribute, but " << x_name
                                   << "'s broadcast hasn't.";
 
-  auto y_shape = op_desc.GetAttr<std::vector<int>>("shape");
+  auto y_shape = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("shape"));
   auto x       = ctx.GetVar(x_name);
 
   VLOG(4) << "Broadcast " << x_name << " from shape (" << cinn::utils::Join(x->shape, ",") << ") to shape ("

--- a/cinn/frontend/op_mappers/science/transform.cc
+++ b/cinn/frontend/op_mappers/science/transform.cc
@@ -66,8 +66,8 @@ void SplitOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
         << "If the attribute 'num_or_sections' is a number, it should be divisible by the "
            "axis's dimension of inputs A ! Please check.";
   } else {
-    utils::DimType sec_sum = 0;
-    bool has_neg           = false;
+    cinn::utils::DimType sec_sum = 0;
+    bool has_neg                 = false;
     for (auto sec : num_or_sections) {
       if (sec > 0) {
         sec_sum += sec;
@@ -155,7 +155,7 @@ void SliceSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
           << cinn::utils::Join(starts, ",") << "], ends [" << cinn::utils::Join(ends, ",") << "], axis ["
           << cinn::utils::Join(axes, ",") << "], strides [" << cinn::utils::Join(strides, ",") << "].";
 
-  auto out = ctx.Builder()->Slice(x, axes, starts, ends, utils::ShapeType{}, strides);
+  auto out = ctx.Builder()->Slice(x, axes, starts, ends, cinn::utils::ShapeType{}, strides);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -279,7 +279,7 @@ void ScatterAddOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
 
   auto out = ctx.Builder()->ScatterAdd(x, updates, index, axis);
 
-  VLOG(4) << "ScatterAdd " << assign_name << " (" << cinn::utils::Join(updates->shape, ",") << ") to " << x_name
+  VLOG(4) << "ScatterAdd " << updates_name << " (" << cinn::utils::Join(updates->shape, ",") << ") to " << x_name
           << " shape (" << cinn::utils::Join(x->shape, ",") << ") "
           << "at dimension " << axis;
 

--- a/cinn/frontend/op_mappers/science/transform.cc
+++ b/cinn/frontend/op_mappers/science/transform.cc
@@ -20,8 +20,8 @@ namespace frontend {
 namespace science_mappers {
 
 void ConcatOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
-  CHECK_GE(op_desc.Input("X").size(), 1UL);
-  auto x_names = op_desc.Input("X");
+  CHECK_GE(op_desc.Input("XS").size(), 1UL);
+  auto x_names = op_desc.Input("XS");
   CHECK_EQ(op_desc.Output("Y").size(), 1UL);
   auto out_name = op_desc.Output("Y").front();
 
@@ -36,7 +36,7 @@ void ConcatOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
       xs.emplace_back(ctx.GetVar(name));
     }
 
-    auto axis = utils::GetAttrOrDefault<int>(op_desc, "axis");
+    auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
 
     out = ctx.Builder()->Concat(xs, axis);
   }
@@ -48,15 +48,15 @@ void ConcatOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
 void SplitOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
   CHECK_EQ(op_desc.Input("X").size(), 1UL);
   auto x_name = op_desc.Input("X").front();
-  CHECK_GE(op_desc.Output("Y").size(), 1UL);
-  auto out_name = op_desc.Output("Y");
+  CHECK_GE(op_desc.Output("YS").size(), 1UL);
+  auto out_name = op_desc.Output("YS");
 
   CHECK(op_desc.HasAttr("num_or_sections"));
-  auto num_or_sections = op_desc.GetAttr<std::vector<int>>("num_or_sections");
+  auto num_or_sections = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("num_or_sections"));
 
   CHECK(!num_or_sections.empty()) << "The Split op cannot found [num_or_sections] attrbute!  ! Please check.";
 
-  auto axis = utils::GetAttrOrDefault<int>(op_desc, "axis", 0);
+  auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
 
   auto x = ctx.GetVar(x_name);
 
@@ -66,8 +66,8 @@ void SplitOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
         << "If the attribute 'num_or_sections' is a number, it should be divisible by the "
            "axis's dimension of inputs A ! Please check.";
   } else {
-    int sec_sum  = 0;
-    bool has_neg = false;
+    utils::DimType sec_sum = 0;
+    bool has_neg           = false;
     for (auto sec : num_or_sections) {
       if (sec > 0) {
         sec_sum += sec;
@@ -102,7 +102,7 @@ void ReshapeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& 
   CHECK_EQ(op_desc.Input("X").size(), 1UL);
   auto x_name = op_desc.Input("X").front();
 
-  auto shape = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "shape");
+  auto shape = utils::ToShapeType(utils::GetAttrOrDefault<std::vector<int64_t>>(op_desc, "shape"));
 
   auto x = ctx.GetVar(x_name);
 
@@ -141,13 +141,13 @@ void SliceSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   auto out_name = op_desc.Output("Y").front();
 
   CHECK(op_desc.HasAttr("starts"));
-  auto starts = op_desc.GetAttr<std::vector<int>>("starts");
+  auto starts = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("starts"));
   CHECK(op_desc.HasAttr("ends"));
-  auto ends = op_desc.GetAttr<std::vector<int>>("ends");
+  auto ends = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("ends"));
   CHECK(op_desc.HasAttr("axis"));
-  auto axes = op_desc.GetAttr<std::vector<int>>("axis");
+  auto axes = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("axis"));
   CHECK(op_desc.HasAttr("strides"));
-  auto strides = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "strides");
+  auto strides = utils::ToShapeType(utils::GetAttrOrDefault<std::vector<int64_t>>(op_desc, "strides"));
 
   auto x = ctx.GetVar(x_name);
 
@@ -155,7 +155,7 @@ void SliceSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
           << cinn::utils::Join(starts, ",") << "], ends [" << cinn::utils::Join(ends, ",") << "], axis ["
           << cinn::utils::Join(axes, ",") << "], strides [" << cinn::utils::Join(strides, ",") << "].";
 
-  auto out = ctx.Builder()->Slice(x, axes, starts, ends, std::vector<int>{}, strides);
+  auto out = ctx.Builder()->Slice(x, axes, starts, ends, utils::ShapeType{}, strides);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
@@ -170,13 +170,13 @@ void SliceAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   auto out_name = op_desc.Output("Z").front();
 
   CHECK(op_desc.HasAttr("starts"));
-  auto starts = op_desc.GetAttr<std::vector<int>>("starts");
+  auto starts = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("starts"));
   CHECK(op_desc.HasAttr("ends"));
-  auto ends = op_desc.GetAttr<std::vector<int>>("ends");
+  auto ends = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("ends"));
   CHECK(op_desc.HasAttr("axis"));
-  auto axes = op_desc.GetAttr<std::vector<int>>("axis");
+  auto axes = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("axis"));
   CHECK(op_desc.HasAttr("strides"));
-  auto strides = op_desc.GetAttr<std::vector<int>>("strides");
+  auto strides = utils::ToShapeType(op_desc.GetAttr<std::vector<int64_t>>("strides"));
 
   auto x      = ctx.GetVar(x_name);
   auto assign = ctx.GetVar(y_name);
@@ -197,7 +197,7 @@ void ReduceOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
   CHECK_EQ(op_desc.Output("Y").size(), 1UL);
   auto out_name = op_desc.Output("Y").front();
 
-  auto axis    = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "axis");
+  auto axis    = utils::ToShapeType(utils::GetAttrOrDefault<std::vector<int64_t>>(op_desc, "axis"));
   auto keepdim = utils::GetAttrOrDefault<bool>(op_desc, "keepdim", false);
 
   auto x = ctx.GetVar(x_name);
@@ -220,7 +220,7 @@ void IndexSelectOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   CHECK_EQ(op_desc.Output("Y").size(), 1UL);
   auto out_name = op_desc.Output("Y").front();
 
-  auto axis = utils::GetAttrOrDefault<int>(op_desc, "axis", 0);
+  auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
 
   auto x     = ctx.GetVar(x_name);
   auto index = ctx.GetVar(index_name);
@@ -245,7 +245,7 @@ void IndexAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   CHECK_EQ(op_desc.Output("Z").size(), 1UL);
   auto out_name = op_desc.Output("Z").front();
 
-  auto axis = utils::GetAttrOrDefault<int>(op_desc, "axis", 0);
+  auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
 
   auto x       = ctx.GetVar(x_name);
   auto updates = ctx.GetVar(updates_name);
@@ -254,6 +254,32 @@ void IndexAssignOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
   auto out = ctx.Builder()->ScatterAssign(x, updates, index, axis);
 
   VLOG(4) << "IndexAssign " << updates_name << " (" << cinn::utils::Join(updates->shape, ",") << ") to " << x_name
+          << " shape (" << cinn::utils::Join(x->shape, ",") << ") "
+          << "at dimension " << axis;
+
+  ctx.AddVar(out_name, out);
+  ctx.AddVarModelToProgram(out_name, out->id);
+}
+
+void ScatterAddOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+  CHECK_EQ(op_desc.Input("X").size(), 1UL);
+  auto x_name = op_desc.Input("X").front();
+  CHECK_EQ(op_desc.Input("Y").size(), 1UL);
+  auto updates_name = op_desc.Input("Y").front();
+  CHECK_EQ(op_desc.Input("IndexTensor").size(), 1UL);
+  auto index_name = op_desc.Input("IndexTensor").front();
+  CHECK_EQ(op_desc.Output("Z").size(), 1UL);
+  auto out_name = op_desc.Output("Z").front();
+
+  auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
+
+  auto x       = ctx.GetVar(x_name);
+  auto updates = ctx.GetVar(updates_name);
+  auto index   = ctx.GetVar(index_name);
+
+  auto out = ctx.Builder()->ScatterAdd(x, updates, index, axis);
+
+  VLOG(4) << "ScatterAdd " << assign_name << " (" << cinn::utils::Join(updates->shape, ",") << ") to " << x_name
           << " shape (" << cinn::utils::Join(x->shape, ",") << ") "
           << "at dimension " << axis;
 
@@ -273,7 +299,9 @@ CINN_REGISTER_HELPER(science_transform) {
   CINN_REGISTER_OP_MAPPER(slice_select_p, cinn::frontend::science_mappers::SliceSelectOpMapper)
   CINN_REGISTER_OP_MAPPER(slice_assign_p, cinn::frontend::science_mappers::SliceAssignOpMapper)
   CINN_REGISTER_OP_MAPPER(index_select_p, cinn::frontend::science_mappers::IndexSelectOpMapper)
+  CINN_REGISTER_OP_MAPPER(gather_p, cinn::frontend::science_mappers::IndexSelectOpMapper)
   CINN_REGISTER_OP_MAPPER(index_assign_p, cinn::frontend::science_mappers::IndexAssignOpMapper)
+  CINN_REGISTER_OP_MAPPER(scatter_add_p, cinn::frontend::science_mappers::ScatterAddOpMapper)
   CINN_REGISTER_OP_MAPPER(reduce_p, cinn::frontend::science_mappers::ReduceOpMapper)
   return true;
 }


### PR DESCRIPTION
# 背景
相比手动拆分版本的科学计算基础算子，自动拆分版本的科学计算基础算子主要有如下改变：

1. 移除`index_select`、`index_assign`基础算子，并替换为`gather`、`scatter_add`基础算子
2. `int`类型的属性均改变为`int64_t`类型

# 简介
本PR针对如上两个问题，做了如下修改：

1. 新增`gather`、`scatter_add`基础算子的OpMapper，其中`gather`可直接复用现有的`index_select`基础算子，`scatter_add`元算子实现见https://github.com/PaddlePaddle/CINN/pull/738
2. 获取`shape,axis`等属性时，类型均修改为`int64_t`，并在OpMapper中转换为`ShapeType`，传入下一步