### PR TITLE
modify broadcast rules

### DIFF
--- a/cinn/frontend/decomposer/broadcast.cc
+++ b/cinn/frontend/decomposer/broadcast.cc
@@ -60,32 +60,59 @@ void elementwise_add(const Instruction& instr, const DecomposerContext& context)
   if (instr->attrs.find("axis") != instr->attrs.end()) {
     axis = instr.GetAttrs<int>("axis");
   }
-  axis          = axis >= 0 ? axis : x->shape.size() - y->shape.size();
-  auto* builder = context.builder();
 
-  Variable out;
-  Variable bcast_x = x;
-  Variable bcast_y = y;
+  if (x->shape.size() >= y->shape.size()) {
+    axis          = axis >= 0 ? axis : x->shape.size() - y->shape.size();
+    auto* builder = context.builder();
 
-  // e.g., x.shape = [4, 1, 3], y.shape = [2, 3], aixs = 1 out.shape = [4, 2, 3]
-  // bcast_axes_x = [0, 1, 2], bcast_axes_y = [1, 2]
-  if (x->shape != output->shape) {
-    std::vector<int> bcast_axes_x(x->shape.size());
-    std::iota(bcast_axes_x.begin(), bcast_axes_x.end(), 0);
-    bcast_x = builder->BroadcastTo(x, output->shape, bcast_axes_x);
+    Variable out;
+    Variable bcast_x = x;
+    Variable bcast_y = y;
+
+    // e.g., x.shape = [4, 1, 3], y.shape = [2, 3], aixs = 1 out.shape = [4, 2, 3]
+    // bcast_axes_x = [0, 1, 2], bcast_axes_y = [1, 2]
+    if (x->shape != output->shape) {
+      std::vector<int> bcast_axes_x(x->shape.size());
+      std::iota(bcast_axes_x.begin(), bcast_axes_x.end(), 0);
+      bcast_x = builder->BroadcastTo(x, output->shape, bcast_axes_x);
+    }
+
+    // if y.shape=[1], y does not need to be broadcast
+    if (y->shape != output->shape && y->shape != std::vector<int>(1, 1)) {
+      std::vector<int> bcast_axes_y(y->shape.size());
+      std::iota(bcast_axes_y.begin(), bcast_axes_y.end(), axis);
+      bcast_y = builder->BroadcastTo(y, output->shape, bcast_axes_y);
+    }
+
+    out = builder->Add(bcast_x, bcast_y);
+
+    // map the the output of decomposed operator to the original.
+    context.MapOutToOrigin(out, output);
+  } else {
+    axis          = axis >= 0 ? axis : y->shape.size() - x->shape.size();
+    auto* builder = context.builder();
+
+    Variable out;
+    Variable bcast_x = x;
+    Variable bcast_y = y;
+
+    if (y->shape != output->shape) {
+      std::vector<int> bcast_axes_y(y->shape.size());
+      std::iota(bcast_axes_y.begin(), bcast_axes_y.end(), 0);
+      bcast_y = builder->BroadcastTo(y, output->shape, bcast_axes_y);
+    }
+
+    if (x->shape != output->shape && x->shape != std::vector<int>(1, 1)) {
+      std::vector<int> bcast_axes_x(x->shape.size());
+      std::iota(bcast_axes_x.begin(), bcast_axes_x.end(), axis);
+      bcast_x = builder->BroadcastTo(x, output->shape, bcast_axes_x);
+    }
+
+    out = builder->Add(bcast_x, bcast_y);
+
+    // map the the output of decomposed operator to the original.
+    context.MapOutToOrigin(out, output);
   }
-
-  // if y.shape=[1], y does not need to be broadcast
-  if (y->shape != output->shape && y->shape != std::vector<int>(1, 1)) {
-    std::vector<int> bcast_axes_y(y->shape.size());
-    std::iota(bcast_axes_y.begin(), bcast_axes_y.end(), axis);
-    bcast_y = builder->BroadcastTo(y, output->shape, bcast_axes_y);
-  }
-
-  out = builder->Add(bcast_x, bcast_y);
-
-  // map the the output of decomposed operator to the original.
-  context.MapOutToOrigin(out, output);
 }
 
 void elementwise_add_grad(const Instruction& instr, const DecomposerContext& context) {

--- a/cinn/frontend/decomposer/broadcast_test.cc
+++ b/cinn/frontend/decomposer/broadcast_test.cc
@@ -28,6 +28,18 @@ TEST(Decomposer, elementwise_add_bcast0) {
   RunAndCheckShape<float>(builder, input_names, output_names, output_shapes);
 }
 
+TEST(Decomposer, elementwise_add_bcase1) {
+  NetBuilder builder("elementwise_add");
+  auto x   = builder.CreateInput(Float(32), {10, 20});
+  auto y   = builder.CreateInput(Float(32), {4, 1, 20, 10});
+  auto out = builder.ElementwiseAdd(x, y, 1);
+
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{4, 10, 20, 10}};
+  RunAndCheckShape<float>(builder, input_names, output_names, output_shapes);
+}
+
 TEST(Decomposer, elementwise_add_grad_bcast0) {
   NetBuilder builder("elementwise_add_grad");
   auto dout      = builder.CreateInput(Float(32), {4, 10, 20, 10});
@@ -55,6 +67,31 @@ TEST(Decomposer, elementwise_add_bcast1) {
       for (size_t j = 0; j < 64; ++j) {
         for (size_t k = 0; k < 32 * 32; ++k) {
           out[(i * 64 + j) * 32 * 32 + k] = x[(i * 64 + j) * 32 * 32 + k] + y[j];
+        }
+      }
+    }
+  };
+
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 64, 32, 32}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, add_cpu);
+}
+
+TEST(Decomposer, elementwise_add_bcast1_2) {
+  NetBuilder builder("elementwise_add");
+  auto x   = builder.CreateInput(Float(32), {64});
+  auto y   = builder.CreateInput(Float(32), {32, 64, 32, 32});
+  auto out = builder.ElementwiseAdd(x, y, 1);
+
+  auto add_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
+    float* x   = static_cast<float*>(ptrs[0]);
+    float* y   = static_cast<float*>(ptrs[1]);
+    float* out = static_cast<float*>(ptrs[2]);
+    for (size_t i = 0; i < 32; ++i) {
+      for (size_t j = 0; j < 64; ++j) {
+        for (size_t k = 0; k < 32 * 32; ++k) {
+          out[(i * 64 + j) * 32 * 32 + k] = y[(i * 64 + j) * 32 * 32 + k] + x[j];
         }
       }
     }
@@ -110,6 +147,29 @@ TEST(Decomposer, elementwise_add_bcast2) {
     float y_data = y[0];
     for (size_t i = 0; i < n; ++i) {
       out[i] = x[i] + y_data;
+    }
+  };
+
+  std::vector<std::string> input_names        = {x.id().data(), y.id().data()};
+  std::vector<std::string> output_names       = {out->id};
+  std::vector<std::vector<int>> output_shapes = {{32, 16}};
+  RunAndCheck<float>(builder, input_names, output_names, output_shapes, add_cpu);
+}
+
+TEST(Decomposer, elementwise_add_bcast2_2) {
+  NetBuilder builder("elementwise_add");
+  auto x   = builder.CreateInput(Float(32), {1});
+  auto y   = builder.CreateInput(Float(32), {32, 16});
+  auto out = builder.ElementwiseAdd(x, y);
+
+  auto add_cpu = [](const std::vector<size_t>& lengths, const std::vector<void*>& ptrs) {
+    size_t n     = 32 * 16;
+    float* x     = static_cast<float*>(ptrs[0]);
+    float* y     = static_cast<float*>(ptrs[1]);
+    float* out   = static_cast<float*>(ptrs[2]);
+    float x_data = x[0];
+    for (size_t i = 0; i < n; ++i) {
+      out[i] = y[i] + x_data;
     }
   };
 

--- a/cinn/hlir/pe/broadcast.cc
+++ b/cinn/hlir/pe/broadcast.cc
@@ -42,52 +42,71 @@ void GetBroadcastShape(const std::vector<Expr>& shape1,
   CHECK(common_shape);
   CHECK(broadcast_flag1);
   CHECK(broadcast_flag2);
-  int size1                    = shape1.size();
+
+  std::vector<Expr> shape1_new = shape1;
   std::vector<Expr> shape2_new = shape2;
+
   if (axis.defined()) {
     int axis_val = axis.as_int32();
     CHECK_GE(axis_val, -1) << "wrong axis: " << axis_val << std::endl;
-    CHECK_GE(shape1.size(), shape2.size()) << "A's shape should be no less than B's when axis is defined\n";
-    CHECK_LE(axis_val, static_cast<int>(shape1.size() - shape2.size()))
-        << "wrong axis: " << axis_val << " is not <= " << shape1.size() - shape2.size() << std::endl;
-    if (axis_val >= 0) {
-      *axis_offset = shape1.size() - shape2.size() - axis_val;
-      for (int i = 1; i <= *axis_offset; ++i) {
-        // specified axis to align, we insert Expr one in tensor B so as to align right with tensor A.
-        shape2_new.emplace_back(Expr(1));
-        common_shape->insert(common_shape->begin(), shape1[size1 - i]);
-        // flag is used to indicate whether to include the indice or not.
-        broadcast_flag1->emplace_back(true);
-        broadcast_flag2->emplace_back(false);
+    if (shape1.size() >= shape2.size()) {
+      CHECK_LE(axis_val, static_cast<int>(shape1.size() - shape2.size()))
+          << "wrong axis: " << axis_val << " is not <= " << shape1.size() - shape2.size() << std::endl;
+      if (axis_val >= 0) {
+        *axis_offset = shape1.size() - shape2.size() - axis_val;
+        for (int i = 1; i <= *axis_offset; ++i) {
+          // specified axis to align, we insert Expr one in tensor B so as to align right with tensor A.
+          shape2_new.emplace_back(Expr(1));
+          common_shape->insert(common_shape->begin(), shape1[static_cast<int>(shape1.size() - i)]);
+          // flag is used to indicate whether to include the indice or not.
+          broadcast_flag1->emplace_back(true);
+          broadcast_flag2->emplace_back(false);
+        }
+      }
+    } else {
+      CHECK_LE(axis_val, static_cast<int>(shape2.size() - shape1.size()))
+          << "wrong axis: " << axis_val << " is not <= " << shape2.size() - shape1.size() << std::endl;
+      if (axis_val >= 0) {
+        *axis_offset = shape2.size() - shape1.size() - axis_val;
+        for (int i = 1; i <= *axis_offset; ++i) {
+          // specified axis to align, we insert Expr one in tensor B so as to align right with tensor A.
+          shape1_new.emplace_back(Expr(1));
+          common_shape->insert(common_shape->begin(), shape2[static_cast<int>(shape2.size() - i)]);
+          // flag is used to indicate whether to include the indice or not.
+          broadcast_flag2->emplace_back(true);
+          broadcast_flag1->emplace_back(false);
+        }
       }
     }
   }
 
+  int size1 = shape1_new.size();
   int size2 = shape2_new.size();
+
   Expr one(1);
   int i;
   i = axis_offset <= 0 ? 1 : *axis_offset + 1;
   for (; i <= std::min(size1, size2); ++i) {
     // traverse from right to left to get the output shape and broadcast flag
-    auto* var1 = shape1[size1 - i].As<ir::_Var_>();
+    auto* var1 = shape1_new[size1 - i].As<ir::_Var_>();
     auto* var2 = shape2_new[size2 - i].As<ir::_Var_>();
-    if (MathEqual(shape1[size1 - i], shape2_new[size2 - i])) {
-      common_shape->insert(common_shape->begin(), shape1[size1 - i]);
+    if (MathEqual(shape1_new[size1 - i], shape2_new[size2 - i])) {
+      common_shape->insert(common_shape->begin(), shape1_new[size1 - i]);
       // broadcast flags are recorded in a reverse order
       broadcast_flag1->emplace_back(true);
       broadcast_flag2->emplace_back(true);
-    } else if (MathEqual(one, shape1[size1 - i])) {
+    } else if (MathEqual(one, shape1_new[size1 - i])) {
       CHECK(!MathEqual(one, shape2_new[size2 - i]));
       common_shape->insert(common_shape->begin(), shape2_new[size2 - i]);
       broadcast_flag1->emplace_back(false);
       broadcast_flag2->emplace_back(true);
     } else if (MathEqual(one, shape2_new[size2 - i])) {
-      CHECK(!MathEqual(one, shape1[size1 - i]));
-      common_shape->insert(common_shape->begin(), shape1[size1 - i]);
+      CHECK(!MathEqual(one, shape1_new[size1 - i]));
+      common_shape->insert(common_shape->begin(), shape1_new[size1 - i]);
       broadcast_flag1->emplace_back(true);
       broadcast_flag2->emplace_back(false);
     } else if (var1 && var2) {
-      Expr max_var = ir::Max::Make(shape1[size1 - i], shape2_new[size2 - i]);
+      Expr max_var = ir::Max::Make(shape1_new[size1 - i], shape2_new[size2 - i]);
       common_shape->insert(common_shape->begin(), max_var);
       broadcast_flag1->emplace_back(true);
       broadcast_flag2->emplace_back(true);
@@ -96,17 +115,17 @@ void GetBroadcastShape(const std::vector<Expr>& shape1,
       broadcast_flag1->emplace_back(true);
       broadcast_flag2->emplace_back(true);
     } else if (var2) {
-      common_shape->insert(common_shape->begin(), shape1[size1 - i]);
+      common_shape->insert(common_shape->begin(), shape1_new[size1 - i]);
       broadcast_flag1->emplace_back(true);
       broadcast_flag2->emplace_back(true);
     } else {
-      LOG(FATAL) << "Incompatible broadcast dims " << shape1[size1 - i] << " and " << shape2_new[size2 - i]
-                 << " in: " << shape1 << " and " << shape2_new << std::endl;
+      LOG(FATAL) << "Incompatible broadcast dims " << shape1_new[size1 - i] << " and " << shape2_new[size2 - i]
+                 << " in: " << shape1_new << " and " << shape2_new << std::endl;
     }
   }
   if (size1 != size2) {
     int max_size = std::max(size1, size2);
-    auto& shape  = (size1 > size2) ? shape1 : shape2_new;
+    auto& shape  = (size1 > size2) ? shape1_new : shape2_new;
     auto var_l   = (size1 > size2) ? broadcast_flag1 : broadcast_flag2;
     auto var_s   = (size1 > size2) ? broadcast_flag2 : broadcast_flag1;
     for (; i <= max_size; ++i) {
@@ -159,7 +178,8 @@ void GetBroadcastIndice(const std::vector<Expr>& indice,
       if (broadcast_flags1[flag_size - 1 - i]) {
         // broadcast indices are added from left to right
         broadcast_indice1->push_back(indice[i]);
-      } else {
+      } else if (flag_size - i <= tensor_a->shape.size() + axis_offset &&
+                 broadcast_indice1->size() < tensor_a->shape.size()) {
         broadcast_indice1->push_back(Expr(0));
       }
       if (broadcast_flags2[flag_size - 1 - i]) {
@@ -193,7 +213,6 @@ Tensor Broadcast(const FuncOp& op,
     std::vector<Expr> broadcast_indice2;
     GetBroadcastIndice(
         indice, a, b, axis_offset, &broadcast_indice1, &broadcast_indice2, broadcast_flags1, broadcast_flags2);
-
     return op(a(broadcast_indice1), b(broadcast_indice2));
   };
   Tensor output = Compute(common_shape, fn, output_name);


### PR DESCRIPTION
To align with paddle fluid, remove the requirement that the size of the first tensor in the eltwise broadcast is larger than the second.