### PR TITLE
try optimize PreparePodArgs

### DIFF
--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -200,9 +200,9 @@ void Program::Export(const std::vector<std::string>& persistent_vars, const std:
   fclose(f);
 }
 
-void Program::Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs, void* stream) {
+void Program::Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs, void* stream, bool use_cache) {
   for (auto& ins : instrs_) {
-    ins->Run(name2podargs, false, stream);
+    ins->Run(name2podargs, false, stream, use_cache);
   }
 #ifdef CINN_WITH_CUDA
   VLOG(4) << "-- The value of the used stream: " << stream;

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -60,7 +60,7 @@ class Program {
    */
   void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
                void* stream                                                = nullptr,
-               bool use_cache                                              = false);
+               bool use_cache                                              = true);
 
   void ExecuteTest(int repeat_);
 

--- a/cinn/hlir/framework/graph_compiler.h
+++ b/cinn/hlir/framework/graph_compiler.h
@@ -58,7 +58,9 @@ class Program {
   /**
    * Execute the program -- that is running all the instructions inside it.
    */
-  void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr, void* stream = nullptr);
+  void Execute(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
+               void* stream                                                = nullptr,
+               bool use_cache                                              = false);
 
   void ExecuteTest(int repeat_);
 

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -23,7 +23,7 @@ namespace hlir {
 namespace framework {
 
 void Instruction::UpdateArgsCache(const std::map<std::string, cinn_pod_value_t>* name2podargs) {
-  int cache_size = std::max(1, size());
+  int cache_size = size();
   args_cached_.resize(cache_size);
 
   for (int i = 0; i < cache_size; ++i) {
@@ -81,7 +81,7 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
 
   VLOG(2) << "Run function " << function_name_;
 
-  if (!use_cache || args_cached_.size() != std::max(1, size())) {
+  if (!use_cache || args_cached_.size() != size()) {
     UpdateArgsCache(name2podargs);
   }
 

--- a/cinn/hlir/framework/instruction.h
+++ b/cinn/hlir/framework/instruction.h
@@ -74,7 +74,7 @@ class Instruction {
   void Run(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
            bool dryrun                                                 = false,
            void* stream                                                = nullptr,
-           bool use_cache                                              = false);
+           bool use_cache                                              = true);
 
   void PreRun(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr) {
     CHECK_EQ(fn_.size(), 4);

--- a/cinn/hlir/framework/instruction.h
+++ b/cinn/hlir/framework/instruction.h
@@ -67,12 +67,14 @@ class Instruction {
   // explicitly finalize the instruction, and can't append function again after call it
   void Finalize();
 
+  void UpdateArgsCache(const std::map<std::string, cinn_pod_value_t>* name2podargs);
   /**
    * Run the Instruction.
    */
   void Run(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr,
            bool dryrun                                                 = false,
-           void* stream                                                = nullptr);
+           void* stream                                                = nullptr,
+           bool use_cache                                              = false);
 
   void PreRun(const std::map<std::string, cinn_pod_value_t>* name2podargs = nullptr) {
     CHECK_EQ(fn_.size(), 4);
@@ -81,9 +83,8 @@ class Instruction {
       out_args_.erase(out_args_.begin());
       in_args_.erase(in_args_.begin());
     }
-    if (name2podargs != nullptr) {
-      args_cached_.clear();
-    }
+    UpdateArgsCache(name2podargs);
+
     CHECK_EQ(fn_.size(), in_args_.size());
     CHECK_EQ(fn_.size(), out_args_.size());
     int flag = -1;
@@ -91,7 +92,7 @@ class Instruction {
       if (utils::Startswith(out_args_[i][0], "kernel_pack")) {
         VLOG(3) << "PreRun " << i << "-th function of fn_:" << fn_names_[i];
         flag           = i;
-        auto& pod_args = PreparePodArgs(i, name2podargs);
+        auto& pod_args = args_cached_[i];
         auto it_fn     = fn_[i];
         CHECK(it_fn) << "The LoweredFunc address should be set first by calling SetLoweredFunc method";
         it_fn(pod_args.data(), pod_args.size());
@@ -120,9 +121,6 @@ class Instruction {
   std::vector<std::string> str_attrs;
   bool pre_run = false;
   Target target_;
-
- protected:
-  std::vector<cinn_pod_value_t>& PreparePodArgs(int i, const std::map<std::string, cinn_pod_value_t>* name2podargs);
 
  private:
   bool finalized_flag_ = false;

--- a/cinn/hlir/framework/instruction_test.cc
+++ b/cinn/hlir/framework/instruction_test.cc
@@ -139,7 +139,7 @@ TEST(Instruction, RunWithRawPodArgs) {
   };
 
   // run with a arguments map passed
-  instr.Run(&name2podargs);
+  instr.Run(&name2podargs, false, nullptr, false);
   // check instruction run correctly
   check_equal_by_element();
 
@@ -152,7 +152,7 @@ TEST(Instruction, RunWithRawPodArgs) {
     auto&& tensor = scope.GetTensor(name);
     name2podargs.emplace(name, tensor->buffer());
   }
-  instr.Run(&name2podargs);
+  instr.Run(&name2podargs, false, nullptr, false);
   // check instruction run correctly
   check_equal_by_element();
 }


### PR DESCRIPTION
打点发现`Instruction::Run`中`PreparePodArgs`的时间比较长，如图，51us的时间有29us用于`PreparePodArgs`，耗时较长，尝试优化：
![image](https://user-images.githubusercontent.com/31386411/168508090-fd361bc0-ddbf-449c-b973-036d7cbcb185.png)

优化方案为添加`use_cache`参数，当`use_cache=true`时使用`arg_cache_`中的参数值而非每次都计算参数值。本地测试模型整体性能提升了一倍，且精度保持不变（如图）：

![image](https://user-images.githubusercontent.com/31386411/168587259-2a21c745-785b-4951-b239-b4bb26f51ec7.png)
