### PR TITLE
split local vars out of singletons

### DIFF
--- a/cinn/backends/codegen_cuda_dev_test.cc
+++ b/cinn/backends/codegen_cuda_dev_test.cc
@@ -1492,8 +1492,8 @@ TEST(CodeGenCUDA, jit_host_call_cuda_kernel) {
 
   LOG(INFO) << "fn_kernel: " << fn_kernel;
 
-  RuntimeSymbolRegistry::Global().RegisterFn("fn_kernel_ptr_", reinterpret_cast<void*>(&fn_kernel));
-  RuntimeSymbolRegistry::Global().RegisterVar("fn_kernel_stream_ptr_", stream);
+  GlobalSymbolRegistry::Global().RegisterFn("fn_kernel_ptr_", reinterpret_cast<void*>(&fn_kernel));
+  GlobalSymbolRegistry::Global().RegisterVar("fn_kernel_stream_ptr_", stream);
 
   // compile host
   {

--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -78,53 +78,49 @@ void Compiler::CompileCudaModule(const Module& module, const std::string& code, 
   auto& device_module              = std::get<1>(_host_module_device_module_);
   VLOG(3) << "[CUDA] host module:\n" << host_module;
 
-  {  // compile cuda device
-    VLOG(3) << "[CUDA] device module:\n" << device_module;
-    CodeGenCUDA_Dev codegen(target_);
-    auto source_code = codegen.Compile(device_module);
-    if (!code.empty()) source_code = code;
-    if (FLAGS_cinn_source_code_save_path.empty()) {
-      if (source_code.size() > DebugLogMaxLen) {
-        VLOG(3) << "[CUDA] source code-0:\n" << source_code.substr(0, DebugLogMaxLen);
-        for (int i = 1; i * DebugLogMaxLen < source_code.size(); ++i) {
-          VLOG(3) << "[CUDA] source code-" << i << ":\n" << source_code.substr(DebugLogMaxLen * i, DebugLogMaxLen);
-        }
-      } else {
-        VLOG(3) << "[CUDA] source code:\n" << source_code;
+  VLOG(3) << "[CUDA] device module:\n" << device_module;
+  CodeGenCUDA_Dev codegen(target_);
+  auto source_code = codegen.Compile(device_module);
+  if (!code.empty()) source_code = code;
+  if (FLAGS_cinn_source_code_save_path.empty()) {
+    if (source_code.size() > DebugLogMaxLen) {
+      VLOG(3) << "[CUDA] source code-0:\n" << source_code.substr(0, DebugLogMaxLen);
+      for (int i = 1; i * DebugLogMaxLen < source_code.size(); ++i) {
+        VLOG(3) << "[CUDA] source code-" << i << ":\n" << source_code.substr(DebugLogMaxLen * i, DebugLogMaxLen);
       }
     } else {
-      VLOG(4) << "Write to " << FLAGS_cinn_source_code_save_path;
-      std::ofstream of(FLAGS_cinn_source_code_save_path, std::ofstream::out | std::ofstream::app);
-      CHECK(of.is_open()) << "Failed to open " << FLAGS_cinn_source_code_save_path;
-      of << source_code << std::endl;
-      of.close();
+      VLOG(3) << "[CUDA] source code:\n" << source_code;
     }
-    using runtime::cuda::CUDAModule;
+  } else {
+    VLOG(4) << "Write to " << FLAGS_cinn_source_code_save_path;
+    std::ofstream of(FLAGS_cinn_source_code_save_path, std::ofstream::out | std::ofstream::app);
+    CHECK(of.is_open()) << "Failed to open " << FLAGS_cinn_source_code_save_path;
+    of << source_code << std::endl;
+    of.close();
+  }
+  using runtime::cuda::CUDAModule;
 
-    backends::NVRTC_Compiler compiler;
+  backends::NVRTC_Compiler compiler;
 
-    auto ptx = compiler(source_code);
-    CHECK(!ptx.empty());
+  auto ptx = compiler(source_code);
+  CHECK(!ptx.empty());
 
-    // TODO(Superjomn) Whether to support multiple CUDA modules?
-    cuda_module_.reset(new CUDAModule(ptx, CUDAModule::Kind::PTX));
+  // TODO(Superjomn) Whether to support multiple CUDA modules?
+  cuda_module_.reset(new CUDAModule(ptx, CUDAModule::Kind::PTX));
 
-    for (auto& fn : device_module.functions()) {
-      std::string kernel_fn_name = fn->name;
-      auto fn_kernel             = cuda_module_->GetFunction(0, kernel_fn_name);
-      CHECK(fn_kernel);
+  RuntimeSymbols symbols;
 
-      backends::GlobalSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_ptr_",
-                                                           reinterpret_cast<void*>(fn_kernel));
-      backends::GlobalSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_",
-                                                           static_cast<cudaStream_t>(stream));
-    }
+  for (auto& fn : device_module.functions()) {
+    std::string kernel_fn_name = fn->name;
+    auto fn_kernel             = cuda_module_->GetFunction(0, kernel_fn_name);
+    CHECK(fn_kernel);
+
+    symbols.RegisterVar(kernel_fn_name + "_ptr_", reinterpret_cast<void*>(fn_kernel));
+    symbols.RegisterVar(kernel_fn_name + "_stream_ptr_", static_cast<cudaStream_t>(stream));
   }
 
-  {  // compile host jit
-    engine_ = ExecutionEngine::Create(ExecutionOptions());
-    engine_->Link<CodeGenCUDA_Host>(host_module);
-  }
+  engine_ = ExecutionEngine::Create(ExecutionOptions(), std::move(symbols));
+  engine_->Link<CodeGenCUDA_Host>(host_module);
 
 #else
   CINN_NOT_IMPLEMENTED

--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -114,10 +114,10 @@ void Compiler::CompileCudaModule(const Module& module, const std::string& code, 
       auto fn_kernel             = cuda_module_->GetFunction(0, kernel_fn_name);
       CHECK(fn_kernel);
 
-      backends::RuntimeSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_ptr_",
-                                                            reinterpret_cast<void*>(fn_kernel));
-      backends::RuntimeSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_",
-                                                            static_cast<cudaStream_t>(stream));
+      backends::GlobalSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_ptr_",
+                                                           reinterpret_cast<void*>(fn_kernel));
+      backends::GlobalSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_",
+                                                           static_cast<cudaStream_t>(stream));
     }
   }
 

--- a/cinn/backends/extern_func_jit_register.cc
+++ b/cinn/backends/extern_func_jit_register.cc
@@ -28,7 +28,7 @@ void RegisterExternFunctionHelper(const std::string &fn_name,
 
   ExternFunctionEmitterRegistry::Global().Register(ExternFuncID{TargetToBackendRepr(target), fn_name.c_str()}, fn_name);
 
-  RuntimeSymbolRegistry::Global().RegisterFn(fn_name, reinterpret_cast<void *>(fn_ptr));
+  GlobalSymbolRegistry::Global().RegisterFn(fn_name, reinterpret_cast<void *>(fn_ptr));
 }
 
 void RegisterExternFunction::End() {

--- a/cinn/backends/llvm/execution_engine.cc
+++ b/cinn/backends/llvm/execution_engine.cc
@@ -102,6 +102,10 @@ std::unique_ptr<llvm::MemoryBuffer> NaiveObjectCache::getObject(const llvm::Modu
   return llvm::MemoryBuffer::getMemBuffer(it->second->getMemBufferRef());
 }
 
+/*static*/ std::unique_ptr<ExecutionEngine> ExecutionEngine::Create(const ExecutionOptions &config) {
+  return Create(config, {});
+}
+
 /*static*/ std::unique_ptr<ExecutionEngine> ExecutionEngine::Create(const ExecutionOptions &config,
                                                                     RuntimeSymbols &&module_symbols) {
   VLOG(1) << "===================== Create CINN ExecutionEngine begin ====================";

--- a/cinn/backends/llvm/execution_engine.cc
+++ b/cinn/backends/llvm/execution_engine.cc
@@ -221,7 +221,7 @@ void *ExecutionEngine::Lookup(absl::string_view name) {
 }
 
 void ExecutionEngine::RegisterRuntimeSymbols() {
-  const auto &registry = RuntimeSymbolRegistry::Global();
+  const auto &registry = GlobalSymbolRegistry::Global();
   auto *session        = &jit_->getExecutionSession();
   for (const auto &_name_addr_ : registry.All()) {
     auto &name = std::get<0>(_name_addr_);

--- a/cinn/backends/llvm/execution_engine.h
+++ b/cinn/backends/llvm/execution_engine.h
@@ -69,7 +69,9 @@ struct ExecutionOptions {
 
 class ExecutionEngine {
  public:
-  static std::unique_ptr<ExecutionEngine> Create(const ExecutionOptions &config, RuntimeSymbols &&module_symbols = {});
+  static std::unique_ptr<ExecutionEngine> Create(const ExecutionOptions &config);
+
+  static std::unique_ptr<ExecutionEngine> Create(const ExecutionOptions &config, RuntimeSymbols &&module_symbols);
 
   void *Lookup(absl::string_view name);
 

--- a/cinn/backends/llvm/execution_engine_test.cc
+++ b/cinn/backends/llvm/execution_engine_test.cc
@@ -55,7 +55,7 @@ namespace backends {
 
 namespace {
 bool RegisterKnownSymbols() {
-  decltype(auto) registry = RuntimeSymbolRegistry::Global();
+  decltype(auto) registry = GlobalSymbolRegistry::Global();
 
   registry.RegisterFn("sinf", reinterpret_cast<void *>(&sinf));
   registry.RegisterFn("sin", reinterpret_cast<void *>(static_cast<double (*)(double)>(&sin)));
@@ -251,7 +251,7 @@ TEST(ExecutionEngine, custom_runtime_symbols) {
   int random_x = dis(mt);
   int random_y = dis(mt);
 
-  decltype(auto) registry = RuntimeSymbolRegistry::Global();
+  decltype(auto) registry = GlobalSymbolRegistry::Global();
   // registry.Register("dereference_f64_ptr", (void *)+[](double *x) { return *x; });
 
   for (size_t i = 0; i < angle.size(); i++) {

--- a/cinn/backends/llvm/runtime_symbol_registry.cc
+++ b/cinn/backends/llvm/runtime_symbol_registry.cc
@@ -22,12 +22,12 @@
 namespace cinn {
 namespace backends {
 
-RuntimeSymbolRegistry &RuntimeSymbolRegistry::Global() {
-  static RuntimeSymbolRegistry registry;
-  return registry;
+RuntimeSymbols &GlobalSymbolRegistry::Global() {
+  static RuntimeSymbols symbols;
+  return symbols;
 }
 
-void *RuntimeSymbolRegistry::Lookup(absl::string_view name) const {
+void *RuntimeSymbols::Lookup(absl::string_view name) const {
   std::lock_guard<std::mutex> lock(mu_);
   auto it = symbols_.find(std::string(name));
   if (it != symbols_.end()) {
@@ -37,7 +37,7 @@ void *RuntimeSymbolRegistry::Lookup(absl::string_view name) const {
   return nullptr;
 }
 
-void RuntimeSymbolRegistry::Register(const std::string &name, void *address) {
+void RuntimeSymbols::Register(const std::string &name, void *address) {
 #ifdef CINN_WITH_DEBUG
   RAW_LOG_INFO("JIT Register function [%s]: %p", name.c_str(), address);
 #endif  // CINN_WITH_DEBUG
@@ -51,7 +51,7 @@ void RuntimeSymbolRegistry::Register(const std::string &name, void *address) {
   symbols_.insert({name, reinterpret_cast<void *>(address)});
 }
 
-void RuntimeSymbolRegistry::Clear() {
+void RuntimeSymbols::Clear() {
   std::lock_guard<std::mutex> lock(mu_);
   symbols_.clear();
   scalar_holder_.clear();

--- a/cinn/backends/llvm/runtime_symbol_registry.h
+++ b/cinn/backends/llvm/runtime_symbol_registry.h
@@ -29,13 +29,8 @@
 namespace cinn {
 namespace backends {
 
-/**
- * Registry for runtime symbols, these symbols will be inserted into JIT.
- */
-class RuntimeSymbolRegistry {
+class RuntimeSymbols {
  public:
-  static RuntimeSymbolRegistry &Global();
-
   /**
    * Register function address.
    * @param name Name of the symbol.
@@ -49,7 +44,7 @@ class RuntimeSymbolRegistry {
    * @param name Name of the symbol.
    * @param val Scalar value.
    */
-  template <typename T>
+  template <typename T, typename = std::enable_if<std::is_pod<T>::value>>
   void RegisterVar(const std::string &name, T val) {
     void *data_ptr = nullptr;
     {
@@ -87,12 +82,22 @@ class RuntimeSymbolRegistry {
    */
   void Register(const std::string &name, void *address);
 
-  RuntimeSymbolRegistry() = default;
-  CINN_DISALLOW_COPY_AND_ASSIGN(RuntimeSymbolRegistry);
-
   mutable std::mutex mu_;
   std::map<std::string, void *> symbols_;
   std::map<std::string, std::vector<int8_t>> scalar_holder_;
+};
+
+/**
+ * Registry for runtime symbols, these symbols will be inserted into JIT.
+ */
+
+class GlobalSymbolRegistry {
+ public:
+  static RuntimeSymbols &Global();
+
+ private:
+  GlobalSymbolRegistry() = default;
+  CINN_DISALLOW_COPY_AND_ASSIGN(GlobalSymbolRegistry);
 };
 
 }  // namespace backends

--- a/cinn/backends/llvm/runtime_symbol_registry.h
+++ b/cinn/backends/llvm/runtime_symbol_registry.h
@@ -31,6 +31,15 @@ namespace backends {
 
 class RuntimeSymbols {
  public:
+  RuntimeSymbols() = default;
+
+  RuntimeSymbols(const RuntimeSymbols &) = delete;
+
+  RuntimeSymbols(RuntimeSymbols &&rhs) {
+    symbols_       = std::move(rhs.symbols_);
+    scalar_holder_ = std::move(rhs.scalar_holder_);
+  }
+
   /**
    * Register function address.
    * @param name Name of the symbol.

--- a/cinn/backends/llvm/simple_jit.cc
+++ b/cinn/backends/llvm/simple_jit.cc
@@ -102,7 +102,7 @@ SimpleJIT::SimpleJIT() : context_(std::make_unique<llvm::LLVMContext>()) {
 
   llvm::orc::MangleAndInterner mangle(jit_->getExecutionSession(), jit_->getDataLayout());
 
-  for (auto &item : RuntimeSymbolRegistry::Global().All()) {
+  for (auto &item : GlobalSymbolRegistry::Global().All()) {
     VLOG(2) << "Insert [" << item.first << "] to SimpleJIT";
     llvm::cantFail(jit_->define(llvm::orc::absoluteSymbols(
         {{mangle(item.first), {llvm::pointerToJITTargetAddress(item.second), llvm::JITSymbolFlags::None}}})));

--- a/cinn/common/cuda_test_helper.cc
+++ b/cinn/common/cuda_test_helper.cc
@@ -52,9 +52,9 @@ void CudaModuleTester::Compile(const ir::Module& m, const std::string& rewrite_c
     CHECK(fn_kernel);
     kernel_handles_.push_back(fn_kernel);
 
-    backends::RuntimeSymbolRegistry::Global().RegisterFn(kernel_fn_name + "_ptr_",
-                                                         reinterpret_cast<void*>(&kernel_handles_.back()));
-    backends::RuntimeSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_", stream_);
+    backends::GlobalSymbolRegistry::Global().RegisterFn(kernel_fn_name + "_ptr_",
+                                                        reinterpret_cast<void*>(&kernel_handles_.back()));
+    backends::GlobalSymbolRegistry::Global().RegisterVar(kernel_fn_name + "_stream_ptr_", stream_);
   }
 
   jit_ = backends::SimpleJIT::Create();

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -334,9 +334,9 @@ TEST(Operator, Operator_Reduction_Case_7) {
 
   // register cufunction and stream
   void* stream = nullptr;
-  backends::RuntimeSymbolRegistry::Global().RegisterFn(func_name + "_kernel_ptr_",
-                                                       reinterpret_cast<void*>(&reduce_sum_kernel));
-  backends::RuntimeSymbolRegistry::Global().RegisterVar(func_name + "_kernel_stream_ptr_", stream);
+  backends::GlobalSymbolRegistry::Global().RegisterFn(func_name + "_kernel_ptr_",
+                                                      reinterpret_cast<void*>(&reduce_sum_kernel));
+  backends::GlobalSymbolRegistry::Global().RegisterVar(func_name + "_kernel_stream_ptr_", stream);
 
   // gen host code
   auto jit = backends::SimpleJIT::Create();

--- a/cinn/pybind/backends.cc
+++ b/cinn/pybind/backends.cc
@@ -49,8 +49,12 @@ void BindExecutionEngine(py::module *m) {
   };
 
   py::class_<ExecutionEngine> engine(*m, "ExecutionEngine");
-  engine.def_static("create", &ExecutionEngine::Create, py::arg("options") = ExecutionOptions())
-      .def(py::init(&ExecutionEngine::Create), py::arg("options") = ExecutionOptions())
+  engine
+      .def_static("create",
+                  py::overload_cast<const ExecutionOptions &>(&ExecutionEngine::Create),
+                  py::arg("options") = ExecutionOptions())
+      .def(py::init(py::overload_cast<const ExecutionOptions &>(&ExecutionEngine::Create)),
+           py::arg("options") = ExecutionOptions())
       .def("lookup", lookup)
       .def("link", &ExecutionEngine::Link);
 

--- a/cinn/runtime/cpu/thread_backend.cc
+++ b/cinn/runtime/cpu/thread_backend.cc
@@ -55,7 +55,7 @@ CINN_REGISTER_HELPER(cinn_backend_parallel) {
   using namespace cinn;  // NOLINT
   using backends::FunctionProto;
   auto host_target = common::DefaultHostTarget();
-  backends::RuntimeSymbolRegistry::Global().RegisterFn(runtime::intrinsic::parallel_launch,
-                                                       reinterpret_cast<void*>(&cinn_backend_parallel_launch));
+  backends::GlobalSymbolRegistry::Global().RegisterFn(runtime::intrinsic::parallel_launch,
+                                                      reinterpret_cast<void*>(&cinn_backend_parallel_launch));
   return true;
 }


### PR DESCRIPTION
For modularization, this PR splits the variables registered to the `llvm::orc::LLJIT` module in the `cinn::backends::ExecutionEngine` into **_global_** and **_local_** parts.