### PR TITLE
Update NV GPG Key

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,6 +86,7 @@ function prepare_ci {
   fi
 
   # NVIDIA update GPG key on 04/29/2022. Fetch the public key for CI machine
+  # Reference: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
   apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
   apt update

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,9 @@ function prepare_ci {
     return
   fi
 
+  # NVIDIA update GPG key on 04/29/2022. Fetch the public key for CI machine
+  apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
   apt update
   echo "the current user EUID=$EUID: $(whoami)"
   if ! command -v doxygen &> /dev/null; then


### PR DESCRIPTION
NVIDIA update GPG key on 04/29/2022. Fetch the public key for CI machine.

Reference: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key