### PR TITLE
Fix Laplace Compute Error(Nan)

### DIFF
--- a/cinn/hlir/framework/op_lowering.cc
+++ b/cinn/hlir/framework/op_lowering.cc
@@ -246,7 +246,7 @@ void OpLowerer::ElementwiseSchedule(poly::StageMap& stages,
       node_stage->CopyTransform(master_stage);
       node_stage->CopyLoopInfo(master_stage);
       // internal node use buffer
-      if (group->internal_nodes.count(node) || sub_group->internal_nodes.count(node)) {
+      if (!group->output_nodes.count(node)) {
         node_stage->SetBuffer("local");
       }
       // compute at master node


### PR DESCRIPTION
这个PR主要是解决代码生成的时候，使用output_nodes set判断是否需要绑定buffer。

出错的子图结构，子图中存在6个输出节点：
![image](https://user-images.githubusercontent.com/12538138/167753794-6f60c623-4f18-4d11-aeab-a95ac6b4f9b7.png)

使用#778 NaN/Inf检测工具打印结果如下，6个输出中有2个输出是全0，导致后续的Kernel中因为除0而出现Inf、NaN：
![image](https://user-images.githubusercontent.com/12538138/167754168-c2cf57cc-7211-49c1-8aa6-484e4cbab646.png)

var_497和var_525结果都非0，`var_533 = elementwise_mul(var_497, var_525)`结果为全0，存在异常。故排查生成的代码，发现kernel只有4个输出，如下：
![image](https://user-images.githubusercontent.com/12538138/167754016-02e9d5c3-e2f4-4cd1-87dd-91854af7c989.png)

laplace2d自动版精度验证：
- 开启CINN，两次运行结果如下

![image](https://user-images.githubusercontent.com/12538138/167761839-31bde23b-dc5e-4915-9a58-943e6236c7e2.png)

![image](https://user-images.githubusercontent.com/12538138/167763367-e52705e2-cd59-4b74-a9b3-ee7dc55272e8.png)

- 关闭CINN，两次运行结果如下

![image](https://user-images.githubusercontent.com/12538138/167762119-eed43d11-61e7-4fd5-b198-b4d8c1faf210.png)

![image](https://user-images.githubusercontent.com/12538138/167763435-78792bec-472f-470a-950d-9c0381f7af1c.png)
