### PR TITLE
add SerializedToString in TuneTask

### DIFF
--- a/cinn/auto_schedule/auto_tuner.cc
+++ b/cinn/auto_schedule/auto_tuner.cc
@@ -26,6 +26,7 @@
 #include "cinn/auto_schedule/task/task_creator.h"
 #include "cinn/auto_schedule/task/tune_task.h"
 #include "cinn/auto_schedule/task_scheduler/task_scheduler.h"
+#include "cinn/common/type.h"
 
 namespace cinn {
 namespace auto_schedule {
@@ -44,6 +45,9 @@ void AutoTuner::Initialize(const Config& config, hlir::framework::GraphCompiler*
   for (TuneTask& task : tasks_) {
     task.SetGraphCompiler(graph_compiler);
     task.TaskGraphToUnoptLoweredFunc();
+    task.SerializeToString(graph_->GetAttrs<absl::flat_hash_map<std::string, hlir::framework::shape_t>>("infershape"),
+                           graph_->GetAttrs<absl::flat_hash_map<std::string, common::Type>>("inferdtype"));
+    VLOG(3) << "Add a task with serialized_key:\n" << task.serialized_key;
   }
 
   // create task optimizers

--- a/cinn/auto_schedule/task/tune_task.h
+++ b/cinn/auto_schedule/task/tune_task.h
@@ -14,10 +14,14 @@
 
 #pragma once
 
+#include <absl/container/flat_hash_map.h>
+
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "cinn/common/target.h"
+#include "cinn/common/type.h"
 #include "cinn/hlir/framework/graph.h"
 #include "cinn/hlir/framework/graph_compiler.h"
 #include "cinn/hlir/framework/node.h"
@@ -44,6 +48,9 @@ class TuneTask {
   // When you set GraphCompiler and task_graph, lower the task graph to
   // un-optimized LoweredFunc and store in lowered_funcs().
   void TaskGraphToUnoptLoweredFunc();
+  // Serialize this task as a string contains specific fields of it
+  const std::string& SerializeToString(const absl::flat_hash_map<std::string, hlir::framework::shape_t>& shape_dict,
+                                       const absl::flat_hash_map<std::string, cinn::common::Type>& dtype_dict);
 
   // In CINN, we use std::vector<hlir::framework::Node*> to represent a fused
   // sub-graph (if an op won't be fused, it will be a vector with size=1). So
@@ -55,6 +62,9 @@ class TuneTask {
   std::vector<ir::LoweredFunc> lowered_funcs;
   // names of the output arguments of lowered_funcs_
   std::unordered_set<std::string> output_names;
+  // serialized string of this task, it contain struct,shape,dtype informat
+  // and can be further used to hash
+  std::string serialized_key;
 
  private:
   // Not owned

--- a/cinn/auto_schedule/task/tune_task_test.cc
+++ b/cinn/auto_schedule/task/tune_task_test.cc
@@ -62,7 +62,7 @@ TEST(TuneTask, GraphToUnoptLoweredFunc_NoPass) {
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
 #else
-  Target target          = common::DefaultHostTarget();
+  Target target                  = common::DefaultHostTarget();
 #endif
   Program prog = CreateAddProgram();
   auto graph   = std::make_shared<hlir::framework::Graph>(prog, target);
@@ -133,7 +133,7 @@ TEST(TuneTask, GraphToUnoptLoweredFunc_ApplyPass) {
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
 #else
-  Target target          = common::DefaultHostTarget();
+  Target target                  = common::DefaultHostTarget();
 #endif
   Program prog = CreateAddProgram();
   auto graph   = std::make_shared<hlir::framework::Graph>(prog, target);
@@ -198,7 +198,7 @@ TEST(TuneTask, GraphToUnoptLoweredFunc_ApplyPass) {
 }
 )ROC";
 #else
-  std::string target_str = R"ROC(
+  std::string target_str         = R"ROC(
 {
   ScheduleBlock(root)
   {
@@ -234,6 +234,69 @@ TEST(TuneTask, GraphToUnoptLoweredFunc_ApplyPass) {
   LOG(INFO) << target_str;
   LOG(INFO) << expr_str;
   EXPECT_EQ(utils::Trim(target_str), utils::Trim(expr_str));
+}
+
+TEST(TuneTask, SerializeToString) {
+  Context::Global().ResetNameId();
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
+  Target target                  = common::DefaultHostTarget();
+#endif
+  Program prog = CreateAddProgram();
+  auto graph   = std::make_shared<hlir::framework::Graph>(prog, target);
+
+  TaskCreator task_creator;
+  std::vector<TuneTask> single_tasks = task_creator.CreateTuneTaskOpLevel(graph.get());
+  ASSERT_EQ(single_tasks.size(), 2UL);
+  for (auto&& task : single_tasks) {
+    task.SerializeToString(graph->GetAttrs<absl::flat_hash_map<std::string, hlir::framework::shape_t>>("infershape"),
+                           graph->GetAttrs<absl::flat_hash_map<std::string, common::Type>>("inferdtype"));
+  }
+
+#ifdef CINN_WITH_CUDA
+  std::string single_add_str = R"ROC(Target<linux,nvgpu,64>
+
+Group 0 {
+  (float32[32,24]) = elementwise_add(float32[32,24], float32[32,24])
+}
+)ROC";
+#else
+  std::string single_add_str     = R"ROC(Target<linux,x86,64>
+
+Group 0 {
+  (float32[32,24]) = elementwise_add(float32[32,24], float32[32,24])
+}
+)ROC";
+#endif
+  EXPECT_EQ(single_tasks[0].serialized_key, single_add_str);
+  EXPECT_EQ(single_tasks[1].serialized_key, single_add_str);
+
+  ApplyPass(graph.get(), "OpFusion");
+  std::vector<TuneTask> fused_tasks = task_creator.CreateTuneTaskOpLevel(graph.get());
+  ASSERT_EQ(fused_tasks.size(), 1UL);
+  fused_tasks[0].SerializeToString(
+      graph->GetAttrs<absl::flat_hash_map<std::string, hlir::framework::shape_t>>("infershape"),
+      graph->GetAttrs<absl::flat_hash_map<std::string, common::Type>>("inferdtype"));
+
+#ifdef CINN_WITH_CUDA
+  std::string fused_expected_str = R"ROC(Target<linux,nvgpu,64>
+
+Group 0 {
+  (float32[32,24]) = elementwise_add(float32[32,24], float32[32,24])
+  (float32[32,24]) = elementwise_add(float32[32,24], float32[32,24])
+}
+)ROC";
+#else
+  std::string fused_expected_str = R"ROC(Target<linux,x86,64>
+
+Group 0 {
+  (float32[32,24]) = elementwise_add(float32[32,24], float32[32,24])
+  (float32[32,24]) = elementwise_add(float32[32,24], float32[32,24])
+}
+)ROC";
+#endif
+  EXPECT_EQ(fused_tasks[0].serialized_key, fused_expected_str);
 }
 
 }  // namespace auto_schedule


### PR DESCRIPTION
add `SerializedToString` function in `TuneTask` class, which generate a string named `serialized_key` that is a newly added public field.
The string contain `target`, shape and dtype of all nodes of a specified task, and can be regarded as an identification of the task.