### PR TITLE
Put input parameters into the input of a frontend::Program.

### DIFF
--- a/cinn/frontend/op_mappers/paddle/fetch_feed.cc
+++ b/cinn/frontend/op_mappers/paddle/fetch_feed.cc
@@ -32,6 +32,14 @@ void FeedOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   auto feed_name = op_desc.Output("Out").front();
   VLOG(4) << "Model get feed [" << feed_name << "]";
 
+  // For input parameters
+  if (ctx.Scope().FindVar(cinn::utils::TransValidVarName(feed_name))) {
+    auto param = ctx.GetVar(feed_name);
+    ctx.Builder()->CreateInput(param);
+    return;
+  }
+
+  // For input variables
   const auto& feed_info = ctx.GetFeedInfo(feed_name);
   auto cinn_id          = cinn::utils::TransValidVarName(feed_name);
   auto input            = ctx.Builder()->CreateInput(feed_info.type, feed_info.shape, cinn_id);


### PR DESCRIPTION
Put input parameters into the input of a frontend::Program, because some passes may need to query all the input ids of a program, such as `RemoveIdentity`.