### PR TITLE
change arg arr of cuda kernel to vector<void*>

### DIFF
--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -151,13 +151,12 @@ void cinn_call_cuda_kernel(void *kernel_fn,
   // prepare void**
   VLOG(3) << "In cinn_call_cuda_kernel, grid_dim={" << grid_x << ", " << grid_y << ", " << grid_z << "}, block_dim={"
           << block_x << ", " << block_y << ", " << block_z << "}, num_args=" << num_args << ", stream=" << stream;
-  void *arr[30];
-  CHECK_LT(num_args, 30);
+  std::vector<void *> arr;
   for (int i = 0; i < num_args; i++) {
     if (args[i].type_code() == ::cinn_type_code<cinn_buffer_t *>()) {
-      arr[i] = &((cinn_buffer_t *)(args[i]))->memory;  // NOLINT
+      arr.emplace_back(&((cinn_buffer_t *)(args[i]))->memory);  // NOLINT
     } else {
-      arr[i] = args[i].data_addr();
+      arr.emplace_back(args[i].data_addr());
     }
   }
   CUDA_DRIVER_CALL(cuLaunchKernel(static_cast<CUfunction>(kernel_fn),
@@ -169,7 +168,7 @@ void cinn_call_cuda_kernel(void *kernel_fn,
                                   block_z,
                                   0,  // share memory
                                   static_cast<CUstream>(stream),
-                                  reinterpret_cast<void **>(arr),
+                                  reinterpret_cast<void **>(arr.data()),
                                   nullptr))
 }
 


### PR DESCRIPTION
原cuda kernel参数是用写死的(void*)[30]存的，现改为用vector<void*>