### PR TITLE
change protobuf output to root directory of build

### DIFF
--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -311,8 +311,8 @@ function(paddle_protobuf_generate_cpp SRCS HDRS)
 
       COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
       COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-      -I${CMAKE_CURRENT_SOURCE_DIR}
-      --cpp_out "${CMAKE_CURRENT_BINARY_DIR}" ${ABS_FIL}
+      -I ${CMAKE_SOURCE_DIR}
+      --cpp_out "${CMAKE_BINARY_DIR}" ${ABS_FIL}
       DEPENDS ${ABS_FIL} protoc
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"
       VERBATIM )


### PR DESCRIPTION
将protobuf编译生成c++ header和source时指令搜索路径改为根目录，并相应更改cpp_out的产出路径，以便支持跨目录import proto