### PR TITLE
fix cinn matmul cannot compute some shape problem

### DIFF
--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -327,7 +327,7 @@ std::pair<Variable, Variable> NetBuilder::BroadcastMatmulInput(
     // broadcast vector y to the same batch size
     // [a, b, c, m] * [m] -> [a, b, c, m] * [a, b, m, 1]
     new_y_shape              = x_shape;
-    new_y_shape[max_dim - 1] = y_shape[0];
+    new_y_shape[max_dim - 2] = y_shape[0];
     new_y_shape[max_dim - 1] = 1;
   } else {
     // matrix * matrix
@@ -425,7 +425,7 @@ std::vector<int> NetBuilder::GetMatmulOutputShape(
     CHECK(x_shape == y_shape)
         << "The matmul input X's numbers must be equal to Y's numbers,when X/Y's dims =1. But here " << matmul_info();
 
-    out_shape = x_shape;
+    out_shape = {1};
   } else if (x_dim == 1) {
     // vector * matrix
     out_shape = y_shape;

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -281,14 +281,218 @@ std::vector<Variable> NetBuilder::Conv2dGrad(const Variable& dy,
   return instr.GetOutputs();
 }
 
+std::pair<Variable, Variable> NetBuilder::BroadcastMatmulInput(
+    const Variable& x, const Variable& y, bool trans_x, bool trans_y, float alpha) {
+  const auto &x_shape = x->shape, &y_shape = y->shape;
+
+  auto matmul_info = [&]() {
+    std::stringstream ss;
+    ss << "matmul(X:" << x->id << "[" << cinn::utils::Join(x_shape, ", ") << "], Y:" << y->id << "["
+       << cinn::utils::Join(y_shape, ", ") << "]"
+       << ", trans_x=" << trans_x << ", trans_y=" << trans_y << ", alpha=" << alpha << ")";
+    return ss.str();
+  };
+
+  CHECK(!x_shape.empty()) << "The input X:" << x->id << " of matmul should not empty! Please check.";
+  CHECK(!y_shape.empty()) << "The input Y:" << y->id << " of matmul should not empty! Please check.";
+
+  int x_dim = x_shape.size(), y_dim = y_shape.size();
+  int max_dim = std::max(x_shape.size(), y_shape.size());
+
+  std::vector<int> new_x_shape, new_y_shape;
+  if (max_dim == 1) {
+    // vector * vector
+    CHECK(x_shape == y_shape)
+        << "The matmul input X's numbers must be equal to Y's numbers,when X/Y's dims =1. But here " << matmul_info();
+
+    // do not need broadcast
+    return {x, y};
+  } else if (x_dim == 1) {
+    // vector * matrix
+    int y_K = trans_y ? y_shape[max_dim - 1] : y_shape[max_dim - 2];
+    CHECK_EQ(y_K, x_shape[0]) << "The K dimension of Y:" << y_K << " should equal to X.shape[0]:" << x_shape[0]
+                              << ". But here " << matmul_info();
+
+    // broadcast vector x to the same batch size
+    // [m] * [a, b, m, d] -> [a, b, 1, m] * [a, b, m, d]
+    new_x_shape              = y_shape;
+    new_x_shape[max_dim - 2] = 1;
+    new_x_shape[max_dim - 1] = x_shape[0];
+  } else if (y_dim == 1) {
+    // matrix * vector
+    int x_K = trans_x ? x_shape[max_dim - 2] : x_shape[max_dim - 1];
+    CHECK_EQ(x_K, y_shape[0]) << "The K dimension of X:" << x_K << " should equal to Y.shape[0]:" << y_shape[0]
+                              << ". But here " << matmul_info();
+
+    // broadcast vector y to the same batch size
+    // [a, b, c, m] * [m] -> [a, b, c, m] * [a, b, m, 1]
+    new_y_shape              = x_shape;
+    new_y_shape[max_dim - 2] = y_shape[0];
+    new_y_shape[max_dim - 1] = 1;
+  } else {
+    // matrix * matrix
+    int x_K = trans_x ? x_shape[x_dim - 2] : x_shape[x_dim - 1];
+    int y_K = trans_y ? y_shape[y_dim - 1] : y_shape[y_dim - 2];
+    CHECK_EQ(x_K, y_K) << "The K dimension of matmul not equal. Where " << matmul_info();
+
+    // if dimension of A or B greater than 2, broadcast input to the same shape
+    auto gen_new_shape = [max_dim](const std::vector<int>& old_shape) {
+      std::vector<int> new_shape;
+      if (old_shape.size() != max_dim) {
+        // if dim not equal, full 1
+        new_shape.resize(max_dim - old_shape.size(), 1);
+        new_shape.insert(new_shape.end(), old_shape.begin(), old_shape.end());
+      } else {
+        new_shape = old_shape;
+      }
+      return new_shape;
+    };
+    new_x_shape = gen_new_shape(x_shape);
+    new_y_shape = gen_new_shape(y_shape);
+
+    // keep the front batch dimension same
+    for (int i = 0; i < max_dim - 2; ++i) {
+      if (new_x_shape[i] == new_y_shape[i]) {
+        continue;
+      }
+
+      CHECK(new_x_shape[i] == 1 || new_y_shape[i] == 1)
+          << "Input X and Y's batch dimension should be same or 1. But here " << matmul_info();
+
+      // broadcast the value 1 dimension
+      if (new_x_shape[i] == 1) {
+        new_x_shape[i] = new_y_shape[i];
+      } else {
+        new_y_shape[i] = new_x_shape[i];
+      }
+    }
+  }
+
+  auto broad_x = x, broad_y = y;
+  if (!new_x_shape.empty()) {
+    int new_size = std::accumulate(new_x_shape.begin(), new_x_shape.end(), 1, std::multiplies<int>());
+    int old_size = std::accumulate(x_shape.begin(), x_shape.end(), 1, std::multiplies<int>());
+
+    if (new_size == old_size) {
+      VLOG(4) << "Reshape matmul's input X from [" << cinn::utils::Join(x_shape, ", ") << "] to ["
+              << cinn::utils::Join(new_x_shape, ", ") << "]. Where " << matmul_info();
+      broad_x = Reshape(x, new_x_shape);
+    } else {
+      VLOG(4) << "Broadcast matmul's input X from [" << cinn::utils::Join(x_shape, ", ") << "] to ["
+              << cinn::utils::Join(new_x_shape, ", ") << "]. Where " << matmul_info();
+      broad_x = BroadcastTo(x, new_x_shape);
+    }
+  }
+
+  if (!new_y_shape.empty()) {
+    int new_size = std::accumulate(new_y_shape.begin(), new_y_shape.end(), 1, std::multiplies<int>());
+    int old_size = std::accumulate(y_shape.begin(), y_shape.end(), 1, std::multiplies<int>());
+
+    if (new_size == old_size) {
+      // only need reshape
+      VLOG(4) << "Reshape matmul's input Y from [" << cinn::utils::Join(y_shape, ", ") << "] to ["
+              << cinn::utils::Join(new_y_shape, ", ") << "]. Where " << matmul_info();
+      broad_y = Reshape(y, new_y_shape);
+    } else {
+      // need broadcast
+      VLOG(4) << "Broadcast matmul's input Y from [" << cinn::utils::Join(y_shape, ", ") << "] to ["
+              << cinn::utils::Join(new_y_shape, ", ") << "]. Where " << matmul_info();
+      broad_y = BroadcastTo(y, new_y_shape);
+    }
+  }
+
+  return {broad_x, broad_y};
+}
+
+std::vector<int> NetBuilder::GetMatmulOutputShape(
+    const Variable& x, const Variable& y, bool trans_x, bool trans_y, float alpha) {
+  const auto &x_shape = x->shape, &y_shape = y->shape;
+
+  auto matmul_info = [&]() {
+    std::stringstream ss;
+    ss << "matmul(X:" << x->id << "[" << cinn::utils::Join(x_shape, ", ") << "], Y:" << y->id << "["
+       << cinn::utils::Join(y_shape, ", ") << "]"
+       << ", trans_x=" << trans_x << ", trans_y=" << trans_y << ", alpha=" << alpha << ")";
+    return ss.str();
+  };
+
+  int x_dim = x_shape.size(), y_dim = y_shape.size();
+  int max_dim = std::max(x_shape.size(), y_shape.size());
+
+  std::vector<int> out_shape;
+  if (max_dim == 1) {
+    // vector * vector
+    CHECK(x_shape == y_shape)
+        << "The matmul input X's numbers must be equal to Y's numbers,when X/Y's dims =1. But here " << matmul_info();
+
+    out_shape = x_shape;
+  } else if (x_dim == 1) {
+    // vector * matrix
+    out_shape = y_shape;
+    // [m] * [a, b, m, d] -> [a, b, d]
+    out_shape.erase(out_shape.end() - 2);
+  } else if (y_dim == 1) {
+    // matrix * vector
+    out_shape = x_shape;
+    // [a, b, c, m] * [m] -> [a, b, c]
+    out_shape.erase(out_shape.end() - 1);
+  } else {
+    // matrix * matrix
+    int M = trans_x ? x_shape[x_dim - 1] : x_shape[x_dim - 2];
+    int N = trans_y ? y_shape[y_dim - 2] : y_shape[y_dim - 1];
+
+    out_shape.resize(max_dim, 1);
+    out_shape[max_dim - 2] = M;
+    out_shape[max_dim - 1] = N;
+
+    // get the batch dimension after broadcast
+    int x_pos = x_dim - 3, y_pos = y_dim - 3, out_pos = max_dim - 3;
+    while (x_pos >= 0 && y_pos >= 0) {
+      CHECK(x_shape[x_pos] == y_shape[y_pos] || x_shape[x_pos] == 1 || y_shape[y_pos] == 1)
+          << "Input X and Y's batch dimension should be same or 1. But here " << matmul_info();
+      out_shape[out_pos] = (x_shape[x_pos] == 1) ? y_shape[y_pos] : x_shape[x_pos];
+
+      out_pos--;
+      x_pos--;
+      y_pos--;
+    }
+
+    while (x_pos >= 0) {
+      out_shape[out_pos--] = x_shape[x_pos--];
+    }
+    while (y_pos >= 0) {
+      out_shape[out_pos--] = x_shape[y_pos--];
+    }
+  }
+  return out_shape;
+}
+
 Variable NetBuilder::Matmul(const Variable& x, const Variable& y, bool trans_x, bool trans_y, float alpha) {
-  Instruction instr("matmul", {x, y});
+  const auto& inputs = BroadcastMatmulInput(x, y, trans_x, trans_y, alpha);
+
+  Instruction instr("matmul", {inputs.first, inputs.second});
   instr.SetAttr("trans_a", trans_x);
   instr.SetAttr("trans_b", trans_y);
   instr.SetAttr("alpha", alpha);
   InferShape(instr);
   AppendInstruction(instr);
-  return instr.GetOutput(0);
+  auto out = instr.GetOutput(0);
+
+  const auto& should_out_shape = GetMatmulOutputShape(x, y, trans_x, trans_y, alpha);
+  if (should_out_shape != out->shape) {
+    int should_out_size = std::accumulate(should_out_shape.begin(), should_out_shape.end(), 1, std::multiplies<int>());
+    int real_out_size   = std::accumulate(out->shape.begin(), out->shape.end(), 1, std::multiplies<int>());
+    CHECK_EQ(should_out_size, real_out_size)
+        << "Cannot reshape the output:[" << out->id << "] of matmul from [" << cinn::utils::Join(out->shape, ", ")
+        << "] to [" << cinn::utils::Join(should_out_shape, ", ") << "]."
+        << " Whose input is "
+        << "matmul(X:" << x->id << "[" << cinn::utils::Join(x->shape, ", ") << "], Y:" << y->id << "["
+        << cinn::utils::Join(y->shape, ", ") << "]"
+        << ", trans_x=" << trans_x << ", trans_y=" << trans_y << ", alpha=" << alpha << ")";
+    out = Reshape(out, should_out_shape);
+  }
+
+  return out;
 }
 
 Variable NetBuilder::ElementwiseOp(const std::string& op_type, const Variable& lhs, const Variable& rhs, int axis) {

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -189,6 +189,12 @@ class NetBuilder : public BaseBuilder {
 
  protected:
   Variable ElementwiseOp(const std::string& op_type, const Variable& lhs, const Variable& rhs, int axis = -1);
+
+ private:
+  // the helper function of Matmul
+  std::pair<Variable, Variable> BroadcastMatmulInput(
+      const Variable& x, const Variable& y, bool trans_x, bool trans_y, float alpha);
+  std::vector<int> GetMatmulOutputShape(const Variable& x, const Variable& y, bool trans_x, bool trans_y, float alpha);
 };
 
 }  // namespace frontend

--- a/cinn/frontend/op_mappers/paddle/matmul.cc
+++ b/cinn/frontend/op_mappers/paddle/matmul.cc
@@ -28,10 +28,10 @@ void MatMulOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
   auto out_name = op_desc.Output("Out").front();
 
   auto trans_x = utils::GetAttrOrDefault<bool>(op_desc, "trans_x", false);
-  trans_x      = trans_x || utils::GetAttrOrDefault<bool>(op_desc, "transpose_X", false);
+  trans_x      = utils::GetAttrOrDefault<bool>(op_desc, "transpose_X", trans_x);
 
   auto trans_y = utils::GetAttrOrDefault<bool>(op_desc, "trans_y", false);
-  trans_y      = trans_y || utils::GetAttrOrDefault<bool>(op_desc, "transpose_Y", false);
+  trans_y      = utils::GetAttrOrDefault<bool>(op_desc, "transpose_Y", trans_y);
 
   auto alpha = utils::GetAttrOrDefault<float>(op_desc, "alpha", 1.0f);
 

--- a/cinn/frontend/op_mappers/paddle/matmul.cc
+++ b/cinn/frontend/op_mappers/paddle/matmul.cc
@@ -28,14 +28,19 @@ void MatMulOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& c
   auto out_name = op_desc.Output("Out").front();
 
   auto trans_x = utils::GetAttrOrDefault<bool>(op_desc, "trans_x", false);
+  trans_x      = trans_x || utils::GetAttrOrDefault<bool>(op_desc, "transpose_X", false);
+
   auto trans_y = utils::GetAttrOrDefault<bool>(op_desc, "trans_y", false);
+  trans_y      = trans_y || utils::GetAttrOrDefault<bool>(op_desc, "transpose_Y", false);
+
+  auto alpha = utils::GetAttrOrDefault<float>(op_desc, "alpha", 1.0f);
 
   VLOG(4) << out_name << "=matmul{" << x_name << ", " << y_name << ", trans_x=" << trans_x << ", trans_y=" << trans_y
-          << "}";
+          << ", alpha=" << alpha << "}";
 
   auto x   = ctx.GetVar(x_name);
   auto y   = ctx.GetVar(y_name);
-  auto out = ctx.Builder()->Matmul(x, y, trans_x, trans_y);
+  auto out = ctx.Builder()->Matmul(x, y, trans_x, trans_y, alpha);
 
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);

--- a/cinn/hlir/op/op_util.h
+++ b/cinn/hlir/op/op_util.h
@@ -22,7 +22,7 @@ namespace cinn {
 namespace hlir {
 
 template <typename T = int>
-inline std::vector<Expr> ToCinnExprs(const std::vector<T>& args) {
+std::vector<Expr> ToCinnExprs(const std::vector<T>& args) {
   std::vector<Expr> exprs;
   std::transform(args.begin(), args.end(), std::back_inserter(exprs), [](const T& arg) { return Expr(arg); });
   return exprs;

--- a/cinn/hlir/op/op_util.h
+++ b/cinn/hlir/op/op_util.h
@@ -22,7 +22,7 @@ namespace cinn {
 namespace hlir {
 
 template <typename T = int>
-std::vector<Expr> ToCinnExprs(const std::vector<T>& args) {
+inline std::vector<Expr> ToCinnExprs(const std::vector<T>& args) {
   std::vector<Expr> exprs;
   std::transform(args.begin(), args.end(), std::back_inserter(exprs), [](const T& arg) { return Expr(arg); });
   return exprs;

--- a/python/tests/ops/test_matmul_op.py
+++ b/python/tests/ops/test_matmul_op.py
@@ -137,7 +137,7 @@ class TestMatmulCase7(TestMatmulOp):
 class TestMatmulCase8(TestMatmulOp):
     def init_case(self):
         self.inputs = {
-            "x": np.random.random([2, 8, 16, 4]).astype("float32"),
+            "x": np.random.random([1, 8, 16, 4]).astype("float32"),
             "y": np.random.random([2, 1, 4, 16]).astype("float32")
         }
         self.transpose_x = False
@@ -181,6 +181,16 @@ class TestMatmulCase12(TestMatmulOp):
             "y": np.random.random([16]).astype("float32")
         }
         self.transpose_x = True
+        self.transpose_y = False
+
+
+class TestMatmulCase13(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([4, 16]).astype("float32"),
+            "y": np.random.random([16]).astype("float32")
+        }
+        self.transpose_x = False
         self.transpose_y = False
 
 

--- a/python/tests/ops/test_matmul_op.py
+++ b/python/tests/ops/test_matmul_op.py
@@ -124,5 +124,45 @@ class TestMatmulCase6(TestMatmulOp):
         self.transpose_y = True
 
 
+class TestMatmulCase7(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([8, 16, 4]).astype("float32"),
+            "y": np.random.random([1, 4, 16]).astype("float32")
+        }
+        self.transpose_x = False
+        self.transpose_y = False
+
+
+class TestMatmulCase8(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 8, 16, 4]).astype("float32"),
+            "y": np.random.random([2, 1, 4, 16]).astype("float32")
+        }
+        self.transpose_x = False
+        self.transpose_y = False
+
+
+class TestMatmulCase9(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([8, 16, 4]).astype("float32"),
+            "y": np.random.random([4, 16]).astype("float32")
+        }
+        self.transpose_x = False
+        self.transpose_y = False
+
+
+class TestMatmulCase10(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 8, 16, 4]).astype("float32"),
+            "y": np.random.random([4, 16]).astype("float32")
+        }
+        self.transpose_x = False
+        self.transpose_y = False
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/ops/test_matmul_op.py
+++ b/python/tests/ops/test_matmul_op.py
@@ -164,5 +164,25 @@ class TestMatmulCase10(TestMatmulOp):
         self.transpose_y = False
 
 
+class TestMatmulCase11(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 8, 4, 16]).astype("float32"),
+            "y": np.random.random([4, 16]).astype("float32")
+        }
+        self.transpose_x = True
+        self.transpose_y = False
+
+
+class TestMatmulCase12(TestMatmulOp):
+    def init_case(self):
+        self.inputs = {
+            "x": np.random.random([2, 8, 16, 4]).astype("float32"),
+            "y": np.random.random([16]).astype("float32")
+        }
+        self.transpose_x = True
+        self.transpose_y = False
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
原CINN中的matmul只支持相同维度大小输入的计算，且多维shape下matmul的输出shape固定为3维，其中第一维为batch size，与预期不符。

本PR通过在netbuilder实现中为输入添加`broadcast`或`reshape`操作来将不符合要求的输入适配到合适shape，同时将输出`reshape`到正确shape。修复完成后API的表现与[paddle.matmul](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/matmul_cn.html#matmul)相同。