### PR TITLE
add Annotate schedule primitive

### DIFF
--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.cc
@@ -61,34 +61,27 @@ bool AutoUnroll::MeetCondition(const ir::ScheduleBlock* schedule_block) {
 }
 
 RuleApplyType AutoUnroll::Init(const ir::IRSchedule& init_schedule) {
-  ir_schedule_ = std::make_unique<ir::IRSchedule>(optim::IRCopy(init_schedule));
-  auto exprs   = ir_schedule_->GetModule().GetExprs();
+  ir_schedule_        = std::make_unique<ir::IRSchedule>(optim::IRCopy(init_schedule));
+  auto block_realizes = ir_schedule_->GetAllBlocks();
 
-  // extract all root schedulable blocks
-  std::vector<ir::ScheduleBlock*> root_schedule_blocks_;
-  for (auto&& it_expr : exprs) {
-    auto* block = it_expr.As<ir::Block>();
-    CHECK(block) << "block is null";
-    for (auto&& stmt : block->stmts) {
-      ir::ScheduleBlockRealize* block_realize = stmt.As<ir::ScheduleBlockRealize>();
-      CHECK(block_realize) << "stmt is not a ScheduleBlockRealize";
-      ir::ScheduleBlock* schedule_block = block_realize->schedule_block.As<ir::ScheduleBlock>();
-      CHECK(schedule_block) << "schedule_block field is not a ScheduleBlock";
-      VLOG(6) << "Find a root schedule block:\n" << stmt;
-      root_schedule_blocks_.emplace_back(schedule_block);
-    }
-  }
-  VLOG(6) << "Module has root_schedule_blocks:" << root_schedule_blocks_.size();
-
-  // collect schedule blocks which meet applicable conditions
+  // A schedule block can perform `auto_unroll` rule should meet two conditions:
+  // (1) it is a root block
+  // (2) MeetCondition returns true with it
   applicable_schedule_blocks_.clear();
-  for (size_t i = 0; i < root_schedule_blocks_.size(); ++i) {
-    ir::ScheduleBlock* schedule_block = root_schedule_blocks_.at(i);
+  std::set<Expr> deduplicate_results;
+  for (size_t i = 0; i < block_realizes.size(); ++i) {
+    // find root block
+    Expr root_block     = ir_schedule_->GetRootBlock(block_realizes[i]);
+    auto* block_realize = root_block.As<ir::ScheduleBlockRealize>();
+    CHECK(block_realize) << "stmt is not a ScheduleBlockRealize:" << root_block;
+    auto* schedule_block = block_realize->schedule_block.As<ir::ScheduleBlock>();
+    CHECK(schedule_block) << "schedule_block field is not a ScheduleBlock:" << Expr(block_realize);
     if (MeetCondition(schedule_block)) {
-      applicable_schedule_blocks_.emplace_back(schedule_block);
+      deduplicate_results.emplace(root_block);
     }
   }
-  num_applicable_ = applicable_schedule_blocks_.size();
+  applicable_schedule_blocks_ = {deduplicate_results.begin(), deduplicate_results.end()};
+  num_applicable_             = applicable_schedule_blocks_.size();
   VLOG(6) << "Collect applicable_schedule_blocks_:" << num_applicable_;
 
   return num_applicable_ > 0 ? RuleApplyType::kApplyAndSkipThisRule : RuleApplyType::kCannotApply;
@@ -96,9 +89,9 @@ RuleApplyType AutoUnroll::Init(const ir::IRSchedule& init_schedule) {
 
 ir::IRSchedule AutoUnroll::Apply(int index) {
   CHECK_LT(index, applicable_schedule_blocks_.size()) << "invalid apply index:" << index;
-  auto* schedule_block = applicable_schedule_blocks_.at(index);
-  int max_step         = auto_unroll_options[std::rand() % auto_unroll_options.size()];
-  schedule_block->attrs.emplace(ir::attr::auto_unroll_max_step, max_step);
+  auto applied_block = applicable_schedule_blocks_.at(index);
+  int max_step       = auto_unroll_options[std::rand() % auto_unroll_options.size()];
+  ir_schedule_->Annotate(applied_block, ir::attr::auto_unroll_max_step, max_step);
   return optim::IRCopy(*ir_schedule_);
 }
 

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.h
@@ -46,7 +46,7 @@ class AutoUnroll : public AutoGenRule {
 
  private:
   std::unique_ptr<ir::IRSchedule> ir_schedule_;
-  std::vector<ir::ScheduleBlock*> applicable_schedule_blocks_;
+  std::vector<Expr> applicable_schedule_blocks_;
 };
 
 }  // namespace auto_schedule

--- a/cinn/ir/ir.h
+++ b/cinn/ir/ir.h
@@ -916,14 +916,11 @@ struct ScheduleBlock : public ExprNode<ScheduleBlock> {
   std::vector<Var> iter_vars;
   std::vector<Expr> read_buffers;
   std::vector<Expr> write_buffers;
+  // Additional attributes about this schedulable block,
+  // which take some auxiliary hints for future transformations.
+  std::map<std::string, attr_t> attrs;
   std::string name;
   Expr body;
-
-  /*!
-   * \brief Additional attributes about this schedulable block,
-   * which take some auxiliary hints for future transformations.
-   */
-  std::map<std::string, attr_t> attrs;
 
   static Expr Make(const std::vector<Var>& iter_vars,
                    const std::vector<Expr>& read_buffers,

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -474,6 +474,18 @@ void IrPrinter::Visit(const ScheduleBlockRealize *x) {
     }
     os() << ")\n";
   }
+  if (!schedule_block->attrs.empty()) {
+    DoIndent();
+    os() << "attrs(";
+    bool comma = false;
+    for (auto &&kv : schedule_block->attrs) {
+      if (comma) os() << ", ";
+      os() << kv.first << ":";
+      absl::visit([this](auto &&arg) { this->os() << arg; }, kv.second);
+      comma = true;
+    }
+    os() << ")\n";
+  }
   DoIndent();
   Print(schedule_block->body);
   os() << "\n";

--- a/cinn/ir/ir_schedule.cc
+++ b/cinn/ir/ir_schedule.cc
@@ -88,6 +88,7 @@ class ScheduleImpl {
   void ComputeInline(const Expr& schedule_block);
   void Bind(const Expr& loop, const std::string& thread_axis);
   Expr Rfactor(const Expr& rf_loop, int rf_axis);
+  void Annotate(const Expr& block, const std::string& key, const attr_t& value);
   void CopyTransformAndLoopInfo(const Expr& block, const Expr& block_target);
   void CopyTransformAndLoopInfo(const std::string& block_name, const std::string& block_target_name);
 
@@ -1323,6 +1324,15 @@ Expr ScheduleImpl::GetBlock(const std::string& block_name) const {
   LOG(FATAL) << "Didn't find a block with name " << block_name << " in this ModuleExpr!";
 }
 
+void ScheduleImpl::Annotate(const Expr& block, const std::string& key, const attr_t& value) {
+  CHECK(block.As<ir::ScheduleBlockRealize>());
+  CHECK(block.As<ir::ScheduleBlockRealize>()->schedule_block.As<ir::ScheduleBlock>());
+  auto copied_block    = optim::IRCopy(block);
+  auto* schedule_block = copied_block.As<ir::ScheduleBlockRealize>()->schedule_block.As<ir::ScheduleBlock>();
+  schedule_block->attrs.emplace(key, value);
+  this->Replace(block, copied_block);
+}
+
 void ScheduleImpl::CopyTransformAndLoopInfo(const std::string& block_name, const std::string& block_target_name) {
   auto block        = this->GetBlock(block_name);
   auto block_target = this->GetBlock(block_target_name);
@@ -1609,6 +1619,26 @@ Expr IRSchedule::Rfactor(const Expr& rf_loop, int rf_axis) {
   trace_.Append(
       ScheduleDesc::Step("Rfactor", {{"rf_loop", std::vector<Expr>({rf_loop})}}, {{"rf_axis", rf_axis}}, {result}));
   return result;
+}
+
+void IRSchedule::Annotate(const Expr& block, const std::string& key, const attr_t& value) {
+  impl_->Annotate(block, key, value);
+
+#define TRACE_ANNOTATE_ITEM(data_type, step_name)                                            \
+  if (absl::holds_alternative<data_type>(value)) {                                           \
+    trace_.Append(ScheduleDesc::Step(#step_name,                                             \
+                                     {{"block", std::vector<Expr>({block})}},                \
+                                     {{"key", key}, {"value", absl::get<data_type>(value)}}, \
+                                     {}));                                                   \
+    return;                                                                                  \
+  }
+  TRACE_ANNOTATE_ITEM(int, AnnotateIntAttr)
+  TRACE_ANNOTATE_ITEM(bool, AnnotateBoolAttr)
+  TRACE_ANNOTATE_ITEM(float, AnnotateFloatAttr)
+  TRACE_ANNOTATE_ITEM(std::string, AnnotateStringAttr)
+#undef TRACE_ANNOTATE_ITEM
+
+  LOG(FATAL) << "Value of attribute:" << key << " input unsupported data type";
 }
 
 void IRSchedule::CopyTransformAndLoopInfo(const Expr& block, const Expr& block_target) {

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -301,6 +301,14 @@ class IRSchedule {
    */
   Expr Rfactor(const Expr& rf_loop, int rf_axis);
 
+  /*!
+   * \brief Annotate a block with a key-value pair to set as its attribute
+   * \param block The block to be annotated
+   * \param key The attribute key
+   * \param val The attribute value, its type should be one of attr_t listing
+   */
+  void Annotate(const Expr& block, const std::string& key, const attr_t& value);
+
  private:
   std::unique_ptr<ScheduleImpl> impl_;
   mutable ScheduleDesc trace_;  // trace the scheduling process

--- a/cinn/ir/schedule_desc.cc
+++ b/cinn/ir/schedule_desc.cc
@@ -409,6 +409,41 @@ CINN_BUILD_STEP_KIND(Rfactor)
 
 CINN_BUILD_STEP_KIND(MergeExprs)
     .SetApplyFn(APPLY_FUNC_UNIFORM(FREE_FUNCTION_CONVERTER(&IRSchedule::MergeExprs)));
+
+template <typename AttrType> void Annotate(IRSchedule* ir_sch, const Expr&, const std::string&, AttrType);
+template <> void Annotate<int>(IRSchedule* ir_sch, const Expr& block, const std::string& key, int value) {
+    ir_sch->Annotate(block, key, value);
+}
+template <> void Annotate<bool>(IRSchedule* ir_sch, const Expr& block, const std::string& key, bool value) {
+    ir_sch->Annotate(block, key, value);
+}
+template <> void Annotate<float>(IRSchedule* ir_sch, const Expr& block, const std::string& key, float value) {
+    ir_sch->Annotate(block, key, value);
+}
+void AnnotateStringAttr(IRSchedule* ir_sch, const Expr& block, const std::string& key, const std::string& value) {
+    ir_sch->Annotate(block, key, value);
+}
+
+CINN_BUILD_STEP_KIND(AnnotateIntAttr)
+    .Inputs({"block"})
+    .Attrs({"key", "value"})
+    .SetApplyFn(APPLY_FUNC_UNIFORM(Annotate<int>));
+
+CINN_BUILD_STEP_KIND(AnnotateBoolAttr)
+    .Inputs({"block"})
+    .Attrs({"key", "value"})
+    .SetApplyFn(APPLY_FUNC_UNIFORM(Annotate<bool>));
+
+CINN_BUILD_STEP_KIND(AnnotateFloatAttr)
+    .Inputs({"block"})
+    .Attrs({"key", "value"})
+    .SetApplyFn(APPLY_FUNC_UNIFORM(Annotate<float>));
+
+CINN_BUILD_STEP_KIND(AnnotateStringAttr)
+    .Inputs({"block"})
+    .Attrs({"key", "value"})
+    .SetApplyFn(APPLY_FUNC_UNIFORM(AnnotateStringAttr));
+
 // clang-format on
 
 // ------ Following codes are about member function implement of the ScheduleDesc class

--- a/cinn/ir/schedule_desc_test.cc
+++ b/cinn/ir/schedule_desc_test.cc
@@ -586,5 +586,45 @@ TEST_F(TestScheduleDesc, StepKind_MergeExprs) {
   }
 }
 
+TEST_F(TestScheduleDesc, StepKind_Annotate) {
+  lowered_funcs         = LowerCompute({32, 128}, target);
+  ir::IRSchedule ir_sch = MakeIRSchedule(lowered_funcs);
+
+  auto block_b = ir_sch.GetBlock("B");
+  trace.Append(ScheduleDesc::Step("GetBlock", {}, {{"block_name", std::string("B")}}, {block_b}));
+  ir_sch.Annotate(block_b, "k1", int(64));
+  trace.Append(ScheduleDesc::Step("AnnotateIntAttr",
+                                  {{"block", std::vector<Expr>({block_b})}},
+                                  {{"key", std::string("k1")}, {"value", int(64)}},
+                                  {}));
+
+  block_b = ir_sch.GetBlock("B");
+  trace.Append(ScheduleDesc::Step("GetBlock", {}, {{"block_name", std::string("B")}}, {block_b}));
+  ir_sch.Annotate(block_b, "k2", bool(true));
+  trace.Append(ScheduleDesc::Step("AnnotateBoolAttr",
+                                  {{"block", std::vector<Expr>({block_b})}},
+                                  {{"key", std::string("k2")}, {"value", bool(true)}},
+                                  {}));
+
+  block_b = ir_sch.GetBlock("B");
+  trace.Append(ScheduleDesc::Step("GetBlock", {}, {{"block_name", std::string("B")}}, {block_b}));
+  ir_sch.Annotate(block_b, "k3", float(2.0));
+  trace.Append(ScheduleDesc::Step("AnnotateFloatAttr",
+                                  {{"block", std::vector<Expr>({block_b})}},
+                                  {{"key", std::string("k3")}, {"value", float(2.0)}},
+                                  {}));
+
+  block_b = ir_sch.GetBlock("B");
+  trace.Append(ScheduleDesc::Step("GetBlock", {}, {{"block_name", std::string("B")}}, {block_b}));
+  ir_sch.Annotate(block_b, "k4", std::string("v4"));
+  trace.Append(ScheduleDesc::Step("AnnotateStringAttr",
+                                  {{"block", std::vector<Expr>({block_b})}},
+                                  {{"key", std::string("k4")}, {"value", std::string("v4")}},
+                                  {}));
+
+  CheckReplayResult(ir_sch, trace);
+  CheckReplayResult(ir_sch, ir_sch.GetTraceDesc());
+}
+
 }  // namespace ir
 }  // namespace cinn

--- a/cinn/optim/ir_copy.cc
+++ b/cinn/optim/ir_copy.cc
@@ -379,7 +379,9 @@ struct IRCopyVisitor : public ir::IRVisitorBase<Expr> {
     for (auto buffer_range : op->write_buffers) {
       write_buffers.push_back(Visit(&buffer_range));
     }
-    return ir::ScheduleBlock::Make(iter_vars, read_buffers, write_buffers, op->name, Visit(&op->body));
+    Expr res = ir::ScheduleBlock::Make(iter_vars, read_buffers, write_buffers, op->name, Visit(&op->body));
+    res.As<ir::ScheduleBlock>()->attrs = op->attrs;
+    return res;
   }
 
   Expr Visit(const ir::ScheduleBlockRealize* op) {


### PR DESCRIPTION
1. 新增`Annotate`调度原语，用于对ScheduleBlock添加属性
2. 同步更新ScheduleDesc注册的step，根据属性数据类型，增加`AnnotateIntAttr`，`AnnotateBoolAttr`，`AnnotateFloatAttr`，`AnnotateStringAttr`四种step
3. 更新`auto unroll`生成规则的实现，改为通过IRSchedule的`Annotate`原语来设置block的属性值，以便后续tracing