### PR TITLE
Simplify the implementation of remove_identity pass.

### DIFF
--- a/cinn/frontend/pass/dead_code_eliminate.cc
+++ b/cinn/frontend/pass/dead_code_eliminate.cc
@@ -22,7 +22,7 @@ namespace cinn {
 namespace frontend {
 namespace pass {
 
-// Program maybe has some unused instructions. `DeadCodeEliminate` will remove
+// Program may have some unused instructions. `DeadCodeEliminate` will remove
 // these instructions. The way to find unused instructions is to traverse all
 // instructions to determine whether its output is used by other instructions in the
 // same subgraph or in the `fetch_ids`.

--- a/cinn/frontend/pass/remove_identity.cc
+++ b/cinn/frontend/pass/remove_identity.cc
@@ -81,13 +81,12 @@ class RemoveIdentityPass : public ProgramPass {
     }
     *program = builder.Build();
     VLOG(5) << "Optimized program: " << *program;
+
+    Clear();
   }
 
  private:
   void CollectInfo(const Program& program, const std::unordered_set<std::string>& fetch_ids) {
-    remove_idxs_.clear();
-    origin2new_.clear();
-
     std::unordered_set<std::string> feed_ids;
     for (auto& var : program.GetInputs()) {
       feed_ids.insert(var->id);
@@ -148,6 +147,11 @@ class RemoveIdentityPass : public ProgramPass {
       return true;
     }
     return false;
+  }
+
+  void Clear() {
+    remove_idxs_.clear();
+    origin2new_.clear();
   }
 
   std::unordered_set<int> remove_idxs_;

--- a/cinn/frontend/pass/reshape_rewriter.cc
+++ b/cinn/frontend/pass/reshape_rewriter.cc
@@ -59,11 +59,11 @@ class ReshapeRewriterPass : public ProgramPass {
       const auto& instr = (*program)[i];
       if (remove_idxs_.count(i)) {
         // Change the attr shape of the previous fill_constant.
-        auto iter         = outputs2instr_.find(instr->inputs[0].get());
-        auto& input_instr = iter->second;
-        CHECK(input_instr->op_type == "fill_constant") << "The previous op's type is not fill_constant, please check.";
-        input_instr->outputs[0]     = instr->outputs[0];
-        input_instr->attrs["shape"] = instr->outputs[0]->shape;
+        auto iter        = outputs2instr_.find(instr->inputs[0].get());
+        auto& prev_instr = iter->second;
+        CHECK(prev_instr->op_type == "fill_constant") << "The previous op's type is not fill_constant, please check.";
+        prev_instr->outputs[0]     = instr->outputs[0];
+        prev_instr->attrs["shape"] = instr->outputs[0]->shape;
       } else {
         if (replace_idxs_.count(i)) {
           instr->op_type = "identity";
@@ -104,19 +104,20 @@ class ReshapeRewriterPass : public ProgramPass {
 
       bool matched = false;
       auto iter    = outputs2instr_.find(input_var.get());
+      // Whether input_var is the output of another instruction.
       if (iter != outputs2instr_.end()) {
-        auto& input_instr = iter->second;
+        auto& prev_instr = iter->second;
         // Match the pattern is fill_constant -> reshape
         // reshape should be the only output instruction of fill_constant, and the output variable of fill_constant
         // cannot be in the fetch_ids.
-        if (input_instr->op_type == "fill_constant" && var_used_count[input_var.get()] == 1 &&
+        if (prev_instr->op_type == "fill_constant" && var_used_count[input_var.get()] == 1 &&
             !fetch_ids.count(input_var->id)) {
           matched = true;
           remove_idxs_.insert(i);
           VLOG(3) << "Remove the " << i << "-th instruction: " << instr;
         }
       }
-      if (!matched && (input_var->id != output_var->id) && (input_var->shape == output_var->shape)) {
+      if (!matched && (input_var->shape == output_var->shape)) {
         // Replace the reshape with the same input and output shape to identity.
         VLOG(3) << "Replace the " << i << "-th instruction to identity: " << instr;
         replace_idxs_.insert(i);


### PR DESCRIPTION
按照 https://github.com/PaddlePaddle/CINN/pull/763#pullrequestreview-971837484 review建议修改。

#763 中的实现逻辑是：遍历program，对于每一个identity指令，依据输入、输出是否可移除确定该identity指令是否可以移除，并且确定移除的变量和用于替换的变量。当存在连续多个identity指令时，if-else逻辑比较复杂。

本PR的修改后的方法：

1. 遍历program，将所有的identity指令在program中的索引保存到`std::vector<std::set<int>> identity_instr_groups_`中。连续的identity指令会保存到同一个set中。`std::set<int>`中按照program中的顺序保存多个连续的identity。
2. 确定可移除的identity、移除的变量和用于替换的变量。分两种情况，一个identity set中，不可移除的变量数：

- `cannot_remove_vars.size() <= 1`时，该set中所有identity指令皆可移除，并且使用唯一的一个不可删除的var、或者第一个identity指令的输入var代替其他所有的var。
- `cannot_remove_vars.size() > 1`时，保留前`cannot_remove_vars.size() - 1`个identity指令，使用cannot_remove_vars中的变量作为这些保留的identity指令的输入、输出。