### PR TITLE
Show instruction fn_name in the nvtx tag in CINN.

### DIFF
--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -74,7 +74,7 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
                       bool dryrun,
                       void* stream,
                       bool use_cache) {
-  utils::RecordEvent record_run("Instruction::Run");
+  utils::RecordEvent record_run(function_name_ + "::Run");
   CHECK(finalized_flag_) << "Instruction must be finalized before run";
   if (function_name_ == "no_run") {
     VLOG(2) << "skip instruction";

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -74,7 +74,7 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
                       bool dryrun,
                       void* stream,
                       bool use_cache) {
-  utils::RecordEvent record_run(function_name_ + "::Run");
+  utils::RecordEvent record_run(function_name_);
   CHECK(finalized_flag_) << "Instruction must be finalized before run";
   if (function_name_ == "no_run") {
     VLOG(2) << "skip instruction";


### PR DESCRIPTION
Show the instruction function_name in the nvtx tag.
More details about nvtx support, please refer to https://github.com/PaddlePaddle/CINN/pull/797 .

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/17102274/169019094-ce95550d-6c7e-402d-8866-c79c2bfe7d4e.png">

