### PR TITLE
optimize reduce for lapalce2d

### DIFF
--- a/cinn/hlir/op/CMakeLists.txt
+++ b/cinn/hlir/op/CMakeLists.txt
@@ -5,6 +5,7 @@ gather_srcs(cinnapi_src SRCS
     broadcast.cc
     transform.cc
     elementwise.cc
+    reduction_util.cc
     reduction.cc
     op_util.cc
     )

--- a/cinn/hlir/op/op_util.cc
+++ b/cinn/hlir/op/op_util.cc
@@ -13,3 +13,15 @@
 // limitations under the License.
 
 #include "cinn/hlir/op/op_util.h"
+
+namespace cinn {
+namespace hlir {
+
+cinn::utils::ShapeType ToShapeType(const std::vector<Expr>& args) {
+  cinn::utils::ShapeType input_shape;
+  std::for_each(args.begin(), args.end(), [&](const Expr& expr) { input_shape.emplace_back(expr.as_int32()); });
+  return input_shape;
+}
+
+}  // namespace hlir
+}  // namespace cinn

--- a/cinn/hlir/op/reduction_util.cc
+++ b/cinn/hlir/op/reduction_util.cc
@@ -1,0 +1,370 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/hlir/op/reduction_util.h"
+
+#include <iostream>
+#include <vector>
+
+#include "cinn/hlir/op/op_util.h"
+#include "cinn/hlir/pe/reduction.h"
+#include "cinn/hlir/pe/schedule.h"
+#include "cinn/ir/ir.h"
+
+namespace cinn {
+namespace hlir {
+namespace op {
+namespace util {
+
+using framework::dim_t;
+using framework::shape_t;
+using ir::Expr;
+
+using ReduceComputeFunc =
+    std::function<ir::Tensor(const ir::Tensor&, const shape_t&, bool, ir::Expr, const std::string&)>;
+using BlockReduceInternalComputeFunc =
+    std::function<std::vector<ir::Tensor>(const ir::Tensor&, const int, const bool, const std::string&)>;
+using BlockReduceComputeFunc =
+    std::function<std::vector<ir::Tensor>(const ir::Tensor&, const int, const int, const bool, const std::string&)>;
+using ReduceForSmallerDimComputeFunc =
+    std::function<std::vector<ir::Tensor>(const ir::Tensor&, const shape_t&, bool, const std::string&)>;
+
+using RunReduceComputeFunc = std::function<std::vector<ir::Tensor>(
+    const std::string&, const ir::Tensor&, const shape_t&, bool, const std::string&)>;
+using RunReduceScheduleFunc =
+    std::function<void(const shape_t&, const shape_t&, const common::Target&, common::CINNValuePack*)>;
+
+std::string ReduceFuncType2String(const ReduceFuncType& reduce_func_type) {
+  static std::unordered_map<ReduceFuncType, std::string> run_reduce_func_map = {
+      {ReduceFuncType::Reduce, "Reduce"},
+      {ReduceFuncType::BlockReduce, "BlockReduce"},
+      {ReduceFuncType::BlockReduceInternal, "BlockReduceInternal"},
+      {ReduceFuncType::ReduceWithInternal, "ReduceWithInternal"},
+      {ReduceFuncType::ReduceForSmallerDim, "ReduceForSmallerDim"}};
+
+  CHECK(run_reduce_func_map.count(reduce_func_type))
+      << "Do not support ReduceFuncType " << static_cast<int>(reduce_func_type) << " ! Please check.";
+
+  return run_reduce_func_map.at(reduce_func_type);
+}
+
+shape_t GetShape(const ir::Tensor& x) {
+  auto last_reduce_dim = x->shape[2].as_int32() * x->shape[3].as_int32();
+  // Split into last_reduce_dim into {n,k}
+  shape_t new_shape = {x->shape[0].as_int32(), x->shape[1].as_int32()};
+  // As the max block size is 1024, setting 1024 as limit
+  if (last_reduce_dim <= 1024) {
+    new_shape.push_back(last_reduce_dim);
+  } else {
+    // As sum of reduce dimension is over 1024, so find a value along(1024, 1) that can be divied by
+    // last_reduce_dim.
+    for (int idx = 1024;; --idx) {
+      if (last_reduce_dim % idx == 0) {
+        new_shape.push_back(last_reduce_dim / idx);
+        new_shape.push_back(idx);
+        break;
+      }
+    }
+
+    CHECK_EQ(new_shape.size(), 4) << "Can't find a new shape that satisfy the requirement!";
+  }
+
+  return new_shape;
+}
+
+shape_t CheckAndValidReduceDim(const shape_t& dim, const size_t rank) {
+  auto new_dim = dim;
+
+  if (new_dim.empty()) {
+    for (int i = 0; i < rank; ++i) {
+      new_dim.push_back(i);
+    }
+  } else {
+    // support dim[i] < 0 like as dim=[-1]
+    for (int i = 0; i < new_dim.size(); ++i) {
+      if (new_dim[i] < 0) {
+        new_dim[i] += rank;
+      }
+      CHECK(new_dim[i] >= 0 && new_dim[i] < rank) << "The value of [dim] of Reduce should between 0 and " << rank
+                                                  << ", but here " << dim[i] << " at " << i << " ! Please check.";
+    }
+  }
+
+  std::sort(new_dim.begin(), new_dim.end());
+  // check dim
+  CHECK_LE(new_dim.size(), rank);
+  CHECK_LT(new_dim.back(), rank);
+  for (int idx = 1; idx < new_dim.size(); ++idx) {
+    CHECK_NE(new_dim[idx - 1], new_dim[idx]);
+  }
+
+  return new_dim;
+}
+
+ReduceFuncType SelectReduceWithLastDimFuncType(const shape_t& dim, const shape_t& input_shape) {
+  // compute reduce args
+  bool reduce_dim_succesive = true;
+  dim_t last_succesive_dim  = input_shape.back();
+  for (int idx = dim.size() - 2; idx >= 0; --idx) {
+    if (dim[idx] != dim[idx + 1] - 1) {
+      reduce_dim_succesive = false;
+      break;
+    } else {
+      if (last_succesive_dim * input_shape[dim[idx]] > 1024) {
+        reduce_dim_succesive = false;
+        break;
+      }
+      last_succesive_dim *= input_shape[dim[idx]];
+    }
+  }
+
+  if (reduce_dim_succesive) {          // the reduce dimension is succesive
+    if (last_succesive_dim <= 1024) {  // if the succesive reduce dimension size <= 1024
+      return ReduceFuncType::BlockReduceInternal;
+    } else {  // if the succesive reduce dimension size > 256
+      return ReduceFuncType::BlockReduce;
+    }
+  }
+  // the reduce dimension is not succesive
+  return ReduceFuncType::ReduceWithInternal;
+}
+
+ReduceFuncType SelectReduceWithOutLastDimFuncType(const shape_t& dim, const shape_t& input_shape) {
+  // compute reduce dim
+  dim_t last_dim = 1;
+  for (int i = dim.back() + 1; i < input_shape.size(); ++i) {
+    last_dim *= input_shape[i];
+  }
+
+  if (last_dim <= 128) {
+    return ReduceFuncType::ReduceForSmallerDim;
+  }
+  return ReduceFuncType::Reduce;
+}
+
+ReduceFuncType SelectReduceFuncType(const std::vector<ir::Expr>& input_shape,
+                                    const shape_t& dim,
+                                    const common::Target& target) {
+  if (target != common::DefaultNVGPUTarget()) {
+    return ReduceFuncType::Reduce;
+  }
+  auto input_shape_int = ToShapeType(input_shape);
+  return dim.back() == input_shape.size() - 1 ? SelectReduceWithLastDimFuncType(dim, input_shape_int)
+                                              : SelectReduceWithOutLastDimFuncType(dim, input_shape_int);
+}
+
+std::vector<ir::Tensor> RunReduceBaseCompute(const std::string& op_name,
+                                             const ir::Tensor& x,
+                                             const shape_t& dim,
+                                             bool keep_dim                  = false,
+                                             const std::string& output_name = "T_Reduce_out") {
+  static std::unordered_map<std::string, ReduceComputeFunc> reduce_func_map = {{"reduce_sum", pe::ReduceSum},
+                                                                               {"reduce_prod", pe::ReduceProd},
+                                                                               {"reduce_max", pe::ReduceMax},
+                                                                               {"reduce_min", pe::ReduceMin}};
+
+  CHECK(reduce_func_map.count(op_name)) << "RunReduceBaseCompute Not support op [" << op_name << "] ! Please check.";
+
+  VLOG(3) << "Compute [" << op_name << "] by ReduceComputeFunc !";
+  return std::vector<ir::Tensor>{reduce_func_map.at(op_name)(x, dim, keep_dim, ir::Expr(), UniqName(output_name))};
+}
+
+std::vector<ir::Tensor> RunBlockReduceCompute(const std::string& op_name,
+                                              const ir::Tensor& x,
+                                              const shape_t& dim,
+                                              bool keep_dim                  = false,
+                                              const std::string& output_name = "T_Reduce_out") {
+  static std::unordered_map<std::string, BlockReduceComputeFunc> reduce_func_map = {
+      {"reduce_sum", pe::BlockReduceSum},
+      {"reduce_prod", pe::BlockReduceProd},
+      {"reduce_max", pe::BlockReduceMax},
+      {"reduce_min", pe::BlockReduceMin}};
+
+  CHECK(reduce_func_map.count(op_name)) << "RunBlockReduceCompute Not support op [" << op_name << "] ! Please check.";
+
+  VLOG(3) << "Do BlockReduce Compute!";
+  int block_size = 1024;
+  return reduce_func_map.at(op_name)(x, static_cast<int>(dim.size()), block_size, keep_dim, UniqName(output_name));
+}
+
+std::vector<ir::Tensor> RunBlockReduceInternalCompute(const std::string& op_name,
+                                                      const ir::Tensor& x,
+                                                      const shape_t& dim,
+                                                      bool keep_dim                  = false,
+                                                      const std::string& output_name = "T_Reduce_out") {
+  static std::unordered_map<std::string, BlockReduceInternalComputeFunc> reduce_func_map = {
+      {"reduce_sum", pe::BlockReduceSumInternal},
+      {"reduce_prod", pe::BlockReduceProdInternal},
+      {"reduce_max", pe::BlockReduceMaxInternal},
+      {"reduce_min", pe::BlockReduceMinInternal}};
+
+  CHECK(reduce_func_map.count(op_name)) << "RunBlockReduceInternalCompute Not support op [" << op_name
+                                        << "] ! Please check.";
+
+  VLOG(3) << "Do BlockReduceInternal Compute!";
+  return reduce_func_map.at(op_name)(x, static_cast<int>(dim.size()), keep_dim, UniqName(output_name));
+}
+
+std::vector<ir::Tensor> RunReduceWithInternalCompute(const std::string& op_name,
+                                                     const ir::Tensor& x,
+                                                     const shape_t& dim,
+                                                     bool keep_dim                  = false,
+                                                     const std::string& output_name = "T_Reduce_out") {
+  VLOG(3) << "Do Reduce And BlockReduceInternal Compute!";
+
+  // compute reduce args
+  auto input_shape         = ToShapeType(x->shape);
+  int succesive_dim_idx    = 0;
+  dim_t last_succesive_dim = input_shape.back();
+  for (int idx = dim.size() - 2; idx >= 0; --idx) {
+    if (dim[idx] != dim[idx + 1] - 1) {
+      succesive_dim_idx = idx + 1;
+      break;
+    } else {
+      if (last_succesive_dim * input_shape[dim[idx]] > 1024) {
+        succesive_dim_idx = idx + 1;
+        break;
+      }
+      last_succesive_dim *= input_shape[dim[idx]];
+    }
+  }
+
+  // compute the parallel reduce dimension size
+  shape_t reduce_without_last_diemension(dim.begin(), dim.begin() + succesive_dim_idx);
+  // TODO(sunli) : support last dimension size over 1024
+  CHECK_LE(last_succesive_dim, 1024) << "last dimension size is over 1024";
+
+  // first: do reduce without last dimension
+  auto reduce_out =
+      RunReduceBaseCompute(op_name, x, reduce_without_last_diemension, keep_dim, UniqName(output_name + "_tmp"));
+
+  // second: do reduce on last dimension
+  shape_t reduce_last_diemension(dim.begin() + succesive_dim_idx, dim.end());
+  auto out =
+      RunBlockReduceInternalCompute(op_name, reduce_out[0], reduce_last_diemension, keep_dim, UniqName(output_name));
+
+  out.insert(out.end(), reduce_out.begin(), reduce_out.end());
+  return out;
+}
+
+std::vector<ir::Tensor> RunReduceForSmallerDimCompute(const std::string& op_name,
+                                                      const ir::Tensor& x,
+                                                      const shape_t& dim,
+                                                      bool keep_dim                  = false,
+                                                      const std::string& output_name = "T_Reduce_out") {
+  static std::unordered_map<std::string, ReduceForSmallerDimComputeFunc> reduce_func_map = {
+      {"reduce_sum", pe::ReduceSumForSmallerDim},
+      {"reduce_prod", pe::ReduceProdForSmallerDim},
+      {"reduce_max", pe::ReduceMaxForSmallerDim},
+      {"reduce_min", pe::ReduceMinForSmallerDim}};
+
+  CHECK(reduce_func_map.count(op_name)) << "RunReduceForSmallerDimCompute Not support op [" << op_name
+                                        << "] ! Please check.";
+
+  VLOG(3) << "Do ReduceForSmallerDim Compute!";
+  return reduce_func_map.at(op_name)(x, dim, keep_dim, UniqName(output_name));
+}
+
+std::vector<ir::Tensor> RunReduceCompute(const ReduceFuncType& reduce_func_type,
+                                         const std::string& op_name,
+                                         const ir::Tensor& x,
+                                         const shape_t& dim,
+                                         bool keep_dim,
+                                         const std::string& output_name) {
+  static std::unordered_map<ReduceFuncType, RunReduceComputeFunc> run_reduce_func_map = {
+      {ReduceFuncType::Reduce, RunReduceBaseCompute},
+      {ReduceFuncType::BlockReduce, RunBlockReduceCompute},
+      {ReduceFuncType::BlockReduceInternal, RunBlockReduceInternalCompute},
+      {ReduceFuncType::ReduceWithInternal, RunReduceWithInternalCompute},
+      {ReduceFuncType::ReduceForSmallerDim, RunReduceForSmallerDimCompute}};
+
+  CHECK(run_reduce_func_map.count(reduce_func_type))
+      << "Do not support ReduceFuncType " << static_cast<int>(reduce_func_type) << " ! Please check.";
+
+  return run_reduce_func_map.at(reduce_func_type)(op_name, x, dim, keep_dim, UniqName(output_name));
+}
+
+void RunBlockReduceInternalSchedule(const shape_t& input_shape,
+                                    const shape_t& dim,
+                                    const common::Target& target,
+                                    common::CINNValuePack* arg_pack) {
+  CHECK_EQ(arg_pack->size(), 3UL);
+  Expr out              = (*arg_pack)[0];
+  Expr tmp_out          = (*arg_pack)[1];
+  poly::StageMap stages = arg_pack->back();
+
+  VLOG(3) << "Do CudaScheduleBlockReduceInternal Schedule!";
+  pe::CudaScheduleBlockReduceInternal(stages, tmp_out.as_tensor_ref(), out.as_tensor_ref(), target);
+}
+
+void RunBlockReduceSchedule(const shape_t& input_shape,
+                            const shape_t& dim,
+                            const common::Target& target,
+                            common::CINNValuePack* arg_pack) {
+  CHECK_EQ(arg_pack->size(), 4UL);
+  Expr out              = (*arg_pack)[0];
+  Expr tmp_out          = (*arg_pack)[1];
+  Expr reduce_tmp_out   = (*arg_pack)[2];
+  poly::StageMap stages = arg_pack->back();
+
+  VLOG(3) << "Do CudaScheduleBlockReduce Schedule!";
+  pe::CudaScheduleBlockReduce(
+      stages, reduce_tmp_out.as_tensor_ref(), tmp_out.as_tensor_ref(), out.as_tensor_ref(), target);
+}
+
+void RunReduceForSmallerDimSchedule(const shape_t& input_shape,
+                                    const shape_t& dim,
+                                    const common::Target& target,
+                                    common::CINNValuePack* arg_pack) {
+  CHECK_EQ(arg_pack->size(), 3UL);
+  Expr out              = (*arg_pack)[0];
+  Expr tmp_out          = (*arg_pack)[1];
+  poly::StageMap stages = arg_pack->back();
+  VLOG(3) << "Do CudaScheduleReduceForSmallerDim Schedule!";
+  pe::CudaScheduleReduceForSmallerDim(stages, dim, tmp_out.as_tensor_ref(), out.as_tensor_ref());
+}
+
+void RunReduceBaseSchedule(const shape_t& input_shape,
+                           const shape_t& dim,
+                           const common::Target& target,
+                           common::CINNValuePack* arg_pack) {
+  CHECK_EQ(arg_pack->size(), 2UL);
+  Expr out              = (*arg_pack)[0];
+  poly::StageMap stages = arg_pack->back();
+  VLOG(3) << "Do CudaScheduleReduceBase Schedule!";
+  pe::CudaScheduleReduce(stages, out.as_tensor_ref(), input_shape.size() - dim.back() - 1, target);
+}
+
+void RunReduceSchedule(const ReduceFuncType& reduce_func_type,
+                       const std::vector<ir::Expr>& input_shape,
+                       const shape_t& dim,
+                       const common::Target& target,
+                       common::CINNValuePack* arg_pack) {
+  static std::unordered_map<ReduceFuncType, RunReduceScheduleFunc> run_reduce_func_map = {
+      {ReduceFuncType::Reduce, RunReduceBaseSchedule},
+      {ReduceFuncType::BlockReduce, RunBlockReduceInternalSchedule},
+      {ReduceFuncType::BlockReduceInternal, RunBlockReduceInternalSchedule},
+      {ReduceFuncType::ReduceWithInternal, RunBlockReduceSchedule},
+      {ReduceFuncType::ReduceForSmallerDim, RunReduceForSmallerDimSchedule}};
+
+  CHECK(run_reduce_func_map.count(reduce_func_type))
+      << "Do not support ReduceFuncType " << static_cast<int>(reduce_func_type) << " ! Please check.";
+
+  return run_reduce_func_map.at(reduce_func_type)(ToShapeType(input_shape), dim, target, arg_pack);
+}
+
+}  // namespace util
+}  // namespace op
+}  // namespace hlir
+}  // namespace cinn

--- a/cinn/hlir/op/reduction_util.cc
+++ b/cinn/hlir/op/reduction_util.cc
@@ -104,7 +104,6 @@ shape_t CheckAndValidReduceDim(const shape_t& dim, const size_t rank) {
   std::sort(new_dim.begin(), new_dim.end());
   // check dim
   CHECK_LE(new_dim.size(), rank);
-  CHECK_LT(new_dim.back(), rank);
   for (int idx = 1; idx < new_dim.size(); ++idx) {
     CHECK_NE(new_dim[idx - 1], new_dim[idx]);
   }

--- a/cinn/hlir/op/reduction_util.h
+++ b/cinn/hlir/op/reduction_util.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <iostream>
+#include <vector>
+
+#include "cinn/common/cinn_value.h"
+#include "cinn/common/target.h"
+#include "cinn/hlir/framework/op.h"
+#include "cinn/ir/tensor.h"
+
+namespace cinn {
+namespace hlir {
+namespace op {
+namespace util {
+
+framework::shape_t GetShape(const ir::Tensor& x);
+
+framework::shape_t CheckAndValidReduceDim(const framework::shape_t& dim, const size_t rank);
+
+enum class ReduceFuncType : int {
+  Reduce = 0,
+  BlockReduce,
+  BlockReduceInternal,
+  ReduceWithInternal,
+  ReduceForSmallerDim
+};
+
+std::string ReduceFuncType2String(const ReduceFuncType& reduce_func_type);
+
+ReduceFuncType SelectReduceFuncType(const std::vector<ir::Expr>& input_shape,
+                                    const framework::shape_t& dim,
+                                    const common::Target& target);
+
+std::vector<ir::Tensor> RunReduceCompute(const ReduceFuncType& reduce_func_type,
+                                         const std::string& op_name,
+                                         const ir::Tensor& x,
+                                         const framework::shape_t& dim,
+                                         bool keep_dim                  = false,
+                                         const std::string& output_name = UniqName("T_reduce_out"));
+
+void RunReduceSchedule(const ReduceFuncType& reduce_func_type,
+                       const std::vector<ir::Expr>& input_shape,
+                       const framework::shape_t& dim,
+                       const common::Target& target,
+                       common::CINNValuePack* arg_pack);
+
+}  // namespace util
+}  // namespace op
+}  // namespace hlir
+}  // namespace cinn

--- a/cinn/hlir/pass/elementwise_reduce_fuse_pass.cc
+++ b/cinn/hlir/pass/elementwise_reduce_fuse_pass.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <unordered_set>
+
+#include "cinn/hlir/framework/graph.h"
+#include "cinn/hlir/framework/node.h"
+#include "cinn/hlir/framework/op.h"
+#include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/pass/use_pass.h"
+#include "cinn/utils/string.h"
+
+namespace cinn {
+namespace hlir {
+namespace pass {
+
+using common::GraphNode;
+using common::Type;
+using framework::Graph;
+using framework::Node;
+using framework::NodeData;
+using framework::Operator;
+using framework::OpPatternKind;
+
+void ElementwiseReduceFusePass(Graph* graph) {}
+
+}  // namespace pass
+}  // namespace hlir
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(ElementwiseReduceFuse) {
+  CINN_REGISTER_PASS(ElementwiseReduceFuse)
+      .describe("This pass fuse elementwise and reduce op.")
+      .set_change_structure(false)
+      .set_body(cinn::hlir::pass::ElementwiseReduceFusePass);
+
+  return true;
+}

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -970,7 +970,7 @@ std::vector<Tensor> PoolImpl(const Tensor &tensor,
   Tensor temp;
   Tensor res;
   if (pool_type == "max") {
-    Expr min_value = lang::min_value(tensor->type());
+    Expr min_value = ir::Minimum(tensor->type());
     // Pad the input tensor with the pad_value of type's minimum value
     temp = do_pad ? Pad(tensor, pad_before, pad_after, min_value, UniqName("pad_temp")) : tensor;
     res  = Compute(

--- a/cinn/hlir/pe/reduction.h
+++ b/cinn/hlir/pe/reduction.h
@@ -250,6 +250,75 @@ std::vector<ir::Tensor> BlockReduceMin(const ir::Tensor& A,
                                        const bool keep_dim            = false,
                                        const std::string& output_name = "T_Block_Reduce_Min_out");
 
+/**
+ * @brief sums array elements over a given axis
+ *
+ * @param A The input Tensor
+ * @param axes Axis or axes along which a sum is performed. If axis is empty, the operation will sum over all elements
+ * of the input array. If axis is negative it counts from the last to the first axis.
+ * @param keep_dim If it is set true, the axes which are reduced are left in the result as dimensions with size one.
+ * With this option, the result will broadcast correctly against the input array.
+ * @param initial Starting value for the sum.
+ * @param output_name The name of the output Tensor
+ *
+ * @return The result Tensors.
+ */
+std::vector<ir::Tensor> ReduceSumForSmallerDim(const ir::Tensor& A,
+                                               const std::vector<int>& axes,
+                                               bool keep_dim                  = false,
+                                               const std::string& output_name = "T_Reduce_Sum_out");
+
+/**
+ * @brief product array elements over a given axis
+ *
+ * @param A The input Tensor
+ * @param axes Axis or axes along which a production is performed. If axis is empty, the operation will product over all
+ * elements of the input array. If axis is negative it counts from the last to the first axis.
+ * @param keep_dim If it is set true, the axes which are reduced are left in the result as dimensions with size one.
+ * With this option, the result will broadcast correctly against the input array.
+ * @param output_name The name of the output Tensor
+ *
+ * @return The result Tensors.
+ */
+std::vector<ir::Tensor> ReduceProdForSmallerDim(const ir::Tensor& A,
+                                                const std::vector<int>& axes,
+                                                bool keep_dim                  = false,
+                                                const std::string& output_name = "T_Reduce_Prod_out");
+
+/**
+ * @brief find the maxium of array elements over a given axis
+ *
+ * @param A The input Tensor
+ * @param axes Axis or axes to find the maximum over. If axis is empty, the operation will product over all elements of
+ * the input array. If axis is negative it counts from the last to the first axis.
+ * @param keep_dim If it is set true, the axes which are reduced are left in the result as dimensions with size one.
+ * With this option, the result will broadcast correctly against the input array.
+ * @param output_name The name of the output Tensor
+ *
+ * @return The result Tensor.
+ */
+std::vector<ir::Tensor> ReduceMaxForSmallerDim(const ir::Tensor& A,
+                                               const std::vector<int>& axes,
+                                               bool keep_dim                  = false,
+                                               const std::string& output_name = "T_Reduce_Max_out");
+
+/**
+ * @brief find the minimum of array elements over a given axis
+ *
+ * @param A The input Tensor
+ * @param axes Axis or axes to find the minimum over. If axis is empty, the operation will product over all elements of
+ * the input array. If axis is negative it counts from the last to the first axis.
+ * @param keep_dim If it is set true, the axes which are reduced are left in the result as dimensions with size one.
+ * With this option, the result will broadcast correctly against the input array.
+ * @param output_name The name of the output Tensor
+ *
+ * @return The result Tensor.
+ */
+std::vector<ir::Tensor> ReduceMinForSmallerDim(const ir::Tensor& A,
+                                               const std::vector<int>& axes,
+                                               bool keep_dim                  = false,
+                                               const std::string& output_name = "T_Reduce_Min_out");
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -168,6 +168,11 @@ void CudaScheduleBlockReduceInternal(poly::StageMap stages,
 void CudaScheduleBlockReduce(
     poly::StageMap stages, ir::Tensor reduce_tmp_out, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target);
 
+void CudaScheduleReduceForSmallerDim(poly::StageMap stages,
+                                     const std::vector<int> &axes,
+                                     ir::Tensor tmp_out,
+                                     ir::Tensor out);
+
 void CudaScheduleDepthwiseConv(poly::StageMap stages, ir::Tensor &output, const common::Target &target);
 
 void CudaScheduleConv(poly::StageMap stages,

--- a/cinn/ir/CMakeLists.txt
+++ b/cinn/ir/CMakeLists.txt
@@ -3,6 +3,7 @@ core_gather_headers()
 gather_srcs(cinnapi_src SRCS
     ir.cc
     ir_base.cc
+    ir_constant.cc
     ir_schedule.cc
     ir_visitor.cc
     ir_printer.cc

--- a/cinn/ir/ir.h
+++ b/cinn/ir/ir.h
@@ -30,6 +30,7 @@
 #include "cinn/common/type.h"
 #include "cinn/ir/function_base.h"
 #include "cinn/ir/ir_base.h"
+#include "cinn/ir/ir_constant.h"
 #include "cinn/utils/small_vector.h"
 
 namespace cinn {

--- a/cinn/ir/ir_base.cc
+++ b/cinn/ir/ir_base.cc
@@ -53,18 +53,6 @@ std::ostream &operator<<(std::ostream &os, IrNodeTy type) {
   return os;
 }
 
-Expr Zero(const Type &type) {
-  if (type.is_float(32)) return Expr(0.f);
-  if (type.is_float(64)) return Expr(double(0.));  // NOLINT
-  if (type.is_bool()) return Expr(false);
-  if (type.is_int(32)) return Expr(int32_t(0));
-  if (type.is_int(64)) return Expr(int64_t(0));
-  if (type.is_uint(32)) return Expr(uint32_t(0));
-  if (type.is_uint(64)) return Expr(uint64_t(0));
-  CINN_NOT_IMPLEMENTED
-  return Expr();
-}
-
 Expr::Expr(const Var &var) { *static_cast<IrNodeRef *>(this) = *static_cast<const IrNodeRef *>(&var); }
 
 int32_t Expr::as_int32() const {

--- a/cinn/ir/ir_base.h
+++ b/cinn/ir/ir_base.h
@@ -396,9 +396,6 @@ struct BinaryOpNode : public ExprNode<T> {
   using ExprNode<T>::operands;
 };
 
-//! Zero in CINN type system.
-Expr Zero(const Type& type);
-
 #define DEVICE_API_FOR_ALL(__) \
   __(UNK)                      \
   __(Host)                     \

--- a/cinn/ir/ir_constant.cc
+++ b/cinn/ir/ir_constant.cc
@@ -1,0 +1,71 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/ir/ir_constant.h"
+
+#include <limits>
+
+namespace cinn {
+namespace ir {
+
+Expr Zero(const Type& type) {
+  if (type.is_float(32)) return Expr(0.f);
+  if (type.is_float(64)) return Expr(double(0.));  // NOLINT
+  if (type.is_bool()) return Expr(false);
+  if (type.is_int(32)) return Expr(int32_t(0));
+  if (type.is_int(64)) return Expr(int64_t(0));
+  if (type.is_uint(32)) return Expr(uint32_t(0));
+  if (type.is_uint(64)) return Expr(uint64_t(0));
+  CINN_NOT_IMPLEMENTED
+  return Expr();
+}
+
+Expr One(const Type& type) {
+  if (type.is_float(32)) return Expr(1.0f);
+  if (type.is_float(64)) return Expr(double(1.0));  // NOLINT
+  if (type.is_bool()) return Expr(true);
+  if (type.is_int(32)) return Expr(int32_t(1));
+  if (type.is_int(64)) return Expr(int64_t(1));
+  if (type.is_uint(32)) return Expr(uint32_t(1));
+  if (type.is_uint(64)) return Expr(uint64_t(1));
+  CINN_NOT_IMPLEMENTED
+  return Expr();
+}
+
+Expr Maximum(const Type& type) {
+  if (type.is_float(32)) return Expr(std::numeric_limits<float>::max());
+  if (type.is_float(64)) return Expr(std::numeric_limits<double>::max());  // NOLINT
+  if (type.is_bool()) return Expr(true);
+  if (type.is_int(32)) return Expr(std::numeric_limits<int32_t>::max());
+  if (type.is_int(64)) return Expr(std::numeric_limits<int64_t>::max());
+  if (type.is_uint(32)) return Expr(std::numeric_limits<uint32_t>::max());
+  if (type.is_uint(64)) return Expr(std::numeric_limits<uint64_t>::max());
+  CINN_NOT_IMPLEMENTED
+  return Expr();
+}
+
+Expr Minimum(const Type& type) {
+  if (type.is_float(32)) return Expr(std::numeric_limits<float>::min());
+  if (type.is_float(64)) return Expr(std::numeric_limits<double>::min());  // NOLINT
+  if (type.is_bool()) return Expr(false);
+  if (type.is_int(32)) return Expr(std::numeric_limits<int32_t>::min());
+  if (type.is_int(64)) return Expr(std::numeric_limits<int64_t>::min());
+  if (type.is_uint(32)) return Expr(std::numeric_limits<uint32_t>::min());
+  if (type.is_uint(64)) return Expr(std::numeric_limits<uint64_t>::min());
+  CINN_NOT_IMPLEMENTED
+  return Expr();
+}
+
+}  // namespace ir
+}  // namespace cinn

--- a/cinn/ir/ir_constant.h
+++ b/cinn/ir/ir_constant.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,23 +13,19 @@
 // limitations under the License.
 
 #pragma once
-#include <string>
-#include <vector>
 
-#include "cinn/ir/ir.h"
-#include "cinn/utils/type_defs.h"
+#include "cinn/ir/ir_base.h"
 
 namespace cinn {
-namespace hlir {
+namespace ir {
 
-template <typename T = int>
-std::vector<Expr> ToCinnExprs(const std::vector<T>& args) {
-  std::vector<Expr> exprs;
-  std::transform(args.begin(), args.end(), std::back_inserter(exprs), [](const T& arg) { return Expr(arg); });
-  return exprs;
-}
+Expr Zero(const Type& type);
 
-cinn::utils::ShapeType ToShapeType(const std::vector<Expr>& args);
+Expr One(const Type& type);
 
-}  // namespace hlir
+Expr Maximum(const Type& type);
+
+Expr Minimum(const Type& type);
+
+}  // namespace ir
 }  // namespace cinn

--- a/cinn/lang/builtin.cc
+++ b/cinn/lang/builtin.cc
@@ -78,41 +78,6 @@ EXTERN_CALL_IMP_NO_VEC(Asinh, asinh);
 EXTERN_CALL_IMP_NO_VEC(Atan, atan);
 EXTERN_CALL_IMP_NO_VEC(Atanh, atanh);
 
-Expr min_value(const Type& type) {
-  CHECK_EQ(type.lanes(), 1);
-#define FOR_CASE(type__)                                \
-  if (type == type_of<type__>()) {                      \
-    return Expr(std::numeric_limits<type__>::lowest()); \
-  }
-  FOR_CASE(int32_t)
-  FOR_CASE(int64_t)
-  FOR_CASE(uint32_t)
-  FOR_CASE(uint64_t)
-  FOR_CASE(float)
-  FOR_CASE(double)
-#undef FOR_CASE
-  return Expr();
-}
-
-Expr max_value(const Type& type) {
-  CHECK_EQ(type.lanes(), 1);
-
-#define FOR_CASE(type__)                             \
-  if (type == type_of<type__>()) {                   \
-    return Expr(std::numeric_limits<type__>::max()); \
-  }
-  FOR_CASE(int32_t)
-  FOR_CASE(int64_t)
-  FOR_CASE(uint32_t)
-  FOR_CASE(uint64_t)
-  FOR_CASE(float)
-  FOR_CASE(double)
-#undef FOR_CASE
-
-  CINN_NOT_IMPLEMENTED
-  return Expr();
-}
-
 Expr Abs(Expr e) {
   Type type      = e->type();
   Type bool_type = Bool(type.lanes());

--- a/cinn/lang/builtin.h
+++ b/cinn/lang/builtin.h
@@ -18,6 +18,7 @@
 
 #include "cinn/common/ir_util.h"
 #include "cinn/ir/ir.h"
+#include "cinn/ir/ir_constant.h"
 #include "cinn/ir/ir_operators.h"
 
 namespace cinn {
@@ -114,18 +115,15 @@ inline Expr ReduceMul(Expr e, const std::vector<Var>& reduce_axis, Expr initial 
   return ir::Reduce::Make(ir::Reduce::kMul, initial, e, reduce_axis);
 }
 
-Expr min_value(const Type& type);
-Expr max_value(const Type& type);
-
 inline Expr ReduceMax(Expr e, const std::vector<Var>& reduce_axis, Expr initial = Expr()) {
   if (!initial.defined()) {
-    initial = min_value(e.type());
+    initial = ir::Minimum(e.type());
   }
   return ir::Reduce::Make(ir::Reduce::kMax, initial, e, reduce_axis);
 }
 inline Expr ReduceMin(Expr e, const std::vector<Var>& reduce_axis, Expr initial = Expr()) {
   if (!initial.defined()) {
-    initial = max_value(e.type());
+    initial = ir::Maximum(e.type());
   }
   return ir::Reduce::Make(ir::Reduce::kMin, initial, e, reduce_axis);
 }

--- a/cinn/poly/stage.cc
+++ b/cinn/poly/stage.cc
@@ -730,6 +730,7 @@ Iterator Stage::Fuse(int level0, int level1) {
 }
 
 Iterator Stage::Fuse(const std::vector<int> &levels) {
+  CHECK(!levels.empty()) << "Cannot Fuse empty levels ! Please check";
   auto dims = isl_get_dim_names(transformed_domain());
   for (auto i : levels) {
     AssertAxisIsNotLocked(i);

--- a/cinn/poly/stage.h
+++ b/cinn/poly/stage.h
@@ -254,7 +254,7 @@ class Stage : public Object {
    * Create a cache Tensor and load the \p source into this buffer, replace all the reading in the readers with the
    * cache.
    * @param tensor the source memory to cache.
-   * @param memory_type the memory type, "share" for CUDA share memory, "local" for CUDA local memory.
+   * @param memory_type the memory type, "shared" for CUDA shared memory, "local" for CUDA local memory.
    * @param readers the readers of the \p tensor
    */
   ir::Tensor CacheRead(const std::string& memory_type, std::vector<ir::Tensor>& readers, poly::StageMap stages);
@@ -291,7 +291,7 @@ class Stage : public Object {
   /**
    * Create a cache for write to the original tensor.
    * @param tensor the tensor to create the cache for.
-   * @param memory_type "share" for CUDA share memory, "local" for CUDA local memory.
+   * @param memory_type "shared" for CUDA shared memory, "local" for CUDA local memory.
    */
   ir::Tensor CacheWrite(const std::string& memory_type, poly::StageMap stages, ir::Tensor& key_tensor);
 

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -30,15 +30,15 @@ class TestReduceBaseOp(OpTest):
         self.init_case()
 
     def init_case(self):
-        self.inputs = {"x": np.random.random([10, 10, 10]).astype("float32")}
-        self.dim = [0]
+        self.inputs = {"x": np.random.random([2, 3, 4]).astype("float32")}
+        self.dim = [0, 1]
         self.keep_dim = False
 
     def paddle_func(self, x):
-        return paddle.sum(x)
+        return paddle.sum(x, axis=self.dim)
 
     def cinn_func(self, builder, x):
-        return builder.reduce(x)
+        return builder.reduce(x, ReduceKind.kSum, self.dim, self.keep_dim)
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
@@ -64,7 +64,7 @@ class TestReduceBaseOp(OpTest):
 
 class TestReduceSumOp(TestReduceBaseOp):
     def paddle_func(self, x):
-        return paddle.sum(x, axis=self.dim)
+        return paddle.sum(x, axis=self.dim, keepdim=self.keep_dim)
 
     def cinn_func(self, builder, x):
         return builder.reduce(x, ReduceKind.kSum, self.dim, self.keep_dim)
@@ -98,9 +98,48 @@ class TestReduceSumCase4(TestReduceSumOp):
         self.keep_dim = True
 
 
+class TestReduceSumCase5(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([101, 50]).astype("float32")}
+        self.dim = [0]
+        self.keep_dim = False
+
+
+class TestReduceSumCase6(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([11, 50]).astype("float32")}
+        self.dim = [0]
+        self.keep_dim = False
+
+
+class TestReduceSumCase7(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": np.random.random([10, 101, 50]).astype("float32")}
+        self.dim = [1]
+        self.keep_dim = False
+
+
+class TestReduceSumCase8(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([7, 6, 5, 4, 3, 2]).astype("float32")
+        }
+        self.dim = [2, 3]
+        self.keep_dim = False
+
+
+class TestReduceSumCase9(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([7, 6, 5, 4, 3, 2]).astype("float32")
+        }
+        self.dim = [2, 3]
+        self.keep_dim = True
+
+
 class TestReduceProdOp(TestReduceBaseOp):
     def paddle_func(self, x):
-        return paddle.prod(x, axis=self.dim)
+        return paddle.prod(x, axis=self.dim, keepdim=self.keep_dim)
 
     def cinn_func(self, builder, x):
         return builder.reduce(x, ReduceKind.kProd, self.dim, self.keep_dim)
@@ -129,7 +168,7 @@ class TestReduceProdCase3(TestReduceProdOp):
 
 class TestReduceMaxOp(TestReduceBaseOp):
     def paddle_func(self, x):
-        return paddle.max(x, axis=self.dim)
+        return paddle.max(x, axis=self.dim, keepdim=self.keep_dim)
 
     def cinn_func(self, builder, x):
         return builder.reduce(x, ReduceKind.kMax, self.dim, self.keep_dim)
@@ -158,7 +197,7 @@ class TestReduceMaxCase3(TestReduceMaxOp):
 
 class TestReduceMinOp(TestReduceBaseOp):
     def paddle_func(self, x):
-        return paddle.min(x, axis=self.dim)
+        return paddle.min(x, axis=self.dim, keepdim=self.keep_dim)
 
     def cinn_func(self, builder, x):
         return builder.reduce(x, ReduceKind.kMin, self.dim, self.keep_dim)


### PR DESCRIPTION
# 背景
laplace2d模型中，reduce算子耗时特别多，经分析，原因在于CINN中现有reduce算子在`shape=[10201, 50],dim=[0]`这种shape下生成的kernel非常不合理。如图，生成的kernel是直接一个for循环遍历第0维的10201个数据，采用的kernel配置为`grid={1, 1, 1}, block={50, 1, 1}`，未能充分利用到gpu的计算能力：
![e537600393ef96703c046c0e124d146d](https://user-images.githubusercontent.com/31386411/164973592-66830ca0-4a64-40e9-adfe-aebca3538187.png)

# 问题分析
假设`shape=[a, b, c, d, e, f]，dim=[2,3]`：将shape分为三个部分：`[batch, row, col]`，其中`batch=a*b, row=c*d, col=e*f`，本问题即可描述为如何优化`col`过小（远小于`block_size=1024`），且`batch * row`过大（大于100）的情况。

此方法在此情况下的缺陷在于如下几个方面：

1. gpu利用率太低，`grid={1, 1, 1}, block={50, 1, 1}`，只起了50个线程，未能充分并行
2. 单个cuda core负担太大，每个线程需要计算10201个数据

# 优化方案
针对以上几个问题，本PR进行了如下优化：

1. 将计算步骤分开到两个kernel中，其中第一个kernel：

   1. 每个block处理若干个`col`数据（设为n），则每个block可启用`n * col`个线程
   2. 每个线程进行`row / n`次循环，并将计算结果存入`shape=[batch, n, col]`的中间结果中
   3. 起`batch`个block，充分利用并行性，每个block计算`row * col`个数据

4. 第二个kernel通过for循环n次计算中间结果，`grid={batch},block={col}`

形象描述如下：
```
loop1 :                 col_1 | col_2 | ... | col_[row_in_block]
...                        +      +     ...         +
loop_[row_per_thread] : col_1 | col_2 | ... | col_[row_in_block]
  |
  V
tmp_out               : sum_1 | sum_2 | ... | sum_[row_in_block]
  |
  V
out = sum_1 + sum_2 + ... + sum_[row_in_block]
```

生成的kernel伪代码如下：
```
if (blockIdx.x < batch) {
  if (threadIdx.x < row_in_block * col) {
    tmp_out[threadIdx.x] = 0;
    for (int i = 0; i < row_per_thread; ++i) {
      tmp_out[threadIdx.x] += input[blockIdx.x, i * row_in_block + threadIdx.x / col, threadIdx.x % col]
    }
  }
  __syncthreads();
  if (threadIdx.x < col) {
    out[blockIdx.x, threadIdx.x] = 0;
    for (int i = 0; i < row_in_block; ++i) {
      out[blockIdx.x, threadIdx.x] += tmp_out[i * col + threadIdx.x];
    }
  }
}
```

# 其它修改
本PR还修复了如下问题：

1. 将元算子实现中复杂的if-else逻辑进行了重构，移到了`reduction_util`中
2. 添加了常量`Expr`
3. 添加了对fuse参数`levels`可能为空值的检查

# TODO
1. 当`batch`较小时而`row`较大时，该方案起的`grid`较小，而每个线程需处理的数据量较大，性能还是会较低，一种解决方案是将`row / n`也算在`grid`的计算中，但这样做的问题是

   1. 需要更多的额外显存：中间结果多出了一个新的大小为`row / n`的维度
   2. 第二个kernel的计算量也会变大：原本只需for循环n次，现在假如改为只循环m次（16<m<n），需要循环`row / m`次
   3. `compute`可能需要对每个索引值判断是否越界（按本方法扩展），过多的判断也会影响性能

2. 当前生成的kernel是直接将`row / n`的循环全部展开了，在`row / n`较大时kernel生成耗时很长，且生成的kernel很大，存在内存溢出风险。