### PR TITLE
Optimize Reduce

### DIFF
--- a/cinn/frontend/base_builder.h
+++ b/cinn/frontend/base_builder.h
@@ -122,6 +122,21 @@ class BaseBuilder {
                        const std::vector<int>& ends,
                        const std::vector<int>& strides = {});
 
+  template <typename T>
+  Variable FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu = false) {
+    Instruction instr("fill_constant");
+    instr.SetInputs({});
+    instr.SetAttr("shape", shape);
+    instr.SetAttr("value", value);
+    instr.SetAttr("force_cpu", force_cpu);
+
+    InferShape(instr);
+    AppendInstruction(instr);
+    auto out = instr.GetOutput(0);
+    out.set_id(name);
+    return out;
+  }
+
  protected:
   void InferShape(Instruction instr) const;
 

--- a/cinn/frontend/decomposer/batch_norm.cc
+++ b/cinn/frontend/decomposer/batch_norm.cc
@@ -54,7 +54,8 @@ struct BatchNormHelper {
 
   template <typename T>
   Variable GetTensorFromScalar(T value, std::string name, const std::vector<int>& shape) {
-    return builder->BroadcastTo(builder->ConstScalar<T>(value, common::UniqName(name)), shape, {0});
+    // return builder->BroadcastTo(builder->ConstScalar<T>(value, common::UniqName(name)), shape, {0});
+    return builder->FillConstant<T>(shape, value, common::UniqName(name));
   }
 
   std::vector<Variable> MeanAndVariance(Variable x) {

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -167,21 +167,6 @@ class NetBuilder : public BaseBuilder {
                                    const std::string& data_format       = "NCHW",
                                    const std::string& padding_algorithm = "EXPLICIT");
 
-  template <typename T>
-  Variable FillConstant(const std::vector<int>& shape, float value, const std::string& name, bool force_cpu = false) {
-    Instruction instr("fill_constant");
-    instr.SetInputs({});
-    instr.SetAttr("shape", shape);
-    instr.SetAttr("value", value);
-    instr.SetAttr("force_cpu", force_cpu);
-
-    InferShape(instr);
-    AppendInstruction(instr);
-    auto out = instr.GetOutput(0);
-    out.set_id(name);
-    return out;
-  }
-
  protected:
   Variable ElementwiseOp(const std::string& op_type, const Variable& lhs, const Variable& rhs, int axis = -1);
 };

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -326,7 +326,8 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const Node* node) {
   for (int i = 0; i < C->size() - 1; i++) {
     ir::Expr temp = C[i];
     // checkout whether the tensor is with buffer.
-    if (!temp.as_tensor_ref()->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) {
+    if ((!temp.as_tensor_ref()->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) &&
+        !stages[temp.as_tensor_ref()]->inlined()) {
       inputs.push_back(temp.as_tensor_ref());
     }
   }
@@ -498,7 +499,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const std::vector<Node*>& 
   // args order: inputs + final output + fetch outputs + other no_fused outputs
   for (auto& tensor : outputs) {
     // checkout the tensor is with buffer.
-    if (!tensor->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) {
+    if ((!tensor->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) && !stages[tensor]->inlined()) {
       inputs.push_back(tensor);
     }
   }
@@ -1276,7 +1277,8 @@ std::vector<ir::LoweredFunc> GraphCompiler::NodeToLoweredFunc(const hlir::framew
   for (int i = 0; i < C->size() - 1; ++i) {
     ir::Expr temp = C[i];
     // checkout whether the tensor is with buffer.
-    if (!temp.as_tensor_ref()->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) {
+    if ((!temp.as_tensor_ref()->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) &&
+        !stages[temp.as_tensor_ref()]->inlined()) {
       // inputs is reused as args of LowerVec, so we add output Tensor here.
       inputs.push_back(temp.as_tensor_ref());
     }

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -658,7 +658,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
 
       OpLowerer op_lowerer(dtype_dict, shape_dict, target_);
       for (auto& group : graph_->fusion_groups) {
-        LOG(INFO) << group->group_id;
+        VLOG(3) << group->group_id;
         groups.push_back(std::move(group->CollectNodes()));
         // set node as output node from fetch_var_ids.
         for (auto node : groups.back()) {

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -657,7 +657,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
 
       OpLowerer op_lowerer(dtype_dict, shape_dict, target_);
       for (auto& group : graph_->fusion_groups) {
-        VLOG(11) << group->group_id;
+        LOG(INFO) << group->group_id;
         groups.push_back(std::move(group->CollectNodes()));
         // set node as output node from fetch_var_ids.
         for (auto node : groups.back()) {
@@ -674,7 +674,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
         }
         local_lowered_funcs.emplace_back(std::move(op_lowerer.Lower(group)));
         CHECK_EQ(local_lowered_funcs.back().size(), 1) << "Lowerd Function Is Not Equal 1!";
-        VLOG(11) << local_lowered_funcs.back()[0];
+        VLOG(3) << local_lowered_funcs.back()[0];
       }
     } else {
       for (int i = 0; i < groups.size(); i++) {

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -185,6 +185,34 @@ TEST(OP_LOWERING, Reduce_Test_0) {
   }
 }
 
+TEST(OP_LOWERING, Reduce_Test_0_0) {
+  int h = 32, w = 32;
+  NetBuilder net_builder("Reduce_Test_0_0");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {w, h}, "A");
+    auto B = net_builder.Reduce(A, ReduceKind::kSum, {0});
+  }
+
+  auto program = net_builder.Build();
+  auto target  = GetTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    LOG(INFO) << lowered_func[0];
+    CodeGen(lowered_func[0]);
+  }
+}
+
 TEST(OP_LOWERING, Reduce_Test_1) {
   int h = 32, w = 32;
   NetBuilder net_builder("Reduce_Test_1");
@@ -337,7 +365,7 @@ TEST(OP_LOWERING, Reduce_Test_5) {
   CHECK_EQ(graph->fusion_groups.size(), 3);
 
   hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
-  // CHECK_EQ(graph->fusion_groups.size(), 2);
+  CHECK_EQ(graph->fusion_groups.size(), 1);
 
   auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
   auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
@@ -375,7 +403,7 @@ TEST(OP_LOWERING, Reduce_Test_6) {
   CHECK_EQ(graph->fusion_groups.size(), 3);
 
   hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
-  // CHECK_EQ(graph->fusion_groups.size(), 2);
+  CHECK_EQ(graph->fusion_groups.size(), 1);
 
   auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
   auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
@@ -452,6 +480,8 @@ TEST(OP_LOWERING, Reduce_Test_8) {
 
   hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
   CHECK_EQ(graph->fusion_groups.size(), 1);
+
+  LOG(INFO) << graph->Visualize();
 
   auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
   auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -533,7 +533,7 @@ TEST(OP_LOWERING, Reduce_Test_9) {
 
 TEST(OP_LOWERING, Reduce_Test_10) {
   int h = 10201, w = 50;
-  NetBuilder net_builder("Reduce_Test_9");
+  NetBuilder net_builder("Reduce_Test_10");
   // create model
   {
     auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
@@ -549,6 +549,76 @@ TEST(OP_LOWERING, Reduce_Test_10) {
   auto graph = std::make_shared<hlir::framework::Graph>(program, target);
   hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
   CHECK_EQ(graph->fusion_groups.size(), 1);
+
+  hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
+  CHECK_EQ(graph->fusion_groups.size(), 1);
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    LOG(INFO) << lowered_func[0];
+    CodeGen(lowered_func[0]);
+  }
+}
+
+TEST(OP_LOWERING, Reduce_Test_11) {
+  int n = 128, c = 128, h = 16, w = 16;
+  NetBuilder net_builder("Reduce_Test_11");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {n, c, h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {n, c, h, w}, "B");
+    auto D = net_builder.ElementwiseAdd(A, B);
+    auto E = net_builder.Reduce(D, ReduceKind::kSum, {0, 2, 3});
+    auto F = net_builder.Reduce(D, ReduceKind::kSum, {0, 2, 3});
+  }
+
+  auto program = net_builder.Build();
+  auto target  = GetTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  CHECK_EQ(graph->fusion_groups.size(), 3);
+
+  hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
+  CHECK_EQ(graph->fusion_groups.size(), 1);
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    LOG(INFO) << lowered_func[0];
+    CodeGen(lowered_func[0]);
+  }
+}
+
+TEST(OP_LOWERING, Reduce_Test_12) {
+  int n = 128, c = 128, h = 112, w = 112;
+  NetBuilder net_builder("Reduce_Test_12");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {n, c, h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {n, c, h, w}, "B");
+    auto D = net_builder.ElementwiseAdd(A, B);
+    auto E = net_builder.Reduce(D, ReduceKind::kSum, {0, 2, 3});
+    auto F = net_builder.Reduce(D, ReduceKind::kSum, {0, 2, 3});
+  }
+
+  auto program = net_builder.Build();
+  auto target  = GetTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  CHECK_EQ(graph->fusion_groups.size(), 3);
 
   hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
   CHECK_EQ(graph->fusion_groups.size(), 1);

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -481,8 +481,6 @@ TEST(OP_LOWERING, Reduce_Test_8) {
   hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
   CHECK_EQ(graph->fusion_groups.size(), 1);
 
-  LOG(INFO) << graph->Visualize();
-
   auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
   auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
 
@@ -517,6 +515,40 @@ TEST(OP_LOWERING, Reduce_Test_9) {
   auto graph = std::make_shared<hlir::framework::Graph>(program, target);
   hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
   CHECK_EQ(graph->fusion_groups.size(), 5);
+
+  hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
+  CHECK_EQ(graph->fusion_groups.size(), 1);
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    LOG(INFO) << lowered_func[0];
+    CodeGen(lowered_func[0]);
+  }
+}
+
+TEST(OP_LOWERING, Reduce_Test_10) {
+  int h = 10201, w = 50;
+  NetBuilder net_builder("Reduce_Test_9");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {w}, "B");
+    auto C = net_builder.Reduce(A, ReduceKind::kSum, {0});
+    auto D = net_builder.ElementwiseAdd(B, C);
+  }
+
+  auto program = net_builder.Build();
+  auto target  = GetTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  CHECK_EQ(graph->fusion_groups.size(), 1);
 
   hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
   CHECK_EQ(graph->fusion_groups.size(), 1);

--- a/cinn/hlir/op/reduction.cc
+++ b/cinn/hlir/op/reduction.cc
@@ -34,32 +34,18 @@ using common::CINNValuePack;
 using framework::OpStrategy;
 using framework::shape_t;
 using framework::StrategyFunction;
-using ReduceFunc =
-    std::function<ir::Tensor(const ir::Tensor &, const std::vector<int> &, const bool, Expr, const std::string &)>;
-using BlockReduceInternalFunc = std::function<std::vector<ir::Tensor>(
-    const ir::Tensor &, const std::vector<int> &, const bool, const std::string &)>;
-using BlockReduceFunc         = std::function<std::vector<ir::Tensor>(
-    const ir::Tensor &, const std::vector<int> &, const int, const bool, const std::string &)>;
-using BlockShuffleFunc        = std::function<std::vector<ir::Tensor>(
+
+using ReduceFunc = std::function<std::vector<ir::Tensor>(
     const ir::Tensor &, const std::vector<int> &, const bool, const std::string &)>;
 
-#define StrategyForReduction(                                                                                 \
-    op_name_, reduce_op_, reduce_func_, block_reduce_internal_func_, block_reduce_func_, block_shuffle_func_) \
-  std::shared_ptr<OpStrategy> StrategyFor##reduce_op_(const framework::NodeAttr &attrs,                       \
-                                                      const std::vector<ir::Tensor> &inputs,                  \
-                                                      const std::vector<Type> &out_type,                      \
-                                                      const std::vector<std::vector<int>> &output_shapes,     \
-                                                      const Target &target) {                                 \
-    return StrategyForReduce(attrs,                                                                           \
-                             inputs,                                                                          \
-                             out_type,                                                                        \
-                             output_shapes,                                                                   \
-                             target,                                                                          \
-                             #op_name_,                                                                       \
-                             reduce_func_,                                                                    \
-                             block_reduce_internal_func_,                                                     \
-                             block_reduce_func_,                                                              \
-                             block_shuffle_func_);                                                            \
+#define StrategyForReduction(op_name_, reduce_op_, block_reduce_func_, block_shuffle_func_)                  \
+  std::shared_ptr<OpStrategy> StrategyFor##reduce_op_(const framework::NodeAttr &attrs,                      \
+                                                      const std::vector<ir::Tensor> &inputs,                 \
+                                                      const std::vector<Type> &out_type,                     \
+                                                      const std::vector<std::vector<int>> &output_shapes,    \
+                                                      const Target &target) {                                \
+    return StrategyForReduce(                                                                                \
+        attrs, inputs, out_type, output_shapes, target, #op_name_, block_reduce_func_, block_shuffle_func_); \
   }
 
 std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
@@ -68,30 +54,28 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
                                               const std::vector<std::vector<int>> &output_shapes,
                                               const Target &target,
                                               const std::string &op_name,
-                                              const ReduceFunc &reduce_func,
-                                              const BlockReduceInternalFunc &block_reduce_internal_func,
-                                              const BlockReduceFunc &block_reduce_func,
-                                              const BlockShuffleFunc &block_shuffle_func) {
-  std::vector<int> dim;
-  bool keep_dim = false;
+                                              ReduceFunc block_reduce_func,
+                                              ReduceFunc block_shuffle_func) {
+  std::vector<int> reduce_axes;
   if (attrs.attr_store.count("dim")) {
-    dim = absl::get<std::vector<int>>(attrs.attr_store.at("dim"));
-    if (dim.empty()) {
+    reduce_axes = absl::get<std::vector<int>>(attrs.attr_store.at("dim"));
+    if (reduce_axes.empty()) {
       for (int i = 0; i < inputs[0]->shape.size(); ++i) {
-        dim.push_back(i);
+        reduce_axes.push_back(i);
       }
     }
-    std::sort(dim.begin(), dim.end());
-    // check dim
-    CHECK_LE(dim.size(), inputs[0]->shape.size());
-    CHECK_LT(dim.back(), inputs[0]->shape.size());
-    for (int idx = 1; idx < dim.size(); ++idx) {
-      CHECK_NE(dim[idx - 1], dim[idx]);
+    std::sort(reduce_axes.begin(), reduce_axes.end());
+    // check reduce_axes
+    CHECK_LE(reduce_axes.size(), inputs[0]->shape.size());
+    CHECK_LT(reduce_axes.back(), inputs[0]->shape.size());
+    for (int idx = 1; idx < reduce_axes.size(); ++idx) {
+      CHECK_NE(reduce_axes[idx - 1], reduce_axes[idx]);
     }
   } else {
     LOG(FATAL) << "reduce dimension is not set!";
   }
 
+  bool keep_dim = false;
   if (attrs.attr_store.count("keep_dim")) {
     keep_dim = absl::get<bool>(attrs.attr_store.at("keep_dim"));
   }
@@ -115,25 +99,6 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
     }
   };
 
-  // compute reduce args
-  int succesive_dim_idx     = dim.back();
-  bool reduce_dim_succesive = true;
-  int last_succesive_dim    = inputs[0]->shape[dim.back()].as_int32();
-  for (int idx = dim.size() - 2; idx >= 0; --idx) {
-    if (dim[idx] != dim[idx + 1] - 1) {
-      succesive_dim_idx    = idx + 1;
-      reduce_dim_succesive = false;
-      break;
-    } else {
-      if (last_succesive_dim * inputs[0]->shape[dim[idx]].as_int32() > 1024) {
-        succesive_dim_idx    = idx + 1;
-        reduce_dim_succesive = false;
-        break;
-      }
-      last_succesive_dim *= inputs[0]->shape[dim[idx]].as_int32();
-    }
-  }
-
   framework::CINNCompute reduction_compute([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input argument of " << op_name << " compute is empty! Please check.";
     CINNValuePack a = args[0];
@@ -141,109 +106,88 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
     Expr x_expr = a[0];
     CHECK(x_expr.as_tensor());
     ir::Tensor x = x_expr.as_tensor_ref();
-    if (target == common::DefaultNVGPUTarget() && !WithoutLastDimInReduce(inputs[0]->shape, dim)) {
-      // the reduce dimension is succesive
-      if (reduce_dim_succesive) {
-        if (last_succesive_dim <= 1024) {
-          VLOG(3) << "Do BlockReduceInternal Compute!";
-          // if the succesive reduce dimension size <= 1024
-          auto res = block_reduce_internal_func(x, dim, keep_dim, UniqName(op_name + "_out"));
-          CHECK_EQ(res.size(), 2);
-          auto stages = CreateStages(res);
-          *ret        = CINNValuePack{{CINNValue(res[0]), CINNValue(res[1]), CINNValue(stages)}};
-        } else {
-          VLOG(3) << "Do BlockReduce Compute!";
-          /*
-          auto res    = pe::TwoStepBlockReduceInternal(x, dim, keep_dim, UniqName(op_name + "_out"));
-          auto stages = CreateStages(res);
-          std::vector<CINNValue> cinn_values;
-          for (auto &t : res) {
-            cinn_values.emplace_back(t);
-          }
-          cinn_values.emplace_back(stages);
-          *ret = CINNValuePack{cinn_values};
-          */
-        }
-      } else /* the reduce dimension is not succesive */ {
-        VLOG(3) << "Do Reduce And BlockReduceInternal Compute!";
-        // compute the parallel reduce dimension size
-        int last_succesive_dim_tmp = last_succesive_dim;
-        std::vector<int> first_reduce_axes(dim.begin(), dim.begin() + succesive_dim_idx);
-        std::vector<int> second_reduce_axes(dim.begin() + succesive_dim_idx, dim.end());
-        if (!keep_dim) {
-          for (auto &axis : second_reduce_axes) {
-            axis -= first_reduce_axes.size();
-          }
-        }
-        // TODO(sunli) : support last dimension size over 1024
-        CHECK_LE(last_succesive_dim_tmp, 1024) << "last dimension size is over 1024";
-        // first: do reduce without last dimension
-        auto out = reduce_func(x, first_reduce_axes, keep_dim, Expr(), UniqName(op_name + "_out"));
-        // second: do reduce on last dimension
-        auto res = block_reduce_internal_func(out, second_reduce_axes, keep_dim, UniqName(op_name + "_out"));
-        CHECK_EQ(res.size(), 2);
-        auto stages = CreateStages({res[0], res[1], out});
-        *ret        = CINNValuePack{{CINNValue(res[0]), CINNValue(res[1]), CINNValue(out), CINNValue(stages)}};
+    if (target == common::DefaultNVGPUTarget() && !WithoutLastDimInReduce(inputs[0]->shape, reduce_axes)) {
+      VLOG(3) << "Do Two Step Block Reduce Compute!";
+      auto res    = block_reduce_func(x, reduce_axes, keep_dim, UniqName(op_name + "_out"));
+      auto stages = CreateStages(res);
+
+      std::vector<CINNValue> cinn_values;
+      for (auto &t : res) {
+        cinn_values.emplace_back(t);
       }
+      cinn_values.emplace_back(stages);
+      *ret = CINNValuePack{cinn_values};
     } else {
-      VLOG(3) << "Do ReduceSum Compute!";
-      auto out    = block_shuffle_func(x, dim, keep_dim, UniqName(op_name + "_out"));
-      auto stages = CreateStages(out);
-      if (out.size() == 1) {
-        *ret = CINNValuePack{{CINNValue(out[0]), CINNValue(stages)}};
-      } else {
-        *ret = CINNValuePack{{CINNValue(out[0]), CINNValue(out[1]), CINNValue(out[2]), CINNValue(stages)}};
+      VLOG(3) << "Do Block Shuffle Reduce Compute!";
+      auto res    = block_shuffle_func(x, reduce_axes, keep_dim, UniqName(op_name + "_out"));
+      auto stages = CreateStages(res);
+
+      std::vector<CINNValue> cinn_values;
+      for (auto &t : res) {
+        cinn_values.emplace_back(t);
       }
+      cinn_values.emplace_back(stages);
+      *ret = CINNValuePack{cinn_values};
     }
   });
 
   framework::CINNSchedule reduction_schedule([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input argument of " << op_name << " schedule is empty! Please check.";
     CINNValuePack arg_pack = args[0];
-    CHECK(arg_pack.size() == 2UL || arg_pack.size() == 3UL || arg_pack.size() == 4UL);
+    CHECK(arg_pack.size() == 2UL || arg_pack.size() == 3UL || arg_pack.size() == 4UL || arg_pack.size() == 5UL);
     if (target.arch == Target::Arch::NVGPU) {
-      if (!WithoutLastDimInReduce(inputs[0]->shape, dim)) {
-        if (reduce_dim_succesive) {
-          CHECK_EQ(arg_pack.size(), 3UL);
+      if (!WithoutLastDimInReduce(inputs[0]->shape, reduce_axes)) {
+        if (arg_pack.size() == 3) {
           Expr out              = arg_pack[0];
           Expr tmp_out          = arg_pack[1];
           poly::StageMap stages = arg_pack.back();
-
-          VLOG(3) << "Do CudaScheduleBlockReduceInternal Schedule!";
-          pe::CudaScheduleBlockReduceInternal(
+          VLOG(3) << "Do CudaBlockReduceInternalSchedule Schedule!";
+          pe::CudaBlockReduceInternalSchedule(
               stages, tmp_out.as_tensor_ref(), out.as_tensor_ref(), common::DefaultNVGPUTarget());
-        } else {
-          CHECK_EQ(arg_pack.size(), 4UL);
+        } else if (arg_pack.size() == 4) {
           Expr out              = arg_pack[0];
           Expr tmp_out          = arg_pack[1];
           Expr reduce_tmp_out   = arg_pack[2];
           poly::StageMap stages = arg_pack.back();
-
-          VLOG(3) << "Do CudaScheduleBlockReduce Schedule!";
-          pe::CudaScheduleBlockReduce(stages,
+          VLOG(3) << "Do CudaBlockReduceSchedule Schedule!";
+          pe::CudaBlockReduceSchedule(stages,
                                       reduce_tmp_out.as_tensor_ref(),
                                       tmp_out.as_tensor_ref(),
                                       out.as_tensor_ref(),
                                       common::DefaultNVGPUTarget());
+        } else {
+          Expr out              = arg_pack[0];
+          Expr tmp_out          = arg_pack[1];
+          Expr reduce_tmp_out   = arg_pack[2];
+          Expr reshape          = arg_pack[3];
+          poly::StageMap stages = arg_pack.back();
+          VLOG(3) << "Do CudaTwoStepReduceSchedule Schedule!";
+          pe::CudaTwoStepReduceSchedule(stages,
+                                        reshape.as_tensor_ref(),
+                                        reduce_tmp_out.as_tensor_ref(),
+                                        tmp_out.as_tensor_ref(),
+                                        out.as_tensor_ref(),
+                                        common::DefaultNVGPUTarget());
         }
       } else {
         if (arg_pack.size(), 2) {
           Expr reduce_out       = arg_pack[0];
           poly::StageMap stages = arg_pack.back();
-          VLOG(3) << "Do CudaScheduleReduce Schedule!";
-          pe::CudaScheduleReduce(stages, reduce_out.as_tensor_ref(), inputs[0]->shape.size() - dim.back() - 1, target);
+          VLOG(3) << "Do CudaReduceSchedule Schedule!";
+          pe::CudaReduceSchedule(
+              stages, reduce_out.as_tensor_ref(), inputs[0]->shape.size() - reduce_axes.back() - 1, target);
         } else {
           CHECK_EQ(arg_pack.size(), 4) << "args is not equal 4!";
           Expr reduce_reshape   = arg_pack[2];
           Expr reduce_internal  = arg_pack[2];
           Expr reduce_out       = arg_pack[0];
           poly::StageMap stages = arg_pack.back();
-          VLOG(3) << "Do CudaScheduleShuffleReduce Schedule!";
-          pe::CudaScheduleShuffleReduce(stages,
-                                        reduce_reshape.as_tensor_ref(),
-                                        reduce_internal.as_tensor_ref(),
-                                        reduce_out.as_tensor_ref(),
-                                        target);
+          VLOG(3) << "Do CudaBlockShuffleReduceSchedule Schedule!";
+          pe::CudaBlockShuffleReduceSchedule(stages,
+                                             reduce_reshape.as_tensor_ref(),
+                                             reduce_internal.as_tensor_ref(),
+                                             reduce_out.as_tensor_ref(),
+                                             target);
         }
       }
     }
@@ -330,18 +274,10 @@ std::vector<std::vector<std::string>> InferLayoutForBnOptimize(const std::vector
   return {{"", ""}, {"", ""}};
 }
 
-StrategyForReduction(
-    reduce_sum, ReduceSum, pe::ReduceSum, pe::BlockReduceSumInternal, pe::BlockReduceSum, pe::BlockShuffleReduceSum);
-StrategyForReduction(reduce_prod,
-                     ReduceProd,
-                     pe::ReduceProd,
-                     pe::BlockReduceProdInternal,
-                     pe::BlockReduceProd,
-                     pe::BlockShuffleReduceProd);
-StrategyForReduction(
-    reduce_max, ReduceMax, pe::ReduceMax, pe::BlockReduceMaxInternal, pe::BlockReduceMax, pe::BlockShuffleReduceMax);
-StrategyForReduction(
-    reduce_min, ReduceMin, pe::ReduceMin, pe::BlockReduceMinInternal, pe::BlockReduceMin, pe::BlockShuffleReduceMin);
+StrategyForReduction(reduce_sum, ReduceSum, pe::TwoStepBlockReduceSum, pe::BlockShuffleReduceSum);
+StrategyForReduction(reduce_prod, ReduceProd, pe::TwoStepBlockReduceProd, pe::BlockShuffleReduceProd);
+StrategyForReduction(reduce_max, ReduceMax, pe::TwoStepBlockReduceMax, pe::BlockShuffleReduceMax);
+StrategyForReduction(reduce_min, ReduceMin, pe::TwoStepBlockReduceMin, pe::BlockShuffleReduceMin);
 
 #undef StrategyForReduction
 

--- a/cinn/hlir/op/reduction.cc
+++ b/cinn/hlir/op/reduction.cc
@@ -170,7 +170,7 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
                                         common::DefaultNVGPUTarget());
         }
       } else {
-        if (arg_pack.size(), 2) {
+        if (arg_pack.size() == 2) {
           Expr reduce_out       = arg_pack[0];
           poly::StageMap stages = arg_pack.back();
           VLOG(3) << "Do CudaReduceSchedule Schedule!";
@@ -179,7 +179,7 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
         } else {
           CHECK_EQ(arg_pack.size(), 4) << "args is not equal 4!";
           Expr reduce_reshape   = arg_pack[2];
-          Expr reduce_internal  = arg_pack[2];
+          Expr reduce_internal  = arg_pack[1];
           Expr reduce_out       = arg_pack[0];
           poly::StageMap stages = arg_pack.back();
           VLOG(3) << "Do CudaBlockShuffleReduceSchedule Schedule!";

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -91,11 +91,12 @@ std::pair<ir::Module, std::string> GenReduceCode(const std::vector<int>& shape,
   common::CINNValuePack cinn_input = common::CINNValuePack{{common::CINNValue(X)}};
   common::CINNValuePack rets       = impl->fcompute(cinn_input);
   rets                             = impl->fschedule(rets);
+  poly::StageMap stages            = rets.back();
 
   // the last element is a StageMap
   for (int i = 0; i < rets->size() - 1; i++) {
     Expr temp = rets[i];
-    if (!temp.as_tensor_ref()->buffer.defined()) {
+    if (!temp.as_tensor_ref()->buffer.defined() && !stages[temp.as_tensor_ref()]->inlined()) {
       inputs.push_back(temp.as_tensor_ref());
     }
   }

--- a/cinn/hlir/pass/fusion_merge_pass.cc
+++ b/cinn/hlir/pass/fusion_merge_pass.cc
@@ -297,6 +297,7 @@ class FusionMergePassHelper : public FusionHelperBase {
 
     std::unordered_set<GroupPtr, Hasher, Comparator> fusionable_consumers;
     for (auto& consumer : consumers) {
+      VLOG(3) << "Check consuemr " << consumer->group_id << " can fuse to producer " << producer->group_id;
       // check consumer exist depency
       if (IsDepency(producer, consumer, consumers)) {
         VLOG(3) << "Can't fuse consumer " << consumer->group_id << " ,As it depency others!";
@@ -645,7 +646,7 @@ class FusionMergePassHelper : public FusionHelperBase {
         }
         int parallel_threads = 1;
         for (int idx = reduce_axes.back() + 1; idx < input_shape.size(); ++idx) {
-          parallel_threads *= input_shape[reduce_axes[idx]];
+          parallel_threads *= input_shape[idx];
         }
 
         std::vector<int> tmp_axes;
@@ -706,15 +707,15 @@ class FusionMergePassHelper : public FusionHelperBase {
             if (head % idx == 0) {
               loop_times *= (head / idx);
               check_bound = false;
+              break;
             }
           }
         }
       }
 
-      if (check_bound || loop_times > max_num_threads / 4) {
+      if (check_bound) {
         return false;
       }
-
       return true;
     };
     auto broadcast_fuse_reduce = [this, elementwise_fuse_reduce](const GroupPtr& first,

--- a/cinn/hlir/pass/op_fusion_pass.cc
+++ b/cinn/hlir/pass/op_fusion_pass.cc
@@ -129,7 +129,7 @@ class OpFusionPassHelper : public FusionHelperBase {
         auto producer = producer_data->source_node.get();
         // if producer is fused.
         if (consumer_fusion->nodes_set.count(producer)) {
-          VLOG(11) << "Op " << producer->id() << " is fused.";
+          VLOG(3) << "Op " << producer->id() << " is fused.";
           continue;
         }
         // if producer data is placeholder
@@ -141,8 +141,8 @@ class OpFusionPassHelper : public FusionHelperBase {
         if (GetOpKind(producer) == framework::kOpaque) {
           continue;
         }
-        VLOG(11) << "Producer Op: " << producer->id() << ", Op Pattern: " << GetOpKind(producer)
-                 << " -> Consumer Op: " << consumer->id() << ", Op Pattern: " << GetOpKind(consumer);
+        VLOG(3) << "Producer Op: " << producer->id() << ", Op Pattern: " << GetOpKind(producer)
+                << " -> Consumer Op: " << consumer->id() << ", Op Pattern: " << GetOpKind(consumer);
         bool can_fuse = true;
         // checkout producer node outputs are all in fusion op
         for (auto& link : producer_data->outlinks()) {
@@ -156,7 +156,7 @@ class OpFusionPassHelper : public FusionHelperBase {
         }
 
         if (!can_fuse || !CanFuse(producer, consumer)) continue;
-        VLOG(11) << "Fuse Op " << producer->id() << " into Op " << consumer->id();
+        VLOG(3) << "Fuse Op " << producer->id() << " into Op " << consumer->id();
 
         // fuse producer to fusion group
         consumer_fusion->group_id = producer->id() + "_" + consumer_fusion->group_id;
@@ -518,12 +518,12 @@ void OpFusionPassInternal(Graph* graph) {
   graph->fusion_groups  = op_fusion_helper();
 
   for (auto& group : graph->fusion_groups) {
-    VLOG(11) << "Group Id : " << group->group_id;
+    VLOG(3) << "Group Id : " << group->group_id;
     for (auto& producer : group->producer_groups) {
-      VLOG(11) << "  producer group -> " << producer->group_id;
+      VLOG(3) << "  producer group -> " << producer->group_id;
     }
     for (auto& consumer : group->consumer_groups) {
-      VLOG(11) << "  consumer group -> " << consumer->group_id;
+      VLOG(3) << "  consumer group -> " << consumer->group_id;
     }
   }
 }

--- a/cinn/hlir/pe/pe_transform_test.cc
+++ b/cinn/hlir/pe/pe_transform_test.cc
@@ -327,7 +327,7 @@ TEST(Reduce, Reduce_Test_1) {
   auto C      = hlir::pe::Add(A.tensor(), B.tensor());
   auto D      = hlir::pe::ReduceSum(C, {0, 2});
   auto stages = CreateStages({C, D});
-  hlir::pe::CudaScheduleReduce(stages, D, 2, common::DefaultNVGPUTarget());
+  hlir::pe::CudaReduceSchedule(stages, D, 2, common::DefaultNVGPUTarget());
   CudaReduceReorder(stages, C, {0, 2});
   stages[C]->SetBuffer("local");
   stages[C]->SimpleComputeAt(stages[D], stages[D]->n_out_dims() - 1);
@@ -345,12 +345,6 @@ TEST(Reduce, Reduce_Test_1) {
   auto host_module_device_module = backends::SplitCudaAndHostModule(module);
   auto &host_module              = std::get<0>(host_module_device_module);
   auto &device_module            = std::get<1>(host_module_device_module);
-  for (auto &func : host_module.functions()) {
-    LOG(INFO) << "host:\n" << func;
-  }
-  for (auto &func : device_module.functions()) {
-    LOG(INFO) << "device:\n" << func;
-  }
 
   backends::CodeGenCUDA_Dev codegen(target);
   auto source_code = codegen.Compile(builder.Build());
@@ -391,12 +385,128 @@ TEST(Reduce, Reduce_Test_2) {
   auto host_module_device_module = backends::SplitCudaAndHostModule(module);
   auto &host_module              = std::get<0>(host_module_device_module);
   auto &device_module            = std::get<1>(host_module_device_module);
-  for (auto &func : host_module.functions()) {
-    LOG(INFO) << "host:\n" << func;
-  }
-  for (auto &func : device_module.functions()) {
-    LOG(INFO) << "device:\n" << func;
-  }
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_2_1) {
+  int m = 10240;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, N});
+
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {0}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 3";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[reduce_out[2]]->ComputeInline();
+  stages[reduce_out[1]]->SetBuffer("shared");
+  stages[reduce_out[1]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[0]]->Bind(0, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_2_2) {
+  int m = 10240;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {N, M, N});
+
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {1}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 3";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[reduce_out[2]]->ComputeInline();
+  stages[reduce_out[1]]->SetBuffer("shared");
+  stages[reduce_out[1]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[1]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[0]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[0]]->Bind(1, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_2_3) {
+  int m = 10240;
+  int n = 16;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, N, N});
+
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {0}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 3";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[reduce_out[2]]->ComputeInline();
+  stages[reduce_out[1]]->SetBuffer("shared");
+  stages[reduce_out[1]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[0]]->Bind(0, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
 
   backends::CodeGenCUDA_Dev codegen(target);
   auto source_code = codegen.Compile(builder.Build());
@@ -442,12 +552,419 @@ TEST(Reduce, Reduce_Test_3) {
   auto host_module_device_module = backends::SplitCudaAndHostModule(module);
   auto &host_module              = std::get<0>(host_module_device_module);
   auto &device_module            = std::get<1>(host_module_device_module);
-  for (auto &func : host_module.functions()) {
-    LOG(INFO) << "host:\n" << func;
-  }
-  for (auto &func : device_module.functions()) {
-    LOG(INFO) << "device:\n" << func;
-  }
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_3_1) {
+  int m = 10240;
+  Expr M(m);
+
+  Placeholder<float> A("A", {M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {0}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape[0].as_int32();
+  LOG(INFO) << reduce_out[1]->shape[0].as_int32();
+  LOG(INFO) << reduce_out[2]->shape[0].as_int32();
+  LOG(INFO) << reduce_out[3]->shape[0].as_int32() << " " << reduce_out[3]->shape[1].as_int32();
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[1]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[0]]->Bind(0, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_3_2) {
+  int m = 10240;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {N, M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {1}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape;
+  LOG(INFO) << reduce_out[1]->shape;
+  LOG(INFO) << reduce_out[2]->shape;
+  LOG(INFO) << reduce_out[3]->shape;
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[2]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[2]]->SimpleComputeAt(stages[reduce_out[1]], 0);
+  stages[reduce_out[1]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[1]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[1]]->SimpleComputeAt(stages[reduce_out[0]], 0);
+  stages[reduce_out[0]]->Bind(0, "blockIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_4) {
+  int m = 10201;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {N, M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {1}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape.size();
+  LOG(INFO) << reduce_out[1]->shape.size();
+  LOG(INFO) << reduce_out[2]->shape.size();
+  LOG(INFO) << reduce_out[3]->shape.size();
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[2]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[2]]->SimpleComputeAt(stages[reduce_out[1]], 0);
+  stages[reduce_out[1]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[1]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[1]]->SimpleComputeAt(stages[reduce_out[0]], 0);
+  stages[reduce_out[0]]->Bind(0, "blockIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_5) {
+  int m = 32;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {N, M, M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {1, 2}, false);
+  CHECK_EQ(reduce_out.size(), 2) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape.size();
+  LOG(INFO) << reduce_out[1]->shape.size();
+
+  CudaBlockReduceInternalSchedule(stages, reduce_out[1], reduce_out[0], common::DefaultNVGPUTarget());
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_6) {
+  int m = 32;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {N, N, M, M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {0, 2, 3}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape.size();
+  LOG(INFO) << reduce_out[1]->shape.size();
+  LOG(INFO) << reduce_out[2]->shape.size();
+
+  CudaBlockReduceSchedule(stages, reduce_out[2], reduce_out[1], reduce_out[0], common::DefaultNVGPUTarget());
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_7) {
+  int m = 10201;
+  int n = 64;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {N, N, M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {1, 2}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape.size();
+  LOG(INFO) << reduce_out[1]->shape.size();
+  LOG(INFO) << reduce_out[2]->shape.size();
+  LOG(INFO) << reduce_out[3]->shape.size();
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[2]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[2]]->SimpleComputeAt(stages[reduce_out[1]], 0);
+  stages[reduce_out[1]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[1]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[1]]->SimpleComputeAt(stages[reduce_out[0]], 0);
+  stages[reduce_out[0]]->Bind(0, "blockIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_8) {
+  int m = 128;
+  int n = 112;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, M, N, N});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {0, 2, 3}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[2]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[2]]->SimpleComputeAt(stages[reduce_out[1]], 0);
+  stages[reduce_out[1]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[1]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[1]]->SimpleComputeAt(stages[reduce_out[0]], 0);
+  stages[reduce_out[0]]->Bind(0, "blockIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_9) {
+  int m = 128;
+  int n = 56;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, M, N, N});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {0, 2, 3}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[2]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[2]]->SimpleComputeAt(stages[reduce_out[1]], 0);
+  stages[reduce_out[1]]->Bind(0, "blockIdx.x");
+  stages[reduce_out[1]]->Bind(1, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[1]]->SimpleComputeAt(stages[reduce_out[0]], 0);
+  stages[reduce_out[0]]->Bind(0, "blockIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_10) {
+  int m = 128;
+  int n = 128;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, N});
+  Placeholder<float> B("B", {M, N});
+
+  auto c          = hlir::pe::Add(A.tensor(), B.tensor());
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(c, {0}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, B, c, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[c]->Split(0, 8);
+  stages[c]->Fuse(1, 2);
+  stages[c]->Reorder({1, 0});
+  stages[c]->SetBuffer("local");
+  stages[c]->SimpleComputeAt(stages[reduce_out[1]], 1);
+  stages[reduce_out[2]]->ComputeInline();
+  stages[reduce_out[1]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("shared");
+  stages[reduce_out[0]]->Bind(0, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, B, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
 
   backends::CodeGenCUDA_Dev codegen(target);
   auto source_code = codegen.Compile(builder.Build());

--- a/cinn/hlir/pe/pe_transform_test.cc
+++ b/cinn/hlir/pe/pe_transform_test.cc
@@ -363,6 +363,103 @@ TEST(Reduce, Reduce_Test_1) {
 #endif
 }
 
+TEST(Reduce, Reduce_Test_2) {
+  int m = 10201;
+  int n = 50;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, N});
+
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {0}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 3";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  stages[reduce_out[2]]->ComputeInline();
+  stages[reduce_out[1]]->SetBuffer("shared");
+  stages[reduce_out[1]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[0]]->Bind(0, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+  for (auto &func : host_module.functions()) {
+    LOG(INFO) << "host:\n" << func;
+  }
+  for (auto &func : device_module.functions()) {
+    LOG(INFO) << "device:\n" << func;
+  }
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_3) {
+  int m = 10201;
+  Expr M(m);
+
+  Placeholder<float> A("A", {M});
+
+  auto reduce_out = hlir::pe::TwoStepBlockReduceSum(A.tensor(), {0}, false);
+  CHECK_EQ(reduce_out.size(), 4) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[3], reduce_out[2], reduce_out[1], reduce_out[0]});
+  LOG(INFO) << reduce_out[0]->shape[0].as_int32();
+  LOG(INFO) << reduce_out[1]->shape[0].as_int32();
+  LOG(INFO) << reduce_out[2]->shape[0].as_int32();
+  LOG(INFO) << reduce_out[3]->shape[0].as_int32() << " " << reduce_out[3]->shape[1].as_int32();
+
+  stages[reduce_out[3]]->ComputeInline();
+  stages[reduce_out[2]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[2]]->SetBuffer("local");
+  stages[reduce_out[1]]->Bind(0, "threadIdx.x");
+  stages[reduce_out[1]]->SetBuffer("local");
+  stages[reduce_out[0]]->Bind(0, "threadIdx.x");
+
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+  for (auto &func : host_module.functions()) {
+    LOG(INFO) << "host:\n" << func;
+  }
+  for (auto &func : device_module.functions()) {
+    LOG(INFO) << "device:\n" << func;
+  }
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/pe_transform_test.cc
+++ b/cinn/hlir/pe/pe_transform_test.cc
@@ -264,6 +264,7 @@ TEST(Reduce, Reduce_Test_0) {
 #endif
 }
 
+#ifdef CINN_WITH_CUDA
 void CudaReduceReorder(poly::StageMap stages, ir::Tensor input, const std::vector<int> &axes) {
   auto &shape = input->shape;
   std::vector<int> order;
@@ -312,7 +313,6 @@ TEST(Reduce, Reduce_Test_1) {
   auto func = Lower("fn", stages, {A, B, D});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -330,7 +330,6 @@ TEST(Reduce, Reduce_Test_1) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_2) {
@@ -349,7 +348,6 @@ TEST(Reduce, Reduce_Test_2) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -367,7 +365,6 @@ TEST(Reduce, Reduce_Test_2) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_2_1) {
@@ -386,7 +383,6 @@ TEST(Reduce, Reduce_Test_2_1) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -404,7 +400,6 @@ TEST(Reduce, Reduce_Test_2_1) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_2_2) {
@@ -423,7 +418,6 @@ TEST(Reduce, Reduce_Test_2_2) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -441,7 +435,6 @@ TEST(Reduce, Reduce_Test_2_2) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_2_3) {
@@ -460,7 +453,6 @@ TEST(Reduce, Reduce_Test_2_3) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -478,7 +470,6 @@ TEST(Reduce, Reduce_Test_2_3) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_3) {
@@ -497,7 +488,6 @@ TEST(Reduce, Reduce_Test_3) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -515,7 +505,6 @@ TEST(Reduce, Reduce_Test_3) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_3_1) {
@@ -534,7 +523,6 @@ TEST(Reduce, Reduce_Test_3_1) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -552,7 +540,6 @@ TEST(Reduce, Reduce_Test_3_1) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_3_2) {
@@ -572,7 +559,6 @@ TEST(Reduce, Reduce_Test_3_2) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -590,7 +576,6 @@ TEST(Reduce, Reduce_Test_3_2) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_4) {
@@ -610,7 +595,6 @@ TEST(Reduce, Reduce_Test_4) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -628,7 +612,6 @@ TEST(Reduce, Reduce_Test_4) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_5) {
@@ -647,7 +630,6 @@ TEST(Reduce, Reduce_Test_5) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -665,7 +647,6 @@ TEST(Reduce, Reduce_Test_5) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_6) {
@@ -684,7 +665,6 @@ TEST(Reduce, Reduce_Test_6) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -702,7 +682,6 @@ TEST(Reduce, Reduce_Test_6) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_7) {
@@ -722,7 +701,6 @@ TEST(Reduce, Reduce_Test_7) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -740,7 +718,6 @@ TEST(Reduce, Reduce_Test_7) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_8) {
@@ -760,7 +737,6 @@ TEST(Reduce, Reduce_Test_8) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -778,7 +754,6 @@ TEST(Reduce, Reduce_Test_8) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_9) {
@@ -798,7 +773,6 @@ TEST(Reduce, Reduce_Test_9) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -816,7 +790,6 @@ TEST(Reduce, Reduce_Test_9) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_10) {
@@ -845,7 +818,6 @@ TEST(Reduce, Reduce_Test_10) {
   auto func = Lower("fn", stages, {A, B, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -863,7 +835,6 @@ TEST(Reduce, Reduce_Test_10) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_11) {
@@ -880,7 +851,6 @@ TEST(Reduce, Reduce_Test_11) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -898,7 +868,6 @@ TEST(Reduce, Reduce_Test_11) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_12) {
@@ -915,7 +884,6 @@ TEST(Reduce, Reduce_Test_12) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -933,7 +901,6 @@ TEST(Reduce, Reduce_Test_12) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
 
 TEST(Reduce, Reduce_Test_13) {
@@ -950,7 +917,6 @@ TEST(Reduce, Reduce_Test_13) {
   auto func = Lower("fn", stages, {A, reduce_out[0]});
   LOG(INFO) << "func:\n" << func;
 
-#ifdef CINN_WITH_CUDA
   auto target = common::DefaultNVGPUTarget();
   Module::Builder builder("Concat_Builder", target);
   builder.AddFunction(func);
@@ -968,8 +934,8 @@ TEST(Reduce, Reduce_Test_13) {
   backends::NVRTC_Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
-#endif
 }
+#endif
 
 }  // namespace pe
 }  // namespace hlir

--- a/cinn/hlir/pe/pe_transform_test.cc
+++ b/cinn/hlir/pe/pe_transform_test.cc
@@ -866,6 +866,111 @@ TEST(Reduce, Reduce_Test_10) {
 #endif
 }
 
+TEST(Reduce, Reduce_Test_11) {
+  int m = 10;
+  int n = 10;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, N, N});
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {0, 1}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  CudaBlockShuffleReduceSchedule(stages, reduce_out[2], reduce_out[1], reduce_out[0], common::DefaultNVGPUTarget());
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_12) {
+  int m = 10;
+  int n = 10;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, M, N, N});
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {0, 1, 2}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  CudaBlockShuffleReduceSchedule(stages, reduce_out[2], reduce_out[1], reduce_out[0], common::DefaultNVGPUTarget());
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
+TEST(Reduce, Reduce_Test_13) {
+  int m = 16;
+  int n = 16;
+  Expr M(m), N(n);
+
+  Placeholder<float> A("A", {M, M, N, N});
+  auto reduce_out = hlir::pe::BlockShuffleReduceSum(A.tensor(), {0, 1, 2}, false);
+  CHECK_EQ(reduce_out.size(), 3) << "the output of reduce is not equal to 4!";
+  auto stages = CreateStages({A, reduce_out[2], reduce_out[1], reduce_out[0]});
+
+  CudaBlockShuffleReduceSchedule(stages, reduce_out[2], reduce_out[1], reduce_out[0], common::DefaultNVGPUTarget());
+  auto func = Lower("fn", stages, {A, reduce_out[0]});
+  LOG(INFO) << "func:\n" << func;
+
+#ifdef CINN_WITH_CUDA
+  auto target = common::DefaultNVGPUTarget();
+  Module::Builder builder("Concat_Builder", target);
+  builder.AddFunction(func);
+
+  auto module                    = builder.Build();
+  auto host_module_device_module = backends::SplitCudaAndHostModule(module);
+  auto &host_module              = std::get<0>(host_module_device_module);
+  auto &device_module            = std::get<1>(host_module_device_module);
+
+  backends::CodeGenCUDA_Dev codegen(target);
+  auto source_code = codegen.Compile(builder.Build());
+  LOG(INFO) << "compiled code:\n\n\n" << source_code;
+
+  // nv jit compile to ptx
+  backends::NVRTC_Compiler compiler;
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
+#endif
+}
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -175,36 +175,20 @@ Tensor Reduce(const Tensor& tensor,
       tensor, fn, output_shapes, real_axes, keep_dims ? std::vector<int>() : real_axes, initial, output_name);
 }
 
-Tensor ReduceSum(const Tensor& A,
-                 const std::vector<int>& axes,
-                 const bool keep_dims,
-                 ir::Expr initial,
-                 const std::string& output_name) {
-  if (!initial.defined()) {
-    initial = common::make_const(A->type(), 0);
-  }
-  return Reduce(A, axes, lang::ReduceSum, keep_dims, initial, output_name);
+Tensor ReduceSum(const Tensor& A, const std::vector<int>& axes, const bool keep_dims, const std::string& output_name) {
+  return Reduce(A, axes, lang::ReduceSum, keep_dims, ir::Expr(0.0f), output_name);
 }
 
-Tensor ReduceProd(const Tensor& A,
-                  const std::vector<int>& axes,
-                  const bool keep_dims,
-                  ir::Expr initial,
-                  const std::string& output_name) {
-  if (!initial.defined()) {
-    initial = common::make_const(A->type(), 1);
-  }
-  return Reduce(A, axes, lang::ReduceMul, keep_dims, initial, output_name);
+Tensor ReduceProd(const Tensor& A, const std::vector<int>& axes, const bool keep_dims, const std::string& output_name) {
+  return Reduce(A, axes, lang::ReduceMul, keep_dims, ir::Expr(1.0f), output_name);
 }
 
-Tensor ReduceMax(
-    const Tensor& A, const std::vector<int>& axes, const bool keep_dims, Expr initial, const std::string& output_name) {
-  return Reduce(A, axes, lang::ReduceMax, keep_dims, Expr(), output_name);
+Tensor ReduceMax(const Tensor& A, const std::vector<int>& axes, const bool keep_dims, const std::string& output_name) {
+  return Reduce(A, axes, lang::ReduceMax, keep_dims, ir::Expr(-3.402823e+38f), output_name);
 }
 
-Tensor ReduceMin(
-    const Tensor& A, const std::vector<int>& axes, const bool keep_dims, Expr initial, const std::string& output_name) {
-  return Reduce(A, axes, lang::ReduceMin, keep_dims, Expr(), output_name);
+Tensor ReduceMin(const Tensor& A, const std::vector<int>& axes, const bool keep_dims, const std::string& output_name) {
+  return Reduce(A, axes, lang::ReduceMin, keep_dims, Expr(3.402823e+38f), output_name);
 }
 
 std::vector<Tensor> WarpReduce(const ir::Tensor& A,
@@ -470,44 +454,54 @@ int GetParallelThreads(const ir::Tensor& A, const std::vector<int>& axes) {
 }
 
 ir::Tensor ReshapeInternal(const ir::Tensor& A, const std::vector<int>& axes, const std::string& output_name) {
+  bool check_bound     = true;
+  int last_stride      = A->shape[axes.back()].as_int32();
   int parallel_threads = GetParallelThreads(A, axes);
-  int times            = common::DefaultNVGPUTarget().max_num_threads() / parallel_threads;
+  int max_num_threads  = common::DefaultNVGPUTarget().max_num_threads();
   std::vector<Expr> out_shape(A->shape.begin(), A->shape.begin() + axes.back());
-  out_shape.emplace_back((A->shape[axes.back()].as_int32() + times - 1) / times);
-  out_shape.emplace_back(parallel_threads * std::min(times, A->shape[axes.back()].as_int32()));
-
-  std::vector<int> strides(out_shape.size(), 1);
-  for (int idx = out_shape.size() - 2; idx >= 0; --idx) {
-    strides[idx] *= strides[idx + 1] * out_shape[idx + 1].as_int32();
+  for (int idx = max_num_threads / parallel_threads; idx > ((max_num_threads / 2) / parallel_threads); --idx) {
+    if (last_stride % idx == 0) {
+      out_shape.emplace_back(last_stride / idx);
+      out_shape.emplace_back(idx * parallel_threads);
+      check_bound = false;
+      break;
+    }
   }
-  int total_elements = 1;
-  for (auto& shape : A->shape) {
-    total_elements *= shape.as_int32();
+
+  if (check_bound) {
+    int times = max_num_threads / parallel_threads;
+    out_shape.emplace_back((last_stride + times - 1) / times);
+    out_shape.emplace_back(times * parallel_threads);
   }
 
   std::vector<int> tail_strides(A->shape.size() - axes.back(), 1);
-  for (int idx = A->shape.size() - 1, index = tail_strides.size() - 2; index >= 0; --idx, --index) {
-    tail_strides[index] = tail_strides[index + 1] * A->shape[idx].as_int32();
+  for (int idx = tail_strides.size() - 2, index = A->shape.size() - 1; idx >= 0; --idx, --index) {
+    tail_strides[idx] = tail_strides[idx + 1] * A->shape[index].as_int32();
+  }
+
+  int tail_elements = 1;
+  for (int idx = axes.back(); idx < A->shape.size(); ++idx) {
+    tail_elements *= A->shape[idx].as_int32();
   }
   auto out = Compute(
       out_shape,
       [=](const std::vector<Expr>& indexs) -> Expr {
-        Expr index(0);
-        for (int idx = 0; idx < indexs.size(); ++idx) {
-          index = index + indexs[idx] * Expr(strides[idx]);
-        }
-        auto selected = ir::LT::Make(index, Expr(total_elements));
+        Expr index    = indexs[out_shape.size() - 2] * out_shape.back() + indexs.back();
+        auto selected = ir::LT::Make(index, Expr(tail_elements));
 
         std::vector<Expr> tmp_indexs(indexs.begin(), indexs.begin() + axes.back());
         // last and the second of last.
-        Expr tail = indexs[out_shape.size() - 2] * Expr(out_shape.back().as_int32()) + indexs.back();
         for (auto tail_stride : tail_strides) {
-          tmp_indexs.push_back(tail / tail_stride);
-          tail = tail % tail_stride;
+          tmp_indexs.push_back(index / Expr(tail_stride));
+          index = index % Expr(tail_stride);
         }
 
         CHECK_EQ(tmp_indexs.size(), A->shape.size()) << "Indexs size is not equal to Input shape!";
-        return ir::Select::Make(selected, A(tmp_indexs), Expr(0.0f));
+        if (check_bound) {
+          return ir::Select::Make(selected, A(tmp_indexs), Expr(0.0f));
+        } else {
+          return A(tmp_indexs);
+        }
       },
       UniqName(output_name));
   return out;
@@ -534,19 +528,19 @@ ir::Tensor BlockShuffleReduce(const ir::Tensor& A,
   return out;
 }
 
-#define BlockShuffleReduce(name, reduce_type, init_val)                                                               \
-  std::vector<ir::Tensor> BlockShuffleReduce##name(                                                                   \
-      const ir::Tensor& A, const std::vector<int>& axes, const bool keep_dim, const std::string& output_name) {       \
-    if (GetParallelThreads(A, axes) > common::DefaultNVGPUTarget().max_num_threads() / 2) {                           \
-      return {Reduce##name(A, axes, keep_dim, Expr(init_val), output_name)};                                          \
-    } else {                                                                                                          \
-      auto reduce_reshape  = ReshapeInternal(A, axes, output_name + "_reshape");                                      \
-      auto reduce_internal = Reduce##name(reduce_reshape, axes, keep_dim, Expr(init_val), output_name + "_internal"); \
-      reduce_internal->WithBuffer("shared");                                                                          \
-      std::vector<Expr> tail(A->shape.begin() + axes.back() + 1, A->shape.end());                                     \
-      auto reduce_out = BlockShuffleReduce(reduce_internal, tail, reduce_type, output_name);                          \
-      return {reduce_out, reduce_internal, reduce_reshape};                                                           \
-    }                                                                                                                 \
+#define BlockShuffleReduce(name, reduce_type, init_val)                                                         \
+  std::vector<ir::Tensor> BlockShuffleReduce##name(                                                             \
+      const ir::Tensor& A, const std::vector<int>& axes, const bool keep_dim, const std::string& output_name) { \
+    if (GetParallelThreads(A, axes) > common::DefaultNVGPUTarget().max_num_threads() / 2) {                     \
+      return {Reduce##name(A, axes, keep_dim, output_name)};                                                    \
+    } else {                                                                                                    \
+      auto reduce_reshape  = ReshapeInternal(A, axes, output_name + "_reshape");                                \
+      auto reduce_internal = Reduce##name(reduce_reshape, axes, keep_dim, output_name + "_internal");           \
+      reduce_internal->WithBuffer("shared");                                                                    \
+      std::vector<Expr> tail(A->shape.begin() + axes.back() + 1, A->shape.end());                               \
+      auto reduce_out = BlockShuffleReduce(reduce_internal, tail, reduce_type, output_name);                    \
+      return {reduce_out, reduce_internal, reduce_reshape};                                                     \
+    }                                                                                                           \
   }
 
 BlockShuffleReduce(Sum, "block_shuffle_sum", 0.0f);
@@ -574,7 +568,7 @@ bool WithoutLastDimInReduce(const std::vector<ir::Expr>& inshape, const std::vec
 };
 
 using ReduceFunc =
-    std::function<ir::Tensor(const ir::Tensor&, const std::vector<int>&, const bool, Expr, const std::string&)>;
+    std::function<ir::Tensor(const ir::Tensor&, const std::vector<int>&, const bool, const std::string&)>;
 using BlockReduceFunc =
     std::function<std::vector<ir::Tensor>(const ir::Tensor&, const std::vector<int>&, const bool, const std::string&)>;
 
@@ -583,9 +577,9 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
                                                    const bool keep_dim,
                                                    const std::string& output_name,
                                                    ReduceFunc reduce_func,
-                                                   BlockReduceFunc block_reduce_func,
-                                                   const float init_val) {
+                                                   BlockReduceFunc block_reduce_func) {
   CHECK(!WithoutLastDimInReduce(A->shape, axes)) << "Can't find last axis in reduce!";
+
   int index = axes.size() - 2;
   for (; index >= 0; --index) {
     if (axes[index] != axes[index + 1] - 1) {
@@ -594,11 +588,24 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
   }
   std::vector<int> first_axes(axes.begin(), axes.begin() + index + 1);
   std::vector<int> second_axes(axes.begin() + index + 1, axes.end());
-  auto lane = 1;
-  for (auto& idx : second_axes) {
-    lane *= A->shape[idx].as_int32();
+
+  int lane             = 1;
+  auto max_num_threads = common::DefaultNVGPUTarget().max_num_threads();
+  for (int idx = static_cast<int>(second_axes.size()) - 1; idx >= 0; --idx) {
+    lane *= A->shape[second_axes[idx]].as_int32();
+    if (lane >= max_num_threads / 2) {
+      for (int idy = 0; idy < idx; ++idy) {
+        first_axes.push_back(second_axes[idy]);
+      }
+      std::vector<int> tmp;
+      for (int idy = idx; idy < second_axes.size(); ++idy) {
+        tmp.push_back(second_axes[idy]);
+      }
+      second_axes = tmp;
+      break;
+    }
   }
-  auto max_num_threads     = common::DefaultNVGPUTarget().max_num_threads();
+
   bool keep_dim_first      = keep_dim;
   bool keep_dim_second     = keep_dim;
   auto reduce_reshape_func = [&first_axes,
@@ -610,18 +617,54 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
                               keep_dim,
                               output_name,
                               lane,
+                              index,
                               max_num_threads]() {
+    bool check_bound = true;
     std::vector<Expr> out_shape(A->shape.begin(), A->shape.begin() + second_axes.front());
-    first_axes.push_back(out_shape.size());
-    out_shape.emplace_back((lane + max_num_threads - 1) / max_num_threads);
-    second_axes.clear();
-    if (keep_dim) {
-      second_axes.push_back(out_shape.size());
+    if (second_axes.size() == 1) {
+      int times = 1;
+      int tail  = max_num_threads;
+      for (; tail >= max_num_threads / 2; --tail) {
+        if (lane % tail == 0) {
+          check_bound = false;
+          break;
+        }
+      }
+      if (!check_bound) {
+        times = lane / tail;
+        out_shape.emplace_back(times);
+        out_shape.emplace_back(tail);
+      } else {
+        times = (lane + max_num_threads - 1) / max_num_threads;
+        out_shape.emplace_back(times);
+        out_shape.emplace_back(max_num_threads);
+      }
     } else {
-      second_axes.push_back(out_shape.size() - first_axes.size());
+      int times = 1;
+      int head  = A->shape[second_axes.front()].as_int32();
+      int tail  = lane / head;
+      // from (1024, 512) check one size as tail.
+      for (int idx = (max_num_threads / tail); idx > (max_num_threads / 2 / tail); --idx) {
+        if (head % idx == 0) {
+          check_bound = false;
+          times       = idx;
+          tail *= idx;
+          break;
+        }
+      }
+      if (!check_bound) {
+        out_shape.emplace_back(head / times);
+        out_shape.emplace_back(tail);
+      } else {
+        times = max_num_threads / tail;
+        out_shape.emplace_back((head + times - 1) / times);
+        out_shape.emplace_back(tail * times);
+      }
     }
-    out_shape.emplace_back(max_num_threads);
+    first_axes.push_back(out_shape.size() - 2);
+
     if (keep_dim) {
+      second_axes = {static_cast<int>(out_shape.size()) - 1};
       if (out_shape.size() > A->shape.size()) {
         keep_dim_second = false;
       } else {
@@ -631,36 +674,34 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
       for (int idx = 0; idx < tail_count; ++idx) {
         out_shape.push_back(Expr(1));
       }
+    } else {
+      second_axes = {static_cast<int>(out_shape.size()) - static_cast<int>(first_axes.size()) - 1};
     }
-    std::vector<int> strides(out_shape.size(), 1);
-    for (int idx = out_shape.size() - 2; idx <= 0; ++idx) {
-      strides[idx] = strides[idx + 1] * out_shape[idx + 1].as_int32();
-    }
-    std::vector<int> tail_strides(A->shape.size() - axes.front(), 1);
-    for (int idx = tail_strides.size() - 2, index = A->shape.size() - 1; idx >= 0; --idx, --index) {
+
+    std::vector<int> tail_strides(A->shape.size() - (out_shape.size() - 2), 1);
+    for (int idx = static_cast<int>(tail_strides.size()) - 2, index = static_cast<int>(A->shape.size()) - 1; idx >= 0;
+         --idx, --index) {
       tail_strides[idx] = tail_strides[idx + 1] * A->shape[index].as_int32();
     }
-    auto total_elements = 1;
-    for (auto& shape : A->shape) {
-      total_elements *= shape.as_int32();
-    }
+
     auto out = Compute(
         out_shape,
         [=](const std::vector<Expr>& indexs) -> Expr {
-          Expr index(0);
-          for (int idx = 0; idx < strides.size(); ++idx) {
-            index = index + indexs[idx] * Expr(strides[idx]);
-          }
-          auto selected = ir::LT::Make(index, Expr(total_elements));
-          std::vector<Expr> tmp_indexs(indexs.begin(), indexs.begin() + first_axes.back());
+          Expr index = indexs.back() + indexs[indexs.size() - 2] * out_shape.back();
+          std::vector<Expr> tmp_indexs(indexs.begin(), indexs.begin() + out_shape.size() - 2);
           // last and the second of last.
-          Expr tail = indexs[first_axes.back()] * Expr(max_num_threads) + indexs[first_axes.back() + 1];
+          auto selected = ir::LT::Make(index, Expr(lane));
           for (auto tail_stride : tail_strides) {
-            tmp_indexs.push_back(tail / Expr(tail_stride));
-            tail = tail % Expr(tail_stride);
+            tmp_indexs.push_back(index / Expr(tail_stride));
+            index = index % Expr(tail_stride);
           }
+
           CHECK_EQ(tmp_indexs.size(), A->shape.size()) << "Indexs size is not equal to Input shape!";
-          return ir::Select::Make(selected, A(tmp_indexs), Expr(0.0f));
+          if (check_bound) {
+            return ir::Select::Make(selected, A(tmp_indexs), Expr(0.0f));
+          } else {
+            return A(tmp_indexs);
+          }
         },
         UniqName(output_name + "_reshape"));
     return out;
@@ -668,10 +709,16 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
   std::vector<ir::Tensor> results;
   if (lane > max_num_threads) {
     results.push_back(reduce_reshape_func());
+  } else {
+    if (!keep_dim) {
+      for (auto& axis : second_axes) {
+        axis -= first_axes.size();
+      }
+    }
   }
   if (first_axes.size()) {
-    results.push_back(reduce_func(
-        results.size() ? results.back() : A, first_axes, keep_dim_first, Expr(init_val), output_name + "_internal"));
+    results.push_back(
+        reduce_func(results.size() ? results.back() : A, first_axes, keep_dim_first, output_name + "_internal"));
     results.back()->WithBuffer("local");
   }
   if (second_axes.size()) {
@@ -688,28 +735,28 @@ std::vector<ir::Tensor> TwoStepBlockReduceSum(const ir::Tensor& A,
                                               const std::vector<int>& axes,
                                               const bool keep_dim,
                                               const std::string& output_name) {
-  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceSum, BlockReduceSumInternal, 0.0f);
+  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceSum, BlockReduceSumInternal);
 }
 
 std::vector<ir::Tensor> TwoStepBlockReduceProd(const ir::Tensor& A,
                                                const std::vector<int>& axes,
                                                const bool keep_dim,
                                                const std::string& output_name) {
-  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceProd, BlockReduceProdInternal, 1.0f);
+  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceProd, BlockReduceProdInternal);
 }
 
 std::vector<ir::Tensor> TwoStepBlockReduceMax(const ir::Tensor& A,
                                               const std::vector<int>& axes,
                                               const bool keep_dim,
                                               const std::string& output_name) {
-  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceMax, BlockReduceMaxInternal, -3.402823e+38f);
+  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceMax, BlockReduceMaxInternal);
 }
 
 std::vector<ir::Tensor> TwoStepBlockReduceMin(const ir::Tensor& A,
                                               const std::vector<int>& axes,
                                               const bool keep_dim,
                                               const std::string& output_name) {
-  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceMin, BlockReduceMinInternal, 3.402823e+38f);
+  return TwoStepBlockReduceInternal(A, axes, keep_dim, output_name, ReduceMin, BlockReduceMinInternal);
 }
 
 }  // namespace pe

--- a/cinn/hlir/pe/reduction.h
+++ b/cinn/hlir/pe/reduction.h
@@ -37,7 +37,7 @@ namespace pe {
  */
 ir::Tensor ReduceSum(const ir::Tensor& A,
                      const std::vector<int>& axis,
-                     bool keep_dims                 = false,
+                     const bool keep_dims           = false,
                      Expr initial                   = Expr(0.f),
                      const std::string& output_name = "T_Reduce_Sum_out");
 
@@ -57,7 +57,7 @@ ir::Tensor ReduceSum(const ir::Tensor& A,
  */
 ir::Tensor ReduceProd(const ir::Tensor& A,
                       const std::vector<int>& axis,
-                      bool keep_dims                 = false,
+                      const bool keep_dims           = false,
                       Expr initial                   = Expr(1.f),
                       const std::string& output_name = "T_Reduce_Prod_out");
 
@@ -76,7 +76,7 @@ ir::Tensor ReduceProd(const ir::Tensor& A,
  */
 ir::Tensor ReduceMax(const ir::Tensor& A,
                      const std::vector<int>& axis,
-                     bool keep_dims                 = false,
+                     const bool keep_dims           = false,
                      Expr initial                   = Expr(),
                      const std::string& output_name = "T_Reduce_Max_out");
 
@@ -95,7 +95,7 @@ ir::Tensor ReduceMax(const ir::Tensor& A,
  */
 ir::Tensor ReduceMin(const ir::Tensor& A,
                      const std::vector<int>& axis,
-                     bool keep_dims                 = false,
+                     const bool keep_dims           = false,
                      Expr initial                   = Expr(),
                      const std::string& output_name = "T_Reduce_Min_out");
 
@@ -250,6 +250,62 @@ std::vector<ir::Tensor> BlockReduceMin(const ir::Tensor& A,
                                        const bool keep_dim            = false,
                                        const std::string& output_name = "T_Block_Reduce_Min_out");
 
+/**
+ * @brief compute the value of array elements over the last dimension with block reduce
+ *
+ * @param A The input Tensor.
+ * @param axes the reduce axes.
+ * @param keep_dim keep the output tensor shape size as input.
+ * @param output_name The name of the output Tensor.
+ */
+std::vector<ir::Tensor> BlockShuffleReduceSum(const ir::Tensor& A,
+                                              const std::vector<int>& axes,
+                                              const bool keep_dim,
+                                              const std::string& output_name = "T_Reduce_Sum_out");
+
+std::vector<ir::Tensor> BlockShuffleReduceProd(const ir::Tensor& A,
+                                               const std::vector<int>& axes,
+                                               const bool keep_dim,
+                                               const std::string& output_name = "T_Reduce_Prod_out");
+
+std::vector<ir::Tensor> BlockShuffleReduceMax(const ir::Tensor& A,
+                                              const std::vector<int>& axes,
+                                              const bool keep_dim,
+                                              const std::string& output_name = "T_Reduce_Max_out");
+
+std::vector<ir::Tensor> BlockShuffleReduceMin(const ir::Tensor& A,
+                                              const std::vector<int>& axes,
+                                              const bool keep_dim,
+                                              const std::string& output_name = "T_Reduce_Min_out");
+
+/**
+ * @brief compute the value of array elements over the last dimension with block reduce
+ *
+ * @param A The input Tensor.
+ * @param axes the reduce axes.
+ * @param keep_dim keep the output tensor shape size as input.
+ * @param output_name The name of the output Tensor.
+ */
+
+std::vector<ir::Tensor> TwoStepBlockReduceSum(const ir::Tensor& A,
+                                              const std::vector<int>& axes,
+                                              const bool keep_dim,
+                                              const std::string& output_name = "T_Reduce_Sum_out");
+
+std::vector<ir::Tensor> TwoStepBlockReduceProd(const ir::Tensor& A,
+                                               const std::vector<int>& axes,
+                                               const bool keep_dim,
+                                               const std::string& output_name = "T_Reduce_Prod_out");
+
+std::vector<ir::Tensor> TwoStepBlockReduceMax(const ir::Tensor& A,
+                                              const std::vector<int>& axes,
+                                              const bool keep_dim,
+                                              const std::string& output_name = "T_Reduce_Max_out");
+
+std::vector<ir::Tensor> TwoStepBlockReduceMin(const ir::Tensor& A,
+                                              const std::vector<int>& axes,
+                                              const bool keep_dim,
+                                              const std::string& output_name = "T_Reduce_Min_out");
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/reduction.h
+++ b/cinn/hlir/pe/reduction.h
@@ -38,7 +38,6 @@ namespace pe {
 ir::Tensor ReduceSum(const ir::Tensor& A,
                      const std::vector<int>& axis,
                      const bool keep_dims           = false,
-                     Expr initial                   = Expr(0.f),
                      const std::string& output_name = "T_Reduce_Sum_out");
 
 /**
@@ -58,7 +57,6 @@ ir::Tensor ReduceSum(const ir::Tensor& A,
 ir::Tensor ReduceProd(const ir::Tensor& A,
                       const std::vector<int>& axis,
                       const bool keep_dims           = false,
-                      Expr initial                   = Expr(1.f),
                       const std::string& output_name = "T_Reduce_Prod_out");
 
 /**
@@ -77,7 +75,6 @@ ir::Tensor ReduceProd(const ir::Tensor& A,
 ir::Tensor ReduceMax(const ir::Tensor& A,
                      const std::vector<int>& axis,
                      const bool keep_dims           = false,
-                     Expr initial                   = Expr(),
                      const std::string& output_name = "T_Reduce_Max_out");
 
 /**
@@ -96,7 +93,6 @@ ir::Tensor ReduceMax(const ir::Tensor& A,
 ir::Tensor ReduceMin(const ir::Tensor& A,
                      const std::vector<int>& axis,
                      const bool keep_dims           = false,
-                     Expr initial                   = Expr(),
                      const std::string& output_name = "T_Reduce_Min_out");
 
 /**

--- a/cinn/hlir/pe/schedule.cc
+++ b/cinn/hlir/pe/schedule.cc
@@ -343,7 +343,7 @@ int GetBlockBindAxis(const std::vector<ir::Expr> &shape, const int thread_axis) 
   return block_axis;
 }
 
-void CudaScheduleReduce(poly::StageMap stages,
+void CudaReduceSchedule(poly::StageMap stages,
                         ir::Tensor output,
                         int last_dimension_num,
                         const common::Target &target) {
@@ -374,7 +374,7 @@ void CudaScheduleReduce(poly::StageMap stages,
   }
 }
 
-void CudaScheduleWarpReduce(poly::StageMap stages, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target) {
+void CudaWarpReduceSchedule(poly::StageMap stages, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target) {
   int sum_out_dim = 1;
   for (int idx = 0; idx < static_cast<int>(tmp_out->shape.size()) - 2; ++idx) {
     stages[out]->Fuse(0, 1);
@@ -408,7 +408,7 @@ void CudaScheduleWarpReduce(poly::StageMap stages, ir::Tensor tmp_out, ir::Tenso
   }
 }
 
-void CudaScheduleBlockReduceInternal(poly::StageMap stages,
+void CudaBlockReduceInternalSchedule(poly::StageMap stages,
                                      ir::Tensor tmp_out,
                                      ir::Tensor out,
                                      const common::Target &target) {
@@ -430,7 +430,7 @@ void CudaScheduleBlockReduceInternal(poly::StageMap stages,
   stages[out]->Bind(0, "blockIdx.x");
 }
 
-void CudaScheduleBlockReduce(poly::StageMap stages,
+void CudaBlockReduceSchedule(poly::StageMap stages,
                              ir::Tensor reduce_tmp_out,
                              ir::Tensor tmp_out,
                              ir::Tensor out,
@@ -466,11 +466,12 @@ void CudaScheduleBlockReduce(poly::StageMap stages,
 
   stages[out]->Bind(0, "blockIdx.x");
 }
-void CudaScheduleShuffleReduce(poly::StageMap stages,
-                               ir::Tensor reduce_reshape,
-                               ir::Tensor reduce_internal,
-                               ir::Tensor reduce_out,
-                               const common::Target &target) {
+
+void CudaBlockShuffleReduceSchedule(poly::StageMap stages,
+                                    ir::Tensor reduce_reshape,
+                                    ir::Tensor reduce_internal,
+                                    ir::Tensor reduce_out,
+                                    const common::Target &target) {
   int fuse_times = reduce_internal->shape.size() - 2;
   for (int idx = 0; idx < fuse_times; ++idx) {
     stages[reduce_internal]->Fuse(0, 1);
@@ -500,6 +501,40 @@ void CudaScheduleShuffleReduce(poly::StageMap stages,
   }
   stages[reduce_reshape]->ComputeInline();
   stages[reduce_internal]->SetBuffer("shared");
+}
+
+void CudaTwoStepReduceSchedule(poly::StageMap stages,
+                               ir::Tensor reshape,
+                               ir::Tensor internal,
+                               ir::Tensor tmp_out,
+                               ir::Tensor out,
+                               const common::Target &target) {
+  // fuse axis
+  for (int idx = 0; idx < internal->shape.size() - 2; ++idx) {
+    stages[internal]->Fuse(0, 1);
+    stages[tmp_out]->Fuse(0, 1);
+    stages[out]->Fuse(0, 1);
+  }
+
+  if (stages[internal]->n_out_dims() == 1) {
+    stages[internal]->Split(0, stages[internal]->GetDimRange(0));
+    stages[tmp_out]->Split(0, stages[tmp_out]->GetDimRange(0));
+    stages[out]->Split(0, stages[out]->GetDimRange(0));
+  }
+
+  stages[reshape]->ComputeInline();
+
+  stages[internal]->Bind(0, "blockIdx.x");
+  stages[internal]->Bind(1, "threadIdx.x");
+  stages[internal]->SetBuffer("local");
+  stages[internal]->SimpleComputeAt(stages[tmp_out], 0);
+
+  stages[tmp_out]->Bind(0, "blockIdx.x");
+  stages[tmp_out]->Bind(1, "threadIdx.x");
+  stages[tmp_out]->SetBuffer("local");
+  stages[tmp_out]->SimpleComputeAt(stages[out], 0);
+
+  stages[out]->Bind(0, "blockIdx.x");
 }
 
 void SoftmaxScheduleCPU(poly::StageMap stage, const ir::Tensor &output, const ir::Tensor &temp, int axis) {

--- a/cinn/hlir/pe/schedule.cc
+++ b/cinn/hlir/pe/schedule.cc
@@ -484,18 +484,19 @@ void CudaBlockShuffleReduceSchedule(
     }
   }
 
-  if (stages[out]->n_out_dims() > 1) {
-    stages[internal]->Bind(0, "blockIdx.x");
-    stages[internal]->Bind(1, "threadIdx.x");
-
-    stages[out]->Bind(0, "blockIdx.x");
-    stages[out]->Bind(1, "threadIdx.x");
-
-    stages[internal]->SimpleComputeAt(stages[out], 0);
-  } else {
-    stages[internal]->Bind(0, "threadIdx.x");
-    stages[out]->Bind(0, "threadIdx.x");
+  if (stages[out]->n_out_dims() == 1) {
+    stages[internal]->Split(0, stages[internal]->GetDimRange(0));
+    stages[out]->Split(0, stages[out]->GetDimRange(0));
   }
+
+  stages[internal]->Bind(0, "blockIdx.x");
+  stages[internal]->Bind(1, "threadIdx.x");
+
+  stages[out]->Bind(0, "blockIdx.x");
+  stages[out]->Bind(1, "threadIdx.x");
+
+  stages[internal]->SimpleComputeAt(stages[out], 0);
+
   stages[reshape]->ComputeInline();
   stages[internal]->SetBuffer("shared");
 }

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -168,6 +168,12 @@ void CudaScheduleBlockReduceInternal(poly::StageMap stages,
 void CudaScheduleBlockReduce(
     poly::StageMap stages, ir::Tensor reduce_tmp_out, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target);
 
+void CudaScheduleShuffleReduce(poly::StageMap stages,
+                               ir::Tensor reduce_reshape,
+                               ir::Tensor reduce_internal,
+                               ir::Tensor reduce_out,
+                               const common::Target &target);
+
 void CudaScheduleDepthwiseConv(poly::StageMap stages, ir::Tensor &output, const common::Target &target);
 
 void CudaScheduleConv(poly::StageMap stages,

--- a/cinn/hlir/pe/schedule.h
+++ b/cinn/hlir/pe/schedule.h
@@ -156,22 +156,30 @@ void CudaScheduleMul(poly::StageMap stages,
                      const std::vector<int> &output_shape,
                      const common::Target &target);
 
-void CudaScheduleReduce(poly::StageMap stages, ir::Tensor output, int last_dimension_num, const common::Target &target);
+// reduce shedules.
+void CudaReduceSchedule(poly::StageMap stages, ir::Tensor output, int last_dimension_num, const common::Target &target);
 
-void CudaScheduleWarpReduce(poly::StageMap stages, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target);
+void CudaWarpReduceSchedule(poly::StageMap stages, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target);
 
-void CudaScheduleBlockReduceInternal(poly::StageMap stages,
+void CudaBlockReduceInternalSchedule(poly::StageMap stages,
                                      ir::Tensor tmp_out,
                                      ir::Tensor out,
                                      const common::Target &target);
 
-void CudaScheduleBlockReduce(
+void CudaBlockReduceSchedule(
     poly::StageMap stages, ir::Tensor reduce_tmp_out, ir::Tensor tmp_out, ir::Tensor out, const common::Target &target);
 
-void CudaScheduleShuffleReduce(poly::StageMap stages,
-                               ir::Tensor reduce_reshape,
-                               ir::Tensor reduce_internal,
-                               ir::Tensor reduce_out,
+void CudaBlockShuffleReduceSchedule(poly::StageMap stages,
+                                    ir::Tensor reduce_reshape,
+                                    ir::Tensor reduce_internal,
+                                    ir::Tensor reduce_out,
+                                    const common::Target &target);
+
+void CudaTwoStepReduceSchedule(poly::StageMap stages,
+                               ir::Tensor reshape,
+                               ir::Tensor internal,
+                               ir::Tensor tmp_out,
+                               ir::Tensor out,
                                const common::Target &target);
 
 void CudaScheduleDepthwiseConv(poly::StageMap stages, ir::Tensor &output, const common::Target &target);

--- a/cinn/pybind/pe.cc
+++ b/cinn/pybind/pe.cc
@@ -103,8 +103,7 @@ void BindPE(py::module* m) {
          py::arg("x"),                 \
          py::arg("axes"),              \
          py::arg("keep_dims") = false, \
-         py::arg("initial"),           \
-         py::arg("out") = "T_" #name__ "_out")
+         py::arg("out")       = "T_" #name__ "_out")
   BIND_REDUCE(reduce_sum, ReduceSum);
   BIND_REDUCE(reduce_prod, ReduceProd);
   BIND_REDUCE(reduce_max, ReduceMax);

--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -167,11 +167,9 @@ __device__ inline float cinn_block_reduce_min(const float *buf, int offset, int 
       if (buf[i] == num) return i;              \
     }                                           \
     return -1;                                  \
-  } while(0)
+  } while (0)
 
-__device__ inline int cinn_cuda_find_int(const int *buf, int size, int num) {
-  __cinn_cuda_find_kernel(buf, size, num);
-}
+__device__ inline int cinn_cuda_find_int(const int *buf, int size, int num) { __cinn_cuda_find_kernel(buf, size, num); }
 
 __device__ inline int cinn_cuda_find_float(const float *buf, int size, float num) {
   __cinn_cuda_find_kernel(buf, size, num);
@@ -185,7 +183,7 @@ __device__ inline int cinn_cuda_find_float(const float *buf, int size, float num
       if (buf[i] == num) return i;                          \
     }                                                       \
     return -1;                                              \
-  } while(0)
+  } while (0)
 
 __device__ inline int cinn_cuda_find_int_from(const int *buf, int size, int num, int begin) {
   __cinn_cuda_find_from_kernel(buf, size, num, begin);
@@ -197,13 +195,15 @@ __device__ inline int cinn_cuda_find_float_from(const float *buf, int size, floa
 
 #undef __cinn_cuda_find_from_kernel
 
-__device__ inline float cinn_cuda_index_add(
-    const float x, const int axis_indice,
-    const float* __restrict__ y,
-    const int offset, const int stride,
-    const int* __restrict__ index, const int index_size) {
+__device__ inline float cinn_cuda_index_add(const float x,
+                                            const int axis_indice,
+                                            const float *__restrict__ y,
+                                            const int offset,
+                                            const int stride,
+                                            const int *__restrict__ index,
+                                            const int index_size) {
   float res = x;
-  int idx = -1;
+  int idx   = -1;
   do {
     idx = cinn_cuda_find_int_from(index, index_size, axis_indice, idx + 1);
     if (idx >= 0) {
@@ -212,3 +212,17 @@ __device__ inline float cinn_cuda_index_add(
   } while (idx != -1);
   return res;
 }
+
+#define block_shuffle_kernel(name, op, init_value)                                       \
+  __device__ inline float block_shuffle_##name(const float *buf, int line, int stride) { \
+    float val = init_value;                                                              \
+    for (int idx = threadIdx.x; idx < line; idx += stride) {                             \
+      val = op(val, buf[idx]);                                                           \
+    }                                                                                    \
+    return val;                                                                          \
+  }
+
+block_shuffle_kernel(sum, cinn_sum, 0.0f);
+block_shuffle_kernel(prod, cinn_prod, 1.0f);
+block_shuffle_kernel(max, cinn_max, -3.402823e+38f);
+block_shuffle_kernel(min, cinn_min, 3.402823e+38f);

--- a/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -173,6 +173,30 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
       .AddInputType<int>()
       .End();
 
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(block_shuffle_sum, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .End();
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(block_shuffle_prod, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .End();
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(block_shuffle_max, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .End();
+
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(block_shuffle_min, target)
+      .SetRetType<float>()
+      .AddInputType<cinn_buffer_t *>()
+      .AddInputType<int>()
+      .End();
+
   return true;
 }
 


### PR DESCRIPTION
这个PR主要是对现有的reduce进行深度的优化，解决reduce的性能和融合问题。

### 关于col维度做reduce的优化
对一个 M x N维度矩阵做 在col的方向做reduce的计算。常规GPU优化方法是 将最后一个维度绑定threadIdx.x 然后做M次循环。但是某些case， M很大、N很小。因此做如下优化:

1. 将 M x N的矩阵变为 M/K x K x N的三维矩阵
2. 第一步在K * N的维度合并绑定threadIdx.x，中间结果写入shared memory
3. 第二步对K * N的矩阵 在N上绑定threadIdx.x，输出结果N

需要满足 K*N < max block thread这样方便在一个block中完成计算
M/K可能不能被除尽，因此某些时候 需要边界检查。
如果kernel存在边界检查，将会影响others + reduce的fusion，当前这种情况是限制进行fuse的。后面如果producer只使用compute inline原语，可以在满足条件的情况下合并。

### 关于对 M x K x N在包含N进行reduce的任意情况reduce的通用优化
存在以下四种情况：
1. last dimension size > 1024
2. 包含最后一个维度连续reduce维度的累积 size > 1024
3. 包含最后一个维度连续reduce维度的累积 size < 1024
4. 包含其他连续reduce的维度

关于连续维度的解释：即reduce的axis是连续的.
例如 reduce_axes = {0, 1, 2, 5, 6}包含两个连续的reduce维度，{0， 1， 2}和{5， 6}
为了提高reduce的并行度，主要是对包含最后一个维度的连续reduce维度进行划分和优化。
这种情况的reduce包含两步可选和一步必选计算
可选第一步：reshape 即对包含最后一个维度连续reduce进行尺寸的调整，最大化进行并行。
可选第二部：col维度的reduce，对不包含最后一个维度的其他连续reduce维度区间先进行reduce的计算。
必选第三步：对包含最后一个维度连续reduce维度区间进行reduce的计算。

