### PR TITLE
Fix op implementation with new ir schedule

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -112,7 +112,7 @@ function prepare_ci {
   pip install clang-format==9.0
   pip install wheel
   pip install sphinx==3.3.1 sphinx_gallery==0.8.1 recommonmark==0.6.0 exhale scipy breathe==4.24.0 matplotlib sphinx_rtd_theme
-  pip install paddlepaddle-gpu==2.2.2.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+  pip install paddlepaddle-gpu==2.3.1.post101 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
 }
 
 function prepare_doc_model_file {

--- a/cinn/common/cinn_value.cc
+++ b/cinn/common/cinn_value.cc
@@ -92,9 +92,15 @@ bool CINNValue::is_string() const { return type_code_ == TypeCode<std::string>()
 
 bool CINNValue::is_var() const { return type_code_ == TypeCode<ir::Var>(); }
 
-bool CINNValue::is_expr() const { return type_code_ == TypeCode<ir::Expr>(); }
+bool CINNValue::is_expr() const {
+  return type_code_ == TypeCode<ir::Expr>() && !absl::any_cast<Expr>(shared_).as_tensor();
+}
 
 bool CINNValue::is_stagemap() const { return type_code_ == TypeCode<poly::StageMap>(); }
+
+bool CINNValue::is_tensor() const {
+  return type_code_ == TypeCode<ir::Expr>() && absl::any_cast<Expr>(shared_).as_tensor();
+}
 
 CINNValue::operator std::string() const {
   CHECK_EQ(type_code_, TypeCode<std::string>());

--- a/cinn/common/cinn_value.h
+++ b/cinn/common/cinn_value.h
@@ -153,6 +153,7 @@ class CINNValue : public cinn_pod_value_t {
   bool is_var() const;
   bool is_expr() const;
   bool is_stagemap() const;
+  bool is_tensor() const;
 
   //! Assign operators
   // @{

--- a/cinn/hlir/framework/op_lowering.cc
+++ b/cinn/hlir/framework/op_lowering.cc
@@ -332,7 +332,18 @@ std::vector<Expr> OpLowerer::IRElementwiseCompute(poly::StageMap& stages,
     auto func = lang::LowerVec("fn_" + node->id(), node_stages, tensor_inputs, {}, {}, nullptr, this->target_, true);
     CHECK_EQ(func.size(), 1);
 
-    common::CINNValuePack expr_pack = impl->fschedule(common::CINNValuePack{{common::CINNValue(func[0]->body)}});
+    std::vector<common::CINNValue> schedule_inputs;
+    // collect tensor
+    for (int idx = 0; idx < pack.size() - 1; ++idx) {
+      CHECK(pack[idx].is_tensor());
+      schedule_inputs.push_back(common::CINNValue(pack[idx]));
+    }
+    for (auto& f : func) {
+      schedule_inputs.push_back(common::CINNValue(f->body));
+    }
+    // do ast tree schedule
+    common::CINNValuePack expr_pack = impl->fschedule(common::CINNValuePack{schedule_inputs});
+
     CHECK_EQ(expr_pack.size(), 1);
     Expr ast_expr = expr_pack[0];
     ast_exprs.push_back(ast_expr);
@@ -432,6 +443,7 @@ std::vector<Expr> OpLowerer::IRReduceCompute(poly::StageMap& stages,
       std::vector<common::CINNValue> schedule_inputs;
       // collect tensor
       for (int idx = 0; idx < pack.size() - 1; ++idx) {
+        CHECK(pack[idx].is_tensor());
         schedule_inputs.push_back(common::CINNValue(pack[idx]));
       }
       for (auto& f : func) {
@@ -1071,10 +1083,10 @@ std::vector<ir::LoweredFunc> OpLowerer::IRLowerOpaqueOp(GroupPtr& group) {
   }
 
   auto impl = OpStrategy::SelectImpl(cinn_strategy[node->op()](node->attrs, inputs, out_types, out_shapes, target_));
-  common::CINNValuePack C = impl->fcompute(common::CINNValuePack{cinn_inputs});
+  common::CINNValuePack pack = impl->fcompute(common::CINNValuePack{cinn_inputs});
 
-  for (int i = 0; i < C->size() - 1; i++) {
-    ir::Expr temp = C[i];
+  for (int i = 0; i < pack->size() - 1; i++) {
+    ir::Expr temp = pack[i];
     // checkout whether the tensor is with buffer.
     if (!temp.as_tensor_ref()->buffer.defined() || this->target_ != common::DefaultNVGPUTarget()) {
       inputs.push_back(temp.as_tensor_ref());
@@ -1083,14 +1095,19 @@ std::vector<ir::LoweredFunc> OpLowerer::IRLowerOpaqueOp(GroupPtr& group) {
     }
   }
 
-  poly::StageMap stages = C.back();
+  poly::StageMap stages = pack.back();
   auto func             = lang::LowerVec(group->GetFuncName(), stages, inputs, {}, {}, nullptr, this->target_, true);
 
   std::vector<common::CINNValue> schedule_inputs;
+  // collect tensor
+  for (int idx = 0; idx < pack.size() - 1; ++idx) {
+    CHECK(pack[idx].is_tensor());
+    schedule_inputs.push_back(common::CINNValue(pack[idx]));
+  }
   for (auto& f : func) {
     schedule_inputs.push_back(common::CINNValue(f->body));
   }
-
+  // do ast tree schedule
   common::CINNValuePack expr_pack = impl->fschedule(common::CINNValuePack{schedule_inputs});
 
   std::vector<ir::LoweredFunc> res;

--- a/cinn/hlir/op/broadcast.cc
+++ b/cinn/hlir/op/broadcast.cc
@@ -88,19 +88,23 @@ std::shared_ptr<OpStrategy> StrategyForBroadcast(
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of " << op_name << " schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of " << op_name << " schedule is empty! Please check.";
@@ -226,19 +230,23 @@ std::shared_ptr<OpStrategy> StrategyForBroadcastTo(const framework::NodeAttr &at
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of broadcast_to schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, out_shape, target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, out_shape, target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(CINNValue(ir_sch.GetModule().GetExprs().at(0)));
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of broadcast_to schedule is empty! Please check.";

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -82,18 +82,23 @@ std::shared_ptr<OpStrategy> StrategyForElementwise(const framework::NodeAttr &at
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of " << op_name << " schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of " << op_name << " schedule is empty! Please check.";
@@ -184,18 +189,23 @@ std::shared_ptr<OpStrategy> StrategyForScale(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of scale schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of scale schedule is empty! Please check.";
@@ -264,18 +274,23 @@ std::shared_ptr<OpStrategy> StrategyForConstScalar(const framework::NodeAttr &at
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of create_const_float schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of create_const_float schedule is empty! Please check.";
@@ -390,19 +405,23 @@ std::shared_ptr<OpStrategy> StrategyForFillConstant(const framework::NodeAttr &a
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of create_const_float schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of create_const_float schedule is empty! Please check.";

--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -65,19 +65,23 @@ std::shared_ptr<OpStrategy> StrategyForRelu(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of relu schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of relu schedule is empty! Please check.\n";
@@ -147,19 +151,23 @@ std::shared_ptr<OpStrategy> StrategyForRelu6(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of relu schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of relu6 schedule is empty! Please check.\n";
@@ -349,49 +357,35 @@ std::shared_ptr<OpStrategy> StrategyForConv2d(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of conv2d schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      std::vector<Expr> vec_ast{};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
+      ir::ModuleExpr mod_expr(vec_ast);
+      ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
 #ifdef CINN_WITH_CUDNN
         // If conv_type is backward_filter or backward_data, we built a fake op.
         // As runtime use cudnn to compute conv2d, this fake op is not to be called.
         // When cinn support backward_filter/backward_data code gen, this code is to be removed.
         if (conv_type != "forward") {
-          CHECK(arg_pack[0].is_expr());
-          Expr temp = arg_pack[0];
-          vec_ast.push_back(temp);
-          ir::ModuleExpr mod_expr(vec_ast);
-          ir::IRSchedule ir_sch(mod_expr);
+          CHECK_EQ(vec_ast.size(), 1);
           pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
-          std::vector<CINNValue> res;
-          res.push_back(arg_pack[0]);
+          std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
           *ret = CINNValuePack{res};
           return;
         }
 #endif
-        LOG(INFO) << "arg_pack size is : " << arg_pack.size();
-        int expr_size = 0;
-        for (int i = 0; i < arg_pack.size(); i++) {
-          if (arg_pack[i].type_code() == 22) {
-            Expr temp = arg_pack[i];
-            expr_size++;
-          }
-        }
+        int expr_size = vec_ast.size();
         if (expr_size == 2) {
-          CHECK(arg_pack[0].is_expr());
-          Expr temp = arg_pack[0];
-          vec_ast.push_back(temp);
-          CHECK(arg_pack[1].is_expr());
-          temp = arg_pack[1];
-          vec_ast.push_back(temp);
-          ir::ModuleExpr mod_expr(vec_ast);
-          ir::IRSchedule ir_sch(mod_expr);
-          ir_sch.MergeExprs();
           pe::IRCudaScheduleConv(ir_sch, target);
-          std::vector<CINNValue> res;
-          temp = arg_pack[0];
-          VLOG(3) << "After IRCudaScheduleConv, arg_pack[0] is : " << temp;
-          res.push_back(arg_pack[0]);
+          VLOG(3) << "After IRCudaScheduleConv, arg_pack[0] is : " << ir_sch.GetModule().GetExprs().at(0);
+          std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
           *ret = CINNValuePack{res};
           return;
         } else {
@@ -1138,19 +1132,23 @@ std::shared_ptr<OpStrategy> StrategyForBatchNorm(const framework::NodeAttr &attr
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of batchnorm schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of batchnorm schedule is empty! Please check.\n";
@@ -1275,21 +1273,31 @@ std::shared_ptr<OpStrategy> StrategyForPool1d(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of pool1d schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 2UL);
-      CHECK(arg_pack[0].is_expr());
-      CHECK(arg_pack[arg_pack.size() - 1].is_expr());
-      Expr Out      = arg_pack[0];
-      Expr ast_expr = arg_pack[arg_pack.size() - 1];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      std::vector<Expr> vec_tensor;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        } else if (arg_pack[i].is_tensor()) {
+          Expr temp = arg_pack[i];
+          vec_tensor.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (arg_pack.size() == 3UL) {
-        Expr input_pad = arg_pack[1];
+        CHECK_EQ(vec_tensor.size(), 2);
+        Expr input_pad = vec_tensor[1];
         CHECK(input_pad.as_tensor());
         auto block_input_pad = ir_sch.GetBlock(input_pad.as_tensor()->name);
         ir_sch.ComputeInline(block_input_pad);
       }
       if (target.arch == Target::Arch::NVGPU) {
+        CHECK(!vec_tensor.empty());
+        Expr Out = vec_tensor[0];
         CHECK(Out.as_tensor());
         auto loops = ir_sch.GetLoops(Out.as_tensor()->name);
         ir_sch.Split(loops[1], {-1, 2});
@@ -1297,8 +1305,7 @@ std::shared_ptr<OpStrategy> StrategyForPool1d(const framework::NodeAttr &attrs,
         ir_sch.Bind(loops[0], "blockIdx.x");
         ir_sch.Bind(loops[1], "threadIdx.x");
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[arg_pack.size() - 1]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of pool1d schedule is empty! Please check.\n";
@@ -1523,16 +1530,24 @@ std::shared_ptr<OpStrategy> StrategyForPool2d(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of pool2d schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 2UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr Out = arg_pack[0];
-      CHECK(arg_pack[arg_pack.size() - 1].is_expr());
-      Expr ast_expr = arg_pack[arg_pack.size() - 1];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      std::vector<Expr> vec_tensor;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        } else if (arg_pack[i].is_tensor()) {
+          Expr temp = arg_pack[i];
+          vec_tensor.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (arg_pack.size() == 3UL) {
-        Expr input_pad = arg_pack[1];
+        CHECK_EQ(vec_tensor.size(), 2);
+        Expr input_pad = vec_tensor[1];
         CHECK(input_pad.as_tensor());
         auto block_input_pad = ir_sch.GetBlock(input_pad.as_tensor()->name);
         ir_sch.ComputeInline(block_input_pad);
@@ -1540,8 +1555,7 @@ std::shared_ptr<OpStrategy> StrategyForPool2d(const framework::NodeAttr &attrs,
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRPoolScheduleGPU(ir_sch, target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[arg_pack.size() - 1]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of pool2d schedule is empty! Please check.\n";
@@ -1742,21 +1756,31 @@ std::shared_ptr<OpStrategy> StrategyForPool3d(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of pool3d schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 2UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr Out = arg_pack[0];
-      CHECK(arg_pack[arg_pack.size() - 1].is_expr());
-      Expr ast_expr = arg_pack[arg_pack.size() - 1];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      std::vector<Expr> vec_tensor;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        } else if (arg_pack[i].is_tensor()) {
+          Expr temp = arg_pack[i];
+          vec_tensor.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (arg_pack.size() == 3UL) {
-        Expr input_pad = arg_pack[1];
+        CHECK_EQ(vec_tensor.size(), 2);
+        Expr input_pad = vec_tensor[1];
         CHECK(input_pad.as_tensor());
         auto block_input_pad = ir_sch.GetBlock(input_pad.as_tensor()->name);
         ir_sch.ComputeInline(block_input_pad);
       }
       if (target.arch == Target::Arch::NVGPU) {
+        CHECK(!vec_tensor.empty());
+        Expr Out = vec_tensor[0];
         CHECK(Out.as_tensor());
         auto loops = ir_sch.GetLoops(Out.as_tensor()->name);
         ir_sch.Split(loops[1], {-1, 2});
@@ -1764,8 +1788,7 @@ std::shared_ptr<OpStrategy> StrategyForPool3d(const framework::NodeAttr &attrs,
         ir_sch.Bind(loops[0], "blockIdx.x");
         ir_sch.Bind(loops[1], "threadIdx.x");
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[arg_pack.size() - 1]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of pool3d schedule is empty! Please check.\n";
@@ -1940,15 +1963,14 @@ std::shared_ptr<OpStrategy> StrategyForSoftmax(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input arguments of softmax schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK_GE(arg_pack.size(), 3UL) << "The input tensor's size of softmax schedule is " << arg_pack.size()
-                                     << "and it should be equal to 3! Please check.";
-      CHECK(arg_pack[0].is_expr());
-      Expr out1 = arg_pack[0];
-      CHECK(arg_pack[1].is_expr());
-      Expr out2 = arg_pack[1];
-      std::vector<Expr> vec_ast{};
-      vec_ast.push_back(out1);
-      vec_ast.push_back(out2);
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
       ir_sch.MergeExprs();
@@ -1964,17 +1986,11 @@ std::shared_ptr<OpStrategy> StrategyForSoftmax(const framework::NodeAttr &attrs,
           loops      = ir_sch.GetLoops(all_blocks[1]);
           ir_sch.ComputeAt(all_blocks[0], loops.back());
         }
-        std::vector<CINNValue> res;
-        Expr temp = arg_pack[0];
-        VLOG(3) << "After softmax_schedule, arg_pack[0] is : " << temp;
-        res.push_back(arg_pack[0]);
+        std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
         *ret = CINNValuePack{res};
       } else if (target.arch == Target::Arch::X86) {
         pe::IRSoftmaxScheduleCPU(ir_sch, axis);
-        std::vector<CINNValue> res;
-        Expr temp = arg_pack[0];
-        VLOG(3) << "After IRSoftmaxScheduleCPU, arg_pack[0] is : " << temp;
-        res.push_back(arg_pack[0]);
+        std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
         *ret = CINNValuePack{res};
       }
     } else {
@@ -2073,19 +2089,23 @@ std::shared_ptr<OpStrategy> StrategyForDropoutInfer(const framework::NodeAttr &a
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of dropout_infer schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_EQ(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input arguments of dropout_infer schedule is empty! Please check.";
@@ -2169,19 +2189,23 @@ std::shared_ptr<OpStrategy> StrategyForSelect(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of select schedule is empty! Please check.\n";
       CINNValuePack arg_pack = args[0];
-      CHECK_EQ(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of select schedule is empty! Please check.\n";

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -208,20 +208,32 @@ std::shared_ptr<OpStrategy> StrategyForMatMul(const framework::NodeAttr &attrs,
     CHECK(!args.empty()) << "The input argument of matmul schedule is empty! Please check.\n";
     CINNValuePack arg_pack = args[0];
     if (FLAGS_cinn_ir_schedule) {
-      CHECK_GE(arg_pack.size(), 1UL);
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      if (target.arch == Target::Arch::X86) {
+        CINN_NOT_IMPLEMENTED
+      }
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
       ir_sch.MergeExprs();
       auto blocks = ir_sch.GetAllBlocks();
-      if (ir_sch.GetLoops(blocks[0]).size() == 1) {
-        ir_sch.Bind(ir_sch.GetLoops(blocks[0])[0], "threadIdx.x");
-      } else {
-        ir_sch.Bind(ir_sch.GetLoops(blocks[0])[0], "blockIdx.x");
-        ir_sch.Bind(ir_sch.GetLoops(blocks[0])[1], "threadIdx.x");
+
+      int prod_size = std::accumulate(output_shapes[0].begin(), output_shapes[0].end(), 1, std::multiplies<int>());
+      if (prod_size > 1) {
+        if (ir_sch.GetLoops(blocks[0]).size() == 1) {
+          ir_sch.Bind(ir_sch.GetLoops(blocks[0])[0], "threadIdx.x");
+        } else {
+          ir_sch.Bind(ir_sch.GetLoops(blocks[0])[0], "blockIdx.x");
+          ir_sch.Bind(ir_sch.GetLoops(blocks[0])[1], "threadIdx.x");
+        }
       }
+
       std::vector<CINNValue> results = {CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret                           = CINNValuePack({results});
     } else {
@@ -364,18 +376,23 @@ std::shared_ptr<OpStrategy> StrategyForReshape(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of reshape schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of reshape schedule is empty! Please check.";
@@ -526,12 +543,13 @@ std::shared_ptr<OpStrategy> StrategyForSplit(const framework::NodeAttr &attrs,
       CHECK(!args.empty()) << "The input argument of split schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
       std::vector<Expr> vec_ast;
-      for (int idx = 0; idx < arg_pack.size(); ++idx) {
-        if (arg_pack[idx].is_expr()) {
-          Expr ast_expr = arg_pack[idx];
-          vec_ast.push_back(ast_expr);
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
         }
       }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
       ir_sch.MergeExprs();
@@ -709,18 +727,23 @@ std::shared_ptr<OpStrategy> StrategyForConcat(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of concat schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, false);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of concat schedule is empty! Please check.";
@@ -790,10 +813,10 @@ std::shared_ptr<OpStrategy> StrategyForMul(const framework::NodeAttr &attrs,
                                            const Target &target) {
   framework::CINNCompute mul_compute([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input arguments of Mul compute is empty! Please check.\n";
-    CINNValuePack a = args[0];
-    CHECK_GE(a.size(), 2U) << "at least 2 input tensors for Mul compute\n";
-    Expr A = a[0];
-    Expr B = a[1];
+    CINNValuePack pack_args = args[0];
+    CHECK_GE(pack_args.size(), 2U) << "at least 2 input tensors for Mul compute\n";
+    Expr A = pack_args[0];
+    Expr B = pack_args[1];
     CHECK(A.as_tensor());
     CHECK(B.as_tensor());
     auto attr_store    = attrs.attr_store;
@@ -847,14 +870,20 @@ std::shared_ptr<OpStrategy> StrategyForMul(const framework::NodeAttr &attrs,
     auto new_A = A_tensor->Reshape(new_shape_A, stages);
     auto new_B = B_tensor->Reshape(new_shape_B, stages);
     std::vector<ir::Tensor> out;
+    std::string tensor_name = UniqName("Mul_output");
+    if (FLAGS_cinn_ir_schedule) {
+      CHECK(pack_args.back().is_string());
+      tensor_name = pack_args.back().operator std::string();
+    }
+
     if (target.arch == Target::Arch::X86) {
 #ifdef CINN_WITH_MKL_CBLAS
-      out = pe::MulMKL(new_A, new_B, UniqName("Mul_mkl_output"), target);
+      out = pe::MulMKL(new_A, new_B, tensor_name, target);
 #else
-      out = pe::MulBase(new_A, new_B, UniqName("Mul_output"), target);
+      out = pe::MulBase(new_A, new_B, tensor_name, target);
 #endif
     } else {
-      out = pe::MulBase(new_A, new_B, UniqName("Mul_output"), target);
+      out = pe::MulBase(new_A, new_B, tensor_name, target);
     }
     std::vector<CINNValue> res;
     for (auto &t : out) {
@@ -868,23 +897,48 @@ std::shared_ptr<OpStrategy> StrategyForMul(const framework::NodeAttr &attrs,
   });
 
   framework::CINNSchedule mul_schedule([=](lang::Args args, lang::RetValue *ret) {
-    CHECK(!args.empty()) << "The input argument of mul schedule is empty! Please check.\n";
-    CINNValuePack arg_pack = args[0];
-    CHECK(arg_pack.size() == 2UL || arg_pack.size() == 3UL);
-    Expr out              = arg_pack[0];
-    poly::StageMap stages = arg_pack.back();
-    CHECK(out.as_tensor());
-    if (target.arch == Target::Arch::NVGPU) {
-      pe::CudaScheduleMul(stages, out.as_tensor_ref(), output_shapes.back(), target);
-    } else if (target.arch == Target::Arch::X86) {
-      CHECK_EQ(arg_pack.size(), 3UL);
+    if (FLAGS_cinn_ir_schedule) {
+      CHECK(!args.empty()) << "The input argument of relu schedule is empty! Please check.\n";
+      CINNValuePack arg_pack = args[0];
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
+      ir::ModuleExpr mod_expr(vec_ast);
+      ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
+      if (target.arch == Target::Arch::NVGPU) {
+        pe::IRCudaScheduleMul(ir_sch, output_shapes.front(), target);
+      } else if (target.arch == Target::Arch::X86) {
 #ifndef CINN_WITH_MKL_CBLAS
-      Expr reduce_first = arg_pack[1];
-      CHECK(reduce_first.as_tensor());
-      pe::MulScheduleCPU(stages, out.as_tensor_ref(), reduce_first.as_tensor_ref(), target);
+        pe::IRMulScheduleCPU(ir_sch, output_shapes.back(), target);
 #endif
+      }
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
+      *ret = CINNValuePack{res};
+    } else {
+      CHECK(!args.empty()) << "The input argument of mul schedule is empty! Please check.\n";
+      CINNValuePack arg_pack = args[0];
+      CHECK(arg_pack.size() == 2UL || arg_pack.size() == 3UL);
+      Expr out              = arg_pack[0];
+      poly::StageMap stages = arg_pack.back();
+      CHECK(out.as_tensor());
+      if (target.arch == Target::Arch::NVGPU) {
+        pe::CudaScheduleMul(stages, out.as_tensor_ref(), output_shapes.back(), target);
+      } else if (target.arch == Target::Arch::X86) {
+        CHECK_EQ(arg_pack.size(), 3UL);
+#ifndef CINN_WITH_MKL_CBLAS
+        Expr reduce_first = arg_pack[1];
+        CHECK(reduce_first.as_tensor());
+        pe::MulScheduleCPU(stages, out.as_tensor_ref(), reduce_first.as_tensor_ref(), target);
+#endif
+      }
+      *ret = arg_pack;
     }
-    *ret = arg_pack;
   });
 
   auto strategy = std::make_shared<framework::OpStrategy>();
@@ -1004,19 +1058,24 @@ std::shared_ptr<OpStrategy> StrategyForCublasGemm(const framework::NodeAttr &att
       [output_shape = output_shapes[0], target](lang::Args args, lang::RetValue *ret) {
         if (FLAGS_cinn_ir_schedule) {
           CHECK(!args.empty()) << "The input argument of CublasGemm schedule is empty! Please check.";
-          CINNValuePack input_args = args[0];
-          CHECK(input_args[0].is_expr());
-          Expr ast_expr = input_args[0];
-          std::vector<Expr> vec_ast{ast_expr};
+          CINNValuePack arg_pack = args[0];
+          std::vector<Expr> vec_ast;
+          for (int i = 0; i < arg_pack.size(); i++) {
+            if (arg_pack[i].is_expr()) {
+              Expr temp = arg_pack[i];
+              vec_ast.emplace_back(temp);
+            }
+          }
+          CHECK(!vec_ast.empty());
           ir::ModuleExpr mod_expr(vec_ast);
           ir::IRSchedule ir_sch(mod_expr);
+          ir_sch.MergeExprs();
           if (target.arch == Target::Arch::NVGPU) {
             pe::IRCudaScheduleInjective(ir_sch, output_shape, target);
           } else if (target.arch == Target::Arch::X86) {
             pe::IRScheduleInjectiveCPU(ir_sch, output_shape, target);
           }
-          std::vector<CINNValue> res;
-          res.push_back(input_args[0]);
+          std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
           *ret = CINNValuePack{res};
         } else {
           CHECK(!args.empty()) << "The input `args` of CublasGemm is empty! Please check again.";
@@ -1093,19 +1152,24 @@ std::shared_ptr<OpStrategy> StrategyForLayoutTransform(const framework::NodeAttr
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of CublasGemm schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
 
       if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       } else {
         CINN_NOT_IMPLEMENTED
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of layout_transform schedule is empty! Please check.\n";
@@ -1219,18 +1283,23 @@ std::shared_ptr<OpStrategy> StrategyForReverse(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of reverse schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of reverse schedule is empty! Please check.\n";
@@ -1363,16 +1432,21 @@ std::shared_ptr<OpStrategy> StrategyForTranspose(const framework::NodeAttr &attr
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of transpose schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of transpose schedule is empty! Please check.\n";
@@ -1508,18 +1582,23 @@ std::shared_ptr<OpStrategy> StrategyForIndexSelect(const framework::NodeAttr &at
         if (FLAGS_cinn_ir_schedule) {
           CHECK(!args.empty()) << "The input argument of index_select schedule is empty! Please check.";
           CINNValuePack arg_pack = args[0];
-          CHECK(arg_pack[0].is_expr());
-          Expr ast_expr = arg_pack[0];
-          std::vector<Expr> vec_ast{ast_expr};
+          std::vector<Expr> vec_ast;
+          for (int i = 0; i < arg_pack.size(); i++) {
+            if (arg_pack[i].is_expr()) {
+              Expr temp = arg_pack[i];
+              vec_ast.emplace_back(temp);
+            }
+          }
+          CHECK(!vec_ast.empty());
           ir::ModuleExpr mod_expr(vec_ast);
           ir::IRSchedule ir_sch(mod_expr);
+          ir_sch.MergeExprs();
           if (target.arch == Target::Arch::NVGPU) {
             pe::IRCudaScheduleInjective(ir_sch, output_shape, target);
           } else if (target.arch == Target::Arch::X86) {
             pe::IRScheduleInjectiveCPU(ir_sch, output_shape, target);
           }
-          std::vector<CINNValue> res;
-          res.push_back(arg_pack[0]);
+          std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
           *ret = CINNValuePack{res};
         } else {
           CHECK(!args.empty()) << "The input args are empty! Please check again.";
@@ -1632,18 +1711,23 @@ std::shared_ptr<OpStrategy> StrategyForScatterAssign(const framework::NodeAttr &
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of ScatterAssign schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, false);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of ScatterAssign schedule is empty! Please check.\n";
@@ -1769,18 +1853,23 @@ std::shared_ptr<OpStrategy> StrategyForScatterAdd(const framework::NodeAttr &att
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of ScatterAdd schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, false);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input argument of ScatterAdd schedule is empty! Please check.\n";
@@ -1919,18 +2008,23 @@ std::shared_ptr<OpStrategy> StrategyForSlice(const framework::NodeAttr &attrs,
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of ScatterAdd schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input arguments of slice schedule is empty! Please check.";
@@ -2136,18 +2230,23 @@ std::shared_ptr<OpStrategy> StrategyForSliceAssign(const framework::NodeAttr &at
     if (FLAGS_cinn_ir_schedule) {
       CHECK(!args.empty()) << "The input argument of slice_assign schedule is empty! Please check.";
       CINNValuePack arg_pack = args[0];
-      CHECK(arg_pack[0].is_expr());
-      Expr ast_expr = arg_pack[0];
-      std::vector<Expr> vec_ast{ast_expr};
+      std::vector<Expr> vec_ast;
+      for (int i = 0; i < arg_pack.size(); i++) {
+        if (arg_pack[i].is_expr()) {
+          Expr temp = arg_pack[i];
+          vec_ast.emplace_back(temp);
+        }
+      }
+      CHECK(!vec_ast.empty());
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
+      ir_sch.MergeExprs();
       if (target.arch == Target::Arch::NVGPU) {
         pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
       } else if (target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target);
       }
-      std::vector<CINNValue> res;
-      res.push_back(arg_pack[0]);
+      std::vector<CINNValue> res{CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = CINNValuePack{res};
     } else {
       CHECK(!args.empty()) << "The input args are empty! Please check again.";

--- a/python/tests/ops/test_matmul_op.py
+++ b/python/tests/ops/test_matmul_op.py
@@ -67,8 +67,8 @@ class TestMatmulOp(OpTest):
 class TestMatmulCase1(TestMatmulOp):
     def init_case(self):
         self.inputs = {
-            "x": np.random.random([16]).astype("float32"),
-            "y": np.random.random([16]).astype("float32")
+            "x": np.random.random([2, 16]).astype("float32"),
+            "y": np.random.random([16, 2]).astype("float32")
         }
         self.transpose_x = False
         self.transpose_y = False


### PR DESCRIPTION
此pr做了如下修改：
1.将ci中的paddle版本升级到2.3.1
2.将使用新schedule时输入fschedule的参数全部统一为：Tensor + 全部生成的ir树
3.添加了对CINNValue中存的实例做类型判断的函数(is_tensor(), is_expr())