### PR TITLE
fix `FLAGS_cinn_source_code_save_path` should append source code into file

### DIFF
--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -94,9 +94,9 @@ void Compiler::CompileCudaModule(const Module& module, const std::string& code, 
       }
     } else {
       VLOG(4) << "Write to " << FLAGS_cinn_source_code_save_path;
-      std::ofstream of(FLAGS_cinn_source_code_save_path);
+      std::ofstream of(FLAGS_cinn_source_code_save_path, std::ofstream::out | std::ofstream::app);
       CHECK(of.is_open()) << "Failed to open " << FLAGS_cinn_source_code_save_path;
-      of << source_code;
+      of << source_code << std::endl;
       of.close();
     }
     using runtime::cuda::CUDAModule;


### PR DESCRIPTION
As title. 之前`FLAGS_cinn_source_code_save_path`并非设置为`app`，导致每次写入source code 都是覆盖前面已经写入的source code ，这导致在多子图的情况下只保留的最后一个子图的source code。