### PR TITLE
change namespace of paddle framework.proto

### DIFF
--- a/cinn/frontend/paddle/compatible_pb.cc
+++ b/cinn/frontend/paddle/compatible_pb.cc
@@ -23,7 +23,7 @@
 #include "cinn/frontend/paddle/pb/var_desc.h"
 
 namespace cinn::frontend::paddle {
-namespace framework_proto = ::paddle::framework::proto;
+namespace framework_proto = ::cinn::frontend::paddle::proto;
 
 /// For VarDesc transfrom
 #define TRANS_VAR_ANY_WITH_CPP_IMPL(T)                                          \

--- a/cinn/frontend/paddle/framework.proto
+++ b/cinn/frontend/paddle/framework.proto
@@ -10,7 +10,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 syntax = "proto2";
-package paddle.framework.proto;
+package cinn.frontend.paddle.proto;
 
 // Any incompatible changes to ProgramDesc and its dependencies should
 // raise the version defined version.h.

--- a/cinn/frontend/paddle/model_parser.h
+++ b/cinn/frontend/paddle/model_parser.h
@@ -27,7 +27,7 @@
 #include "cinn/hlir/framework/tensor.h"
 
 namespace cinn::frontend::paddle {
-namespace framework_proto = ::paddle::framework::proto;
+namespace framework_proto = ::cinn::frontend::paddle::proto;
 
 // Read a model and files of parameters in pb format.
 void LoadModelPb(const std::string& model_dir,

--- a/cinn/frontend/paddle/pb/block_desc.h
+++ b/cinn/frontend/paddle/pb/block_desc.h
@@ -20,7 +20,7 @@
 
 namespace cinn::frontend::paddle::pb {
 
-namespace framework_proto = ::paddle::framework::proto;
+namespace framework_proto = ::cinn::frontend::paddle::proto;
 
 class BlockDesc : public cpp::BlockDescAPI {
  public:

--- a/cinn/frontend/paddle/pb/op_desc.h
+++ b/cinn/frontend/paddle/pb/op_desc.h
@@ -20,7 +20,7 @@
 
 namespace cinn::frontend::paddle::pb {
 
-namespace framework_proto = ::paddle::framework::proto;
+namespace framework_proto = ::cinn::frontend::paddle::proto;
 
 using Attribute       = absl::variant<int, float, bool, std::vector<std::string>, std::vector<int>>;
 using VariableNameMap = std::map<std::string, std::vector<std::string>>;

--- a/cinn/frontend/paddle/pb/program_desc.h
+++ b/cinn/frontend/paddle/pb/program_desc.h
@@ -22,7 +22,7 @@
 #include "cinn/frontend/paddle/framework.pb.h"
 
 namespace cinn::frontend::paddle::pb {
-namespace framework_proto = ::paddle::framework::proto;
+namespace framework_proto = ::cinn::frontend::paddle::proto;
 
 class ProgramDesc : public cpp::ProgramDescAPI {
  public:

--- a/cinn/frontend/paddle/pb/var_desc.h
+++ b/cinn/frontend/paddle/pb/var_desc.h
@@ -24,7 +24,7 @@
 #include "cinn/frontend/paddle/framework.pb.h"
 
 namespace cinn::frontend::paddle::pb {
-namespace framework_proto = ::paddle::framework::proto;
+namespace framework_proto = ::cinn::frontend::paddle::proto;
 
 // convert between std::vector and protobuf repeated.
 template <typename T>
@@ -60,7 +60,7 @@ class VarDesc : public cpp::VarDescAPI {
 
   explicit VarDesc(framework_proto::VarDesc *desc) : desc_(desc) { CHECK(desc_); }
 
-  ::paddle::framework::proto::VarDesc *Proto() { return desc_; }
+  ::cinn::frontend::paddle::proto::VarDesc *Proto() { return desc_; }
   const framework_proto::VarDesc &ReadonlyProto() const { return *desc_; }
 
   std::string Name() const override { return desc_->name(); }

--- a/cinn/frontend/paddle_model_to_program.cc
+++ b/cinn/frontend/paddle_model_to_program.cc
@@ -226,7 +226,7 @@ void PaddleModelToProgram::AddOpMapper_fill_constant() {
     Variable out;
     switch (dtype) {
 #define DO(desc, type)                                                           \
-  case ::paddle::framework::proto::VarType::Type::VarType_Type_##desc:           \
+  case ::cinn::frontend::paddle::proto::VarType::Type::VarType_Type_##desc:      \
     out = net_builder_->FillConstant<type>(shapes, value, str_value, force_cpu); \
     break;
       DO(BOOL, bool);


### PR DESCRIPTION
change namespace of paddle framework.proto from `paddle::framework::proto` to `cinn::frontend::paddle::proto`, in order to solve the redefinition error when compiling with Paddle framework due to the same generated protobuf header