### PR TITLE
Fix Vectorize bugs

### DIFF
--- a/cinn/common/ir_util.cc
+++ b/cinn/common/ir_util.cc
@@ -84,6 +84,11 @@ Expr RampRelatedAdd(Expr a, Expr b) {
   auto *b_ramp      = b.As<ir::Ramp>();
   auto *a_broadcast = a.As<ir::Broadcast>();
   auto *b_broadcast = b.As<ir::Broadcast>();
+  if (a.As<ir::Add>() && (a.As<ir::Add>()->a().As<ir::Ramp>() || a.As<ir::Add>()->b().As<ir::Ramp>())) {
+    return RampRelatedAdd(RampRelatedAdd(a.As<ir::Add>()->a(), a.As<ir::Add>()->b()), b);
+  } else if (b.As<ir::Add>() && (b.As<ir::Add>()->a().As<ir::Ramp>() || b.As<ir::Add>()->b().As<ir::Ramp>())) {
+    return RampRelatedAdd(RampRelatedAdd(b.As<ir::Add>()->a(), b.As<ir::Add>()->b()), a);
+  }
   if (a_ramp && !b_ramp && (b->type().lanes() == 1 || b_broadcast)) {
     return RampRelatedAdd(a_ramp, b);
   } else if (!a_ramp && b_ramp && (a->type().lanes() == 1 || a_broadcast)) {
@@ -100,6 +105,7 @@ Expr RampRelatedAdd(Expr a, Expr b) {
     CHECK_EQ(a_broadcast->lanes, b_broadcast->lanes);
     return ir::Broadcast::Make(a_broadcast->value + b_broadcast->value, a_broadcast->lanes);
   } else {
+    VLOG(3) << "a is : " << a << " \n and b is : " << b;
     CINN_NOT_IMPLEMENTED
   }
 }
@@ -109,6 +115,11 @@ Expr RampRelatedMul(Expr a, Expr b) {
   auto *b_ramp      = b.As<ir::Ramp>();
   auto *a_broadcast = a.As<ir::Broadcast>();
   auto *b_broadcast = b.As<ir::Broadcast>();
+  if (a.As<ir::Add>()) {
+    return RampRelatedMul(a.As<ir::Add>()->a(), b) + RampRelatedMul(a.As<ir::Add>()->b(), b);
+  } else if (b.As<ir::Add>()) {
+    return RampRelatedMul(a, b.As<ir::Add>()->a()) + RampRelatedMul(a, b.As<ir::Add>()->b());
+  }
   if (a_ramp && !b_ramp && (!b->type().is_vector() || b_broadcast)) {
     return RampRelatedMul(a_ramp, b);
   } else if (!a_ramp && b_ramp && (a->type().is_vector() || a_broadcast)) {
@@ -125,7 +136,7 @@ Expr RampRelatedMul(Expr a, Expr b) {
     CHECK_EQ(a_broadcast->lanes, b_broadcast->lanes);
     return ir::Broadcast::Make(a_broadcast->value * b_broadcast->value, a_broadcast->lanes);
   } else {
-    VLOG(3) << "a,b: " << a << " " << b;
+    VLOG(3) << "a is : " << a << " \n and b is : " << b;
     CINN_NOT_IMPLEMENTED
   }
 }

--- a/cinn/optim/vectorize_loops_test.cc
+++ b/cinn/optim/vectorize_loops_test.cc
@@ -22,6 +22,7 @@
 #include "cinn/common/common.h"
 #include "cinn/common/ir_util.h"
 #include "cinn/ir/ir_operators.h"
+#include "cinn/lang/lower.h"
 #include "cinn/optim/ir_simplify.h"
 #include "cinn/optim/optimize.h"
 #include "cinn/optim/transform_polyfor_to_for.h"


### PR DESCRIPTION
本PR修复了RampRelatedAdd和RampRelatedMul中情况考虑不完全导致的bug（会在对复杂的loop range使用Vectorize原语时出现），同时增强了报错语句输出的信息