### PR TITLE
Add FLAGS_cinn_use_new_fusion_pass to  switch to the new op fusion and fusion merge pass.

### DIFF
--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -26,9 +26,22 @@
 #include "cinn/hlir/framework/graph.h"
 #include "cinn/hlir/framework/pass.h"
 #include "cinn/hlir/pass/use_pass.h"
+#include "cinn/runtime/flags.h"
 
 namespace cinn {
 namespace frontend {
+
+OptimizeOptions DefaultTrainingOptimizeOptions() {
+  OptimizeOptions options;
+  options.program_passes = {"Decomposer", "TransposeFolding", "GemmRewriter", "RemoveIdentity"};
+  if (cinn::runtime::GetCinnUseNewFusionPassFromEnv()) {
+    options.graph_passes = {"OpFusionPass", "FusionMergePass"};
+  } else {
+    options.graph_passes = {"OpFusion"};
+  }
+  return options;
+}
+
 std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
                                                  const std::unordered_set<std::string>& fetch_ids,
                                                  common::Target target,

--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -26,7 +26,8 @@
 #include "cinn/hlir/framework/graph.h"
 #include "cinn/hlir/framework/pass.h"
 #include "cinn/hlir/pass/use_pass.h"
-#include "cinn/runtime/flags.h"
+
+DECLARE_bool(cinn_use_new_fusion_pass);
 
 namespace cinn {
 namespace frontend {
@@ -34,7 +35,7 @@ namespace frontend {
 OptimizeOptions DefaultTrainingOptimizeOptions() {
   OptimizeOptions options;
   options.program_passes = {"Decomposer", "TransposeFolding", "GemmRewriter", "RemoveIdentity"};
-  if (cinn::runtime::GetCinnUseNewFusionPass()) {
+  if (FLAGS_cinn_use_new_fusion_pass) {
     options.graph_passes = {"OpFusionPass", "FusionMergePass"};
   } else {
     options.graph_passes = {"OpFusion"};

--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -34,7 +34,7 @@ namespace frontend {
 OptimizeOptions DefaultTrainingOptimizeOptions() {
   OptimizeOptions options;
   options.program_passes = {"Decomposer", "TransposeFolding", "GemmRewriter", "RemoveIdentity"};
-  if (cinn::runtime::GetCinnUseNewFusionPassFromEnv()) {
+  if (cinn::runtime::GetCinnUseNewFusionPass()) {
     options.graph_passes = {"OpFusionPass", "FusionMergePass"};
   } else {
     options.graph_passes = {"OpFusion"};

--- a/cinn/frontend/optimize.h
+++ b/cinn/frontend/optimize.h
@@ -29,12 +29,7 @@ struct OptimizeOptions {
   std::vector<std::string> graph_passes;
 };
 
-inline OptimizeOptions DefaultTrainingOptimizeOptions() {
-  OptimizeOptions options;
-  options.program_passes = {"Decomposer", "TransposeFolding", "GemmRewriter", "RemoveIdentity"};
-  options.graph_passes   = {"OpFusionPass", "FusionMergePass"};
-  return options;
-}
+OptimizeOptions DefaultTrainingOptimizeOptions();
 
 std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
                                                  const std::unordered_set<std::string>& fetch_ids,

--- a/cinn/frontend/optimize.h
+++ b/cinn/frontend/optimize.h
@@ -32,7 +32,7 @@ struct OptimizeOptions {
 inline OptimizeOptions DefaultTrainingOptimizeOptions() {
   OptimizeOptions options;
   options.program_passes = {"Decomposer", "TransposeFolding", "GemmRewriter", "RemoveIdentity"};
-  options.graph_passes   = {"OpFusion"};
+  options.graph_passes   = {"OpFusionPass", "FusionMergePass"};
   return options;
 }
 

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -15,7 +15,8 @@
 #include "cinn/hlir/framework/instruction.h"
 
 #include "cinn/common/test_helper.h"
-#include "cinn/runtime/flags.h"
+
+DECLARE_bool(cinn_sync_run);
 
 namespace cinn {
 namespace hlir {
@@ -189,8 +190,8 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
   }
 #endif
 
-#if defined(CINN_WITH_CUDA) || defined(CINN_WITH_CUDNN)
-  if (cinn::runtime::GetCinnSyncRun()) {
+#ifdef CINN_WITH_CUDA
+  if (FLAGS_cinn_sync_run) {
     cudaStreamSynchronize(static_cast<cudaStream_t>(stream));
   }
 #endif

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -15,6 +15,7 @@
 #include "cinn/hlir/framework/instruction.h"
 
 #include "cinn/common/test_helper.h"
+#include "cinn/runtime/flags.h"
 
 namespace cinn {
 namespace hlir {
@@ -185,6 +186,12 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
       it_fn(pod_args.data(), pod_args.size());
     }
     i++;
+  }
+#endif
+
+#if defined(CINN_WITH_CUDA) || defined(CINN_WITH_CUDNN)
+  if (cinn::runtime::GetCinnSyncRunFromEnv()) {
+    cudaStreamSynchronize(static_cast<cudaStream_t>(stream));
   }
 #endif
 }

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -190,7 +190,7 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
 #endif
 
 #if defined(CINN_WITH_CUDA) || defined(CINN_WITH_CUDNN)
-  if (cinn::runtime::GetCinnSyncRunFromEnv()) {
+  if (cinn::runtime::GetCinnSyncRun()) {
     cudaStreamSynchronize(static_cast<cudaStream_t>(stream));
   }
 #endif

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -28,7 +28,8 @@ DEFINE_bool(cinn_cudnn_deterministic,
             "true, the algorithm is deterministic.");
 #endif
 
-DEFINE_bool(cinn_use_new_fusion_pass, false, "Whether use to new op_fusion and fusion_merge pass.");
+DEFINE_bool(cinn_use_new_fusion_pass, false, "Whether use the new op_fusion and fusion_merge pass.");
+DEFINE_bool(cinn_sync_run, false, "Whether sync all devices after each instruction run, which is used for debug.");
 
 namespace cinn {
 namespace runtime {
@@ -50,12 +51,32 @@ bool GetCinnCudnnDeterministic() {
 #endif
 }
 
-bool GetCinnUseNewFusionPassFromEnv() {
-  const char *env_str = std::getenv("FLAGS_cinn_use_new_fusion_pass");
+bool ParseFromEnv(std::string name, bool default_value) {
+  const char *env_str = std::getenv(name.c_str());
   if (env_str) {
-    FLAGS_cinn_use_new_fusion_pass = static_cast<bool>(std::stoi(std::string(env_str)));
+    VLOG(4) << "Parse " << name << ", get " << env_str;
+    return static_cast<bool>(std::stoi(std::string(env_str)));
+  } else {
+    return default_value;
+  }
+}
+
+bool GetCinnUseNewFusionPassFromEnv() {
+  static bool parsed = false;
+  if (!parsed) {
+    FLAGS_cinn_use_new_fusion_pass = ParseFromEnv("FLAGS_cinn_use_new_fusion_pass", FLAGS_cinn_use_new_fusion_pass);
+    parsed                         = true;
   }
   return FLAGS_cinn_use_new_fusion_pass;
+}
+
+bool GetCinnSyncRunFromEnv() {
+  static bool parsed = false;
+  if (!parsed) {
+    FLAGS_cinn_sync_run = ParseFromEnv("FLAGS_cinn_sync_run", FLAGS_cinn_sync_run);
+    parsed              = true;
+  }
+  return FLAGS_cinn_sync_run;
 }
 
 }  // namespace runtime

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -17,6 +17,9 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <cstdlib>
+#include <string>
+
 #ifdef CINN_WITH_CUDNN
 DEFINE_bool(cinn_cudnn_deterministic,
             false,
@@ -24,6 +27,8 @@ DEFINE_bool(cinn_cudnn_deterministic,
             "operator. The autotuning algorithm may be non-deterministic. If "
             "true, the algorithm is deterministic.");
 #endif
+
+DEFINE_bool(cinn_use_new_fusion_pass, false, "Whether use to new op_fusion and fusion_merge pass.");
 
 namespace cinn {
 namespace runtime {
@@ -43,6 +48,14 @@ bool GetCinnCudnnDeterministic() {
   LOG(FATAL) << "CINN is compiled without cuDNN, this api is invalid!";
   return false;
 #endif
+}
+
+bool GetCinnUseNewFusionPassFromEnv() {
+  const char *env_str = std::getenv("FLAGS_cinn_use_new_fusion_pass");
+  if (env_str) {
+    FLAGS_cinn_use_new_fusion_pass = static_cast<bool>(std::stoi(std::string(env_str)));
+  }
+  return FLAGS_cinn_use_new_fusion_pass;
 }
 
 }  // namespace runtime

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -28,8 +28,14 @@ DEFINE_bool(cinn_cudnn_deterministic,
             "true, the algorithm is deterministic.");
 #endif
 
-DEFINE_bool(cinn_use_new_fusion_pass, false, "Whether use the new op_fusion and fusion_merge pass.");
-DEFINE_bool(cinn_sync_run, false, "Whether sync all devices after each instruction run, which is used for debug.");
+using ::GFLAGS_NAMESPACE::BoolFromEnv;
+
+DEFINE_bool(cinn_use_new_fusion_pass,
+            BoolFromEnv("FLAGS_cinn_use_new_fusion_pass", false),
+            "Whether use the new op_fusion and fusion_merge pass.");
+DEFINE_bool(cinn_sync_run,
+            BoolFromEnv("FLAGS_cinn_sync_run", false),
+            "Whether sync all devices after each instruction run, which is used for debug.");
 
 namespace cinn {
 namespace runtime {
@@ -51,33 +57,9 @@ bool GetCinnCudnnDeterministic() {
 #endif
 }
 
-bool ParseFromEnv(std::string name, bool default_value) {
-  const char *env_str = std::getenv(name.c_str());
-  if (env_str) {
-    VLOG(4) << "Parse " << name << ", get " << env_str;
-    return static_cast<bool>(std::stoi(std::string(env_str)));
-  } else {
-    return default_value;
-  }
-}
+bool GetCinnUseNewFusionPass() { return FLAGS_cinn_use_new_fusion_pass; }
 
-bool GetCinnUseNewFusionPassFromEnv() {
-  static bool parsed = false;
-  if (!parsed) {
-    FLAGS_cinn_use_new_fusion_pass = ParseFromEnv("FLAGS_cinn_use_new_fusion_pass", FLAGS_cinn_use_new_fusion_pass);
-    parsed                         = true;
-  }
-  return FLAGS_cinn_use_new_fusion_pass;
-}
-
-bool GetCinnSyncRunFromEnv() {
-  static bool parsed = false;
-  if (!parsed) {
-    FLAGS_cinn_sync_run = ParseFromEnv("FLAGS_cinn_sync_run", FLAGS_cinn_sync_run);
-    parsed              = true;
-  }
-  return FLAGS_cinn_sync_run;
-}
+bool GetCinnSyncRun() { return FLAGS_cinn_sync_run; }
 
 }  // namespace runtime
 }  // namespace cinn

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -57,9 +57,5 @@ bool GetCinnCudnnDeterministic() {
 #endif
 }
 
-bool GetCinnUseNewFusionPass() { return FLAGS_cinn_use_new_fusion_pass; }
-
-bool GetCinnSyncRun() { return FLAGS_cinn_sync_run; }
-
 }  // namespace runtime
 }  // namespace cinn

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -17,9 +17,6 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
-#include <cstdlib>
-#include <string>
-
 #ifdef CINN_WITH_CUDNN
 DEFINE_bool(cinn_cudnn_deterministic,
             false,

--- a/cinn/runtime/flags.h
+++ b/cinn/runtime/flags.h
@@ -21,6 +21,7 @@ void SetCinnCudnnDeterministic(bool state);
 bool GetCinnCudnnDeterministic();
 
 bool GetCinnUseNewFusionPassFromEnv();
+bool GetCinnSyncRunFromEnv();
 
 }  // namespace runtime
 }  // namespace cinn

--- a/cinn/runtime/flags.h
+++ b/cinn/runtime/flags.h
@@ -20,5 +20,7 @@ namespace runtime {
 void SetCinnCudnnDeterministic(bool state);
 bool GetCinnCudnnDeterministic();
 
+bool GetCinnUseNewFusionPassFromEnv();
+
 }  // namespace runtime
 }  // namespace cinn

--- a/cinn/runtime/flags.h
+++ b/cinn/runtime/flags.h
@@ -20,8 +20,8 @@ namespace runtime {
 void SetCinnCudnnDeterministic(bool state);
 bool GetCinnCudnnDeterministic();
 
-bool GetCinnUseNewFusionPassFromEnv();
-bool GetCinnSyncRunFromEnv();
+bool GetCinnUseNewFusionPass();
+bool GetCinnSyncRun();
 
 }  // namespace runtime
 }  // namespace cinn

--- a/cinn/runtime/flags.h
+++ b/cinn/runtime/flags.h
@@ -20,8 +20,5 @@ namespace runtime {
 void SetCinnCudnnDeterministic(bool state);
 bool GetCinnCudnnDeterministic();
 
-bool GetCinnUseNewFusionPass();
-bool GetCinnSyncRun();
-
 }  // namespace runtime
 }  // namespace cinn


### PR DESCRIPTION
添加2个FLAGS，方便调试：

1. `FLAGS_cinn_use_new_fusion_pass`，切换到新的`OpFusionPass` + `FusionMerge`，默认值为`false`。
![image](https://user-images.githubusercontent.com/12538138/165071169-b5edd8a1-7c2f-4db7-9b6e-8fd28539ef3c.png)

2. `FLAGS_cinn_sync_run`，在每个`Instruction->Run`调用介绍后加入stream同步，用于debug，默认值为`false`。