### PR TITLE
enhance UnrollLoop pass to support auto-unroll

### DIFF
--- a/cinn/ir/ir.h
+++ b/cinn/ir/ir.h
@@ -917,6 +917,12 @@ struct ScheduleBlock : public ExprNode<ScheduleBlock> {
   std::string name;
   Expr body;
 
+  /*!
+   * \brief Additional attributes about this schedulable block,
+   * which take some auxiliary hints for future transformations.
+   */
+  std::map<std::string, attr_t> attrs;
+
   static Expr Make(const std::vector<Var>& iter_vars,
                    const std::vector<Expr>& read_buffers,
                    const std::vector<Expr>& write_buffers,
@@ -982,6 +988,14 @@ struct PrimitiveNode : public ExprNode<PrimitiveNode> {
 
   static const IrNodeTy _node_type_ = IrNodeTy::PrimitiveNode;
 };
+
+// possiable keys of attributes in ir nodes with are listed in the following namespace
+namespace attr {
+
+// max permitted steps for auto_unroll, used in unroll_loop pass
+constexpr const char* auto_unroll_max_step = "auto_unroll_max_step";
+
+}  // namespace attr
 
 }  // namespace ir
 

--- a/cinn/optim/CMakeLists.txt
+++ b/cinn/optim/CMakeLists.txt
@@ -47,6 +47,7 @@ cc_test(test_cache_read_write_replace SRCS cache_read_write_replace_test.cc DEPS
 cc_test(test_cast_simplify SRCS cast_simplify_test.cc DEPS cinncore)
 cc_test(test_if_simplify SRCS if_simplify_test.cc DEPS cinncore)
 cc_test(test_remove_schedule_block SRCS remove_schedule_block_test.cc DEPS cinncore)
+cc_test(test_unroll_loops SRCS unroll_loops_test.cc DEPS cinncore)
 
 if (WITH_CUDA)
   cc_test(test_transform_gpu_forloop SRCS transform_gpu_forloop_test.cc DEPS cinncore)

--- a/cinn/optim/unroll_loops.cc
+++ b/cinn/optim/unroll_loops.cc
@@ -60,7 +60,10 @@ struct UnrollMutator : public ir::IRMutator<Expr*> {
   // predicate whether a for-loop can be unrolled and do it
   void Visit(const ir::For* op, Expr* expr) override {
     IRMutator<>::Visit(op, expr);
-    CHECK(op->extent.As<ir::IntImm>() != nullptr) << "loop should have a contant extent";
+    if (op->extent.As<ir::IntImm>() == nullptr) {
+      VLOG(5) << "loop to be unrolled should have a contant extent";
+      return;
+    }
     int extent = op->extent.as_int32();
 
     // predicate this for-loop can be unrolled by auto-unroll conditions

--- a/cinn/optim/unroll_loops_test.cc
+++ b/cinn/optim/unroll_loops_test.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/optim/unroll_loops.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "cinn/cinn.h"
+#include "cinn/ir/ir_schedule.h"
+#include "cinn/lang/lower.h"
+
+namespace cinn {
+namespace optim {
+
+TEST(UnrollLoops, unrolled_tag) {
+  using namespace ir;
+
+  Expr M(100);
+  Expr N(4);
+
+  Placeholder<float> A("A", {M, N});
+  Placeholder<float> B("B", {M, N});
+
+  Tensor C = Compute(
+      {M, N}, [&](Var i, Var j) { return A(i, j) * B(i, j); }, "C");
+
+  auto stages = CreateStages({C});
+
+  Target target = common::DefaultHostTarget();
+  auto func     = cinn::lang::LowerVec("test_unrolled_tag", stages, {A, B, C}, {}, {}, nullptr, target, true);
+  auto ast_expr = func[0]->body;
+
+  ir::ModuleExpr mod_expr({ast_expr});
+  ir::IRSchedule ir_sch(mod_expr);
+  auto loops = ir_sch.GetLoops("C");
+  ASSERT_EQ(loops.size(), 2U);
+
+  // extent of the loop exceed the max permitted value in the unroll_loops pass,
+  // which currently set 50, so the loop can not be unrolled actually
+  loops[1].As<ir::For>()->extent.As<ir::IntImm>()->value = 51;
+  ir_sch.Unroll(loops[1]);
+  UnrollLoop(&ast_expr);
+  loops = ir_sch.GetLoops("C");
+  ASSERT_EQ(loops.size(), 2U);
+
+  // unrolled correctly
+  loops[1].As<ir::For>()->extent.As<ir::IntImm>()->value = 4;
+  UnrollLoop(&ast_expr);
+  EXPECT_EQ(ir_sch.GetLoops("C").size(), 1);
+}
+
+TEST(UnrollLoops, auto_unroll) {
+  using namespace ir;
+
+  Expr M(100);
+  Expr N(4);
+  Expr O(5);
+  Expr const_value(float(2.11));
+
+  Placeholder<float> A("A", {M, N, O});
+
+  // B = A + 2.11
+  Tensor B = Compute(
+      {M, N, O}, [&](Var i, Var j, Var k) { return A(i, j, k) + const_value; }, "B");
+
+  auto stages   = CreateStages({B});
+  Target target = common::DefaultHostTarget();
+  auto func     = cinn::lang::LowerVec("test_auto_unroll", stages, {A, B}, {}, {}, nullptr, target, true);
+  auto ast_expr = func[0]->body;
+  ir::ModuleExpr mod_expr({ast_expr});
+  ir::IRSchedule ir_sch(mod_expr);
+  ASSERT_EQ(ir_sch.GetLoops("B").size(), 3);
+  UnrollLoop(&ast_expr);
+  // check after the last UnrollLoop pass it will remain unchanged
+  ASSERT_EQ(ir_sch.GetLoops("B").size(), 3);
+
+  ASSERT_TRUE(ast_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>() != nullptr);
+  auto* block_realize  = ast_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>();
+  auto* schedule_block = block_realize->schedule_block.As<ir::ScheduleBlock>();
+  // set the 'auto_unroll_max_step' attribute as value 25 that is bigger than
+  // the product of extent of the inner 2 loops
+  schedule_block->attrs.emplace(ir::attr::auto_unroll_max_step, 25);
+  UnrollLoop(&ast_expr);
+  EXPECT_EQ(ir_sch.GetLoops("B").size(), 1);
+}
+
+}  // namespace optim
+}  // namespace cinn


### PR DESCRIPTION
1. Add a field named `attrs` in ir::ScheduleBlock, which is a map to store some auxiliary attributes used in follow-up passes
2. Enhance the `UnrollLoop` pass to support auto-unroll and keep compatible with current unrolled mode tagging `ForType::Unrolled`