### PR TITLE
Fix bug in CollectHostFunctionVisitor

### DIFF
--- a/cinn/backends/codegen_cuda_util.h
+++ b/cinn/backends/codegen_cuda_util.h
@@ -57,12 +57,18 @@ struct CollectHostFunctionVisitor : public ir::IRMutator<> {
 
  private:
   void Visit(const ir::_LoweredFunc_* op, Expr* expr) override {
-    if (!op->cuda_axis_info.valid()) {
-      expr->as_lowered_func_ref()->cuda_axis_info.set_valid(true);
+    auto find_call_nodes = ir::CollectIRNodesWithoutTensor(
+        op->body, [&](const Expr* x) { return x->As<ir::Call>(); }, true);
+    if (!op->cuda_axis_info.valid() && !find_call_nodes.empty()) {
+      host_module_builder.AddFunction(expr->as_lowered_func_ref());
+    } else {
+      if (!op->cuda_axis_info.valid()) {
+        expr->as_lowered_func_ref()->cuda_axis_info.set_valid(true);
+      }
+      auto host_func = CreateHostFunctionGivenDeviceKernel(op);
+      host_module_builder.AddFunction(host_func.as_lowered_func_ref());
+      device_module_builder.AddFunction(CreateDeviceFunctionGivenDeviceKernel(*expr).as_lowered_func_ref());
     }
-    auto host_func = CreateHostFunctionGivenDeviceKernel(op);
-    host_module_builder.AddFunction(host_func.as_lowered_func_ref());
-    device_module_builder.AddFunction(CreateDeviceFunctionGivenDeviceKernel(*expr).as_lowered_func_ref());
   }
 
   /**

--- a/cinn/backends/codegen_cuda_util.h
+++ b/cinn/backends/codegen_cuda_util.h
@@ -57,9 +57,7 @@ struct CollectHostFunctionVisitor : public ir::IRMutator<> {
 
  private:
   void Visit(const ir::_LoweredFunc_* op, Expr* expr) override {
-    auto find_call_nodes = ir::CollectIRNodesWithoutTensor(
-        op->body, [&](const Expr* x) { return x->As<ir::Call>(); }, true);
-    if (!op->cuda_axis_info.valid() && !find_call_nodes.empty()) {
+    if (op->body.As<ir::Call>()) {
       host_module_builder.AddFunction(expr->as_lowered_func_ref());
     } else {
       if (!op->cuda_axis_info.valid()) {


### PR DESCRIPTION
此pr修改了CollectHostFunctionVisitor中判断是否host与device的kernel：
如果func中有ir::Call节点且cuda_axis_info无效，则判断为host function；否则则是kernel function