### PR TITLE
fix transpose folding bug

### DIFF
--- a/cinn/frontend/op_mapper_registry.cc
+++ b/cinn/frontend/op_mapper_registry.cc
@@ -20,6 +20,7 @@ namespace cinn {
 namespace frontend {
 
 void OpMapperContext::AddVar(const std::string& origin_name, const Variable& var, bool replace) const {
+  CHECK(!origin_name.empty()) << "Variable [" << origin_name << "]'s is empty ! Please check.";
   const auto& name = cinn::utils::TransValidVarName(origin_name);
   CheckVarNameValid(name);
   CHECK(replace || !var_map_->count(name)) << "Duplicate variable [" << name << "] found";
@@ -28,6 +29,7 @@ void OpMapperContext::AddVar(const std::string& origin_name, const Variable& var
 }
 
 void OpMapperContext::AddVarModelToProgram(const std::string& name, const std::string& id) const {
+  CHECK(!id.empty()) << "Paddle name [" << name << "]'s program id is empty ! Please check.";
   (*var_model_to_program_map_)[name] = id;
   VLOG(4) << "Paddle name [" << name << "] map to program id " << id;
 }


### PR DESCRIPTION
在如下情况下，现有的`TransposeFoldingPass`不会判断`transpose`算子的输出是否只有本`matmul`算子用到，该`transpose`算子一律会被消除掉，即使输出被其它算子用到了。这导致在跑后一个dot算子时找不到第一个transpose算子的输出。

<img width="326" alt="b4b2b7f4751ca16c0114e813a45db1f5" src="https://user-images.githubusercontent.com/31386411/166897785-ef4d8297-50a0-4309-83dd-954a10294f13.png">
