### PR TITLE
Add auto tune cases

### DIFF
--- a/cinn/auto_schedule/tests/paddle_model_program_builder.h
+++ b/cinn/auto_schedule/tests/paddle_model_program_builder.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/auto_schedule/tests/program_case_builder.h"
+#include "cinn/frontend/net_builder.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+class PaddleModelProgramBuilder : public ProgramCaseBuilder {
+ public:
+  PaddleModelProgramBuilder(const std::string& model_path,
+                            const std::vector<std::string>& input_names,
+                            const std::vector<std::vector<int>>& input_shapes)
+      : model_path_(model_path), input_names_(input_names), input_shapes_(input_shapes) {}
+
+  frontend::Program operator()() override {
+    CHECK(!input_names_.empty());
+    CHECK_EQ(input_names_.size(), input_shapes_.size());
+
+    auto scope = std::make_shared<hlir::framework::Scope>();
+    std::unordered_map<std::string, std::vector<int>> input_to_shape;
+    for (int idx = 0; idx < input_names_.size(); ++idx) {
+      input_to_shape[input_names_[idx]] = input_shapes_[idx];
+    }
+    auto loadedProgram = cinn::frontend::LoadPaddleProgram(model_path_, scope.get(), input_to_shape, true, target_);
+    auto& program      = std::get<0>(loadedProgram);
+    auto& varmap       = std::get<1>(loadedProgram);
+    VLOG(3) << "loaded program: " << *program;
+    CHECK(!varmap.empty());
+
+    std::vector<frontend::Variable> input_vars;
+    std::transform(input_names_.begin(), input_names_.end(), std::back_inserter(input_vars), [&](const std::string& x) {
+      return varmap.at(x);
+    });
+
+    for (int i = 0; i < input_vars.size(); i++) {
+      input_vars[i]->shape = input_shapes_[i];
+    }
+
+    program->SetInputs(input_vars);
+    program->Validate();
+
+    return *program;
+  }
+
+ private:
+  const std::string model_path_;
+  std::vector<std::string> input_names_;
+  std::vector<std::vector<int>> input_shapes_;
+#ifdef CINN_WITH_CUDA
+  Target target_ = common::DefaultNVGPUTarget();
+#else
+  Target target_ = common::DefaultHostTarget();
+#endif
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/tests/paddle_model_program_builder.h
+++ b/cinn/auto_schedule/tests/paddle_model_program_builder.h
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include "cinn/auto_schedule/tests/program_case_builder.h"
+#include "cinn/auto_schedule/tests/test_program_builder.h"
 #include "cinn/frontend/net_builder.h"
 
 namespace cinn {
 namespace auto_schedule {
 
-class PaddleModelProgramBuilder : public ProgramCaseBuilder {
+class PaddleModelProgramBuilder : public TestProgramBuilder {
  public:
   PaddleModelProgramBuilder(const std::string& model_path,
                             const std::vector<std::string>& input_names,

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -19,6 +19,8 @@
 #include <iostream>
 
 #include "cinn/auto_schedule/auto_tuner.h"
+#include "cinn/auto_schedule/tests/paddle_model_program_builder.h"
+#include "cinn/auto_schedule/tests/single_op_program_builder.h"
 #include "cinn/common/target.h"
 #include "cinn/frontend/net_builder.h"
 #include "cinn/frontend/optimize.h"
@@ -42,12 +44,15 @@ using ::cinn::hlir::framework::GraphCompiler;
 using ::cinn::hlir::framework::Instruction;
 using ::cinn::hlir::framework::Scope;
 
-class PerformanceTester {
+class PerformanceTester : public ::testing::Test {
  public:
-  virtual frontend::Program CreateProgram() = 0;
+  void SetUp() override {
+    // AutoTuner is combined with new IR Schedule
+    FLAGS_cinn_ir_schedule = true;
+  }
 
   void BuildRuntimePrograms(int num_tuning_rounds) {
-    scope_          = BuildScope(target_, graph_, scope_);
+    scope_          = BuildScope(target_, graph_);
     graph_compiler_ = std::make_unique<GraphCompiler>(target_, scope_, graph_);
     if (option_flags_.test(0)) {
       VLOG(3) << "Build no schedule program.";
@@ -78,17 +83,11 @@ class PerformanceTester {
     }
   }
 
-  void BuildAndRun(int repeat, int num_tuning_rounds, bool initialize_graph = false) {
-    if (initialize_graph || !is_graph_initialized_) {
-      VLOG(3) << "Start initialize graph.";
-      auto program = CreateProgram();
-      graph_       = std::make_shared<hlir::framework::Graph>(program, target_);
-      hlir::framework::ApplyPass(graph_.get(), "InferShape");
-      is_graph_initialized_ = true;
-      VLOG(3) << "Initialize graph completed.";
-    }
-
-    VLOG(3) << "start building runtime program.";
+  void BuildAndRun(int repeat, int num_tuning_rounds, const frontend::Program& program) {
+    VLOG(3) << "Start initialize graph.";
+    graph_ = std::make_shared<hlir::framework::Graph>(program, target_);
+    hlir::framework::ApplyPass(graph_.get(), "InferShape");
+    VLOG(3) << "Initialize graph completed, Start building runtime program.";
     BuildRuntimePrograms(num_tuning_rounds);
     VLOG(3) << "Build runtime programs completed, start running.";
     Run(repeat);
@@ -155,13 +154,7 @@ class PerformanceTester {
     no_schedule_program_ = graph_compiler_->Build(compile_options).runtime_program;
   }
 
-  void BuildManualScheduleProgram() {
-    manual_schedule_program_ = graph_compiler_->Build();
-
-    VLOG(3) << "===========================Manual Schedule LoweredFunc Begin===========================";
-    graph_compiler_->PrintFunc();
-    VLOG(3) << "===========================Manual Schedule LoweredFunc End=============================";
-  }
+  void BuildManualScheduleProgram() { manual_schedule_program_ = graph_compiler_->Build(); }
 
   void BuildAutoScheduleProgram(int num_tuning_rounds = 10) {
     tuner_ = std::make_unique<AutoTuner>(target_, graph_.get());
@@ -210,106 +203,6 @@ class PerformanceTester {
   // Bit with index 2 controls auto schedule test, means options = 4 = "100" will run auto schedule test.
   // The default value is 7, which means that all tests will be run.
   std::bitset<3> option_flags_ = 7UL;
-  bool is_graph_initialized_   = false;
-};
-
-class MulPerformanceTester : public PerformanceTester {
- public:
-  MulPerformanceTester(int M, int K, int N) : M_(M), K_(K), N_(N) {}
-
-  frontend::Program CreateProgram() override {
-    frontend::NetBuilder builder("mul_net_builder");
-    auto x = builder.CreateInput(Float(32), {M_, K_}, "X");
-    auto y = builder.CreateInput(Float(32), {N_, K_}, "Y");
-
-    auto mul_out = builder.Mul(x, y, 1, 1);
-    return builder.Build();
-  }
-
- private:
-  int M_;
-  int K_;
-  int N_;
-};
-
-class MatmulPerformanceTester : public PerformanceTester {
- public:
-  MatmulPerformanceTester(int M, int K, int N) : M_(M), K_(K), N_(N) {}
-
-  frontend::Program CreateProgram() override {
-    frontend::NetBuilder builder("mul_net_builder");
-    auto x = builder.CreateInput(Float(32), {M_, K_}, "X");
-    auto y = builder.CreateInput(Float(32), {K_, N_}, "Y");
-
-    auto mul_out = builder.Matmul(x, y);
-    return builder.Build();
-  }
-
- private:
-  int M_;
-  int K_;
-  int N_;
-};
-
-class AddPerformanceTester : public PerformanceTester {
- public:
-  AddPerformanceTester(int M, int N) : M_(M), N_(N) {}
-
-  frontend::Program CreateProgram() override {
-    frontend::NetBuilder builder("add_net_builder");
-    auto x = builder.CreateInput(Float(32), {M_, N_}, "X");
-    auto y = builder.CreateInput(Float(32), {M_, N_}, "Y");
-
-    auto mul_out = builder.Add(x, y);
-    return builder.Build();
-  }
-
- private:
-  int M_;
-  int N_;
-};
-
-class PaddleModelPerformanceTester : public PerformanceTester {
- public:
-  PaddleModelPerformanceTester(const std::string& model_path,
-                               const std::vector<std::string>& input_names,
-                               const std::vector<std::vector<int>>& input_shapes)
-      : model_path_(model_path), input_names_(input_names), input_shapes_(input_shapes) {}
-
-  frontend::Program CreateProgram() override {
-    CHECK(!input_names_.empty());
-    CHECK_EQ(input_names_.size(), input_shapes_.size());
-
-    scope_ = std::make_shared<hlir::framework::Scope>();
-    std::unordered_map<std::string, std::vector<int>> input_to_shape;
-    for (int idx = 0; idx < input_names_.size(); ++idx) {
-      input_to_shape[input_names_[idx]] = input_shapes_[idx];
-    }
-    auto loadedProgram = cinn::frontend::LoadPaddleProgram(model_path_, scope_.get(), input_to_shape, true, target_);
-    auto& program      = std::get<0>(loadedProgram);
-    auto& varmap       = std::get<1>(loadedProgram);
-    VLOG(3) << "loaded program: " << *program;
-    CHECK(!varmap.empty());
-
-    std::vector<frontend::Variable> input_vars;
-    std::transform(input_names_.begin(), input_names_.end(), std::back_inserter(input_vars), [&](const std::string& x) {
-      return varmap.at(x);
-    });
-
-    for (int i = 0; i < input_vars.size(); i++) {
-      input_vars[i]->shape = input_shapes_[i];
-    }
-
-    program->SetInputs(input_vars);
-    program->Validate();
-
-    return *program;
-  }
-
- private:
-  const std::string model_path_;
-  std::vector<std::string> input_names_;
-  std::vector<std::vector<int>> input_shapes_;
 };
 
 #ifdef CINN_WITH_CUDA
@@ -317,45 +210,33 @@ class PaddleModelPerformanceTester : public PerformanceTester {
 const int repeat_time       = 100;
 const int num_tuning_rounds = 1;
 
-TEST(MatmulPerformanceTest, matmul_32x16x32) {
-  FLAGS_cinn_ir_schedule = true;
-  int M                  = 32;
-  int K                  = 16;
-  int N                  = 32;
-  MatmulPerformanceTester tester(M, K, N);
-  tester.SetOptionFlags(5UL);
-  tester.BuildAndRun(repeat_time, num_tuning_rounds);
+TEST_F(PerformanceTester, add_32x16) {
+  int M = 32;
+  int N = 16;
+  BuildAndRun(repeat_time, num_tuning_rounds, AddProgramBuilder(M, N)());
 }
 
-TEST(MulPerformanceTest, mul_32x16x32) {
-  FLAGS_cinn_ir_schedule = true;
-  int M                  = 32;
-  int K                  = 16;
-  int N                  = 32;
-  MulPerformanceTester tester(M, K, N);
-  tester.SetOptionFlags(5UL);
-  tester.BuildAndRun(repeat_time, num_tuning_rounds);
+TEST_F(PerformanceTester, mul_32x16x32) {
+  int M = 32;
+  int K = 16;
+  int N = 32;
+  BuildAndRun(repeat_time, num_tuning_rounds, MulProgramBuilder(M, K, N)());
 }
 
-TEST(AddPerformanceTest, add_32x16) {
-  FLAGS_cinn_ir_schedule = true;
-  int M                  = 32;
-  int N                  = 16;
-  AddPerformanceTester tester(M, N);
-  tester.SetOptionFlags(5UL);
-  tester.BuildAndRun(repeat_time, num_tuning_rounds);
+TEST_F(PerformanceTester, matmul_32x16x32) {
+  int M = 32;
+  int K = 16;
+  int N = 32;
+  BuildAndRun(repeat_time, num_tuning_rounds, MatmulProgramBuilder(M, K, N)());
 }
 
-TEST(PaddleModelPerformanceTester, ResNet50) {
-  FLAGS_cinn_ir_schedule                     = true;
+TEST_F(PerformanceTester, ResNet50) {
   std::vector<std::string> input_names       = {"inputs"};
   std::vector<std::vector<int>> input_shapes = {{1, 3, 224, 224}};
-
   CHECK_NE(FLAGS_resnet50_model_dir, "");
-  // ResNet50 can only run manual schedule test now.
-  PaddleModelPerformanceTester tester(FLAGS_resnet50_model_dir, input_names, input_shapes);
-  tester.SetOptionFlags(0UL);
-  tester.BuildAndRun(repeat_time, num_tuning_rounds);
+  SetOptionFlags(0UL);
+  BuildAndRun(
+      repeat_time, num_tuning_rounds, PaddleModelProgramBuilder(FLAGS_resnet50_model_dir, input_names, input_shapes)());
 }
 
 #endif

--- a/cinn/auto_schedule/tests/program_case_builder.h
+++ b/cinn/auto_schedule/tests/program_case_builder.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace cinn {
+namespace auto_schedule {
+
+class ProgramCaseBuilder {
+ public:
+  virtual frontend::Program operator()() = 0;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/tests/single_op_program_builder.h
+++ b/cinn/auto_schedule/tests/single_op_program_builder.h
@@ -76,5 +76,224 @@ class MatmulProgramBuilder : public ProgramCaseBuilder {
   int N_;
 };
 
+class ReluProgramBuilder : public ProgramCaseBuilder {
+ public:
+  ReluProgramBuilder(std::vector<int32_t> input_shape) : input_shape_(input_shape) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("relu_net_builder");
+    auto x = builder.CreateInput(Float(32), input_shape_, "X");
+    auto y = builder.Relu(x);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+};
+
+class Conv2dProgramBuilder : public ProgramCaseBuilder {
+ public:
+  Conv2dProgramBuilder(const std::vector<int32_t>& input_shape,
+                       const std::vector<int32_t>& weight_shape,
+                       const std::vector<int>& strides,
+                       const std::vector<int>& paddings,
+                       const std::vector<int>& dilations,
+                       int groups                           = 1,
+                       const std::string& data_format       = "NCHW",
+                       const std::string& padding_algorithm = "EXPLICIT")
+      : input_shape_(input_shape),
+        weight_shape_(weight_shape),
+        strides_(strides),
+        paddings_(paddings),
+        dilations_(dilations),
+        groups_(groups),
+        data_format_(data_format),
+        padding_algorithm_(padding_algorithm_) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("conv2d_net_builder");
+    auto x       = builder.CreateInput(Float(32), input_shape_, "X");
+    auto weights = builder.CreateInput(Float(32), weight_shape_, "W");
+    auto out = builder.Conv2d(x, weights, strides_, paddings_, dilations_, groups_, data_format_, padding_algorithm_);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+  std::vector<int32_t> weight_shape_;
+  std::vector<int> strides_;
+  std::vector<int> paddings_;
+  std::vector<int> dilations_;
+  int groups_;
+  std::string data_format_;
+  std::string padding_algorithm_;
+};
+
+class Pool2dProgramBuilder : public ProgramCaseBuilder {
+ public:
+  Pool2dProgramBuilder(const std::vector<int32_t>& input_shape,
+                       const std::string& pooling_type,
+                       const std::vector<int>& ksize,
+                       const std::vector<int>& strides,
+                       const std::vector<int>& paddings,
+                       bool ceil_mode                       = false,
+                       bool exclusive                       = true,
+                       bool global_pooling                  = false,
+                       const std::string& data_format       = "NCHW",
+                       bool adaptive                        = false,
+                       const std::string& padding_algorithm = "EXPLICIT")
+      : input_shape_(input_shape),
+        pooling_type_(pooling_type),
+        ksize_(ksize),
+        strides_(strides),
+        paddings_(paddings),
+        ceil_mode_(ceil_mode),
+        exclusive_(exclusive),
+        global_pooling_(global_pooling),
+        data_format_(data_format),
+        adaptive_(adaptive),
+        padding_algorithm_(padding_algorithm) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("pool2d_net_builder");
+    auto x   = builder.CreateInput(Float(32), input_shape_, "X");
+    auto out = builder.Pool2d(x,
+                              pooling_type_,
+                              ksize_,
+                              strides_,
+                              paddings_,
+                              ceil_mode_,
+                              exclusive_,
+                              global_pooling_,
+                              data_format_,
+                              adaptive_,
+                              padding_algorithm_);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+  std::string pooling_type_;
+  std::vector<int> ksize_;
+  std::vector<int> strides_;
+  std::vector<int> paddings_;
+  bool ceil_mode_;
+  bool exclusive_;
+  bool global_pooling_;
+  std::string data_format_;
+  bool adaptive_;
+  std::string padding_algorithm_;
+};
+
+class BatchNormProgramBuilder : public ProgramCaseBuilder {
+ public:
+  BatchNormProgramBuilder(const std::vector<int32_t>& input_shape,
+                          const std::vector<int32_t>& scale_shape,
+                          const std::vector<int32_t>& bias_shape,
+                          const std::vector<int32_t>& mean_shape,
+                          const std::vector<int32_t>& variance_shape,
+                          float epsilon                  = 1e-5f,
+                          float momentum                 = 0.9f,
+                          const std::string& data_layout = "NCHW",
+                          bool is_test                   = false)
+      : input_shape_(input_shape),
+        scale_shape_(scale_shape),
+        bias_shape_(bias_shape),
+        mean_shape_(mean_shape),
+        variance_shape_(variance_shape),
+        epsilon_(epsilon),
+        momentum_(momentum),
+        data_layout_(data_layout),
+        is_test_(is_test) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("pool2d_net_builder");
+    auto x        = builder.CreateInput(Float(32), input_shape_, "X");
+    auto scale    = builder.CreateInput(Float(32), scale_shape_, "scale");
+    auto bias     = builder.CreateInput(Float(32), bias_shape_, "bias");
+    auto mean     = builder.CreateInput(Float(32), mean_shape_, "mean");
+    auto variance = builder.CreateInput(Float(32), variance_shape_, "variance");
+    auto out      = builder.BatchNorm(x, scale, bias, mean, variance, epsilon_, momentum_, data_layout_, is_test_);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+  std::vector<int32_t> scale_shape_;
+  std::vector<int32_t> bias_shape_;
+  std::vector<int32_t> mean_shape_;
+  std::vector<int32_t> variance_shape_;
+  float epsilon_;
+  float momentum_;
+  std::string data_layout_;
+  bool is_test_;
+};
+
+class ReshapeProgramBuilder : public ProgramCaseBuilder {
+ public:
+  ReshapeProgramBuilder(const std::vector<int32_t>& input_shape, const std::vector<int32_t>& output_shape)
+      : input_shape_(input_shape), output_shape_(output_shape) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("reshape_net_builder");
+    auto x = builder.CreateInput(Float(32), input_shape_, "X");
+    auto y = builder.Reshape(x, output_shape_);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+  std::vector<int32_t> output_shape_;
+};
+
+class SoftmaxProgramBuilder : public ProgramCaseBuilder {
+ public:
+  SoftmaxProgramBuilder(const std::vector<int32_t>& input_shape,
+                        int axis                       = -1,
+                        const std::string& data_format = "AnyLayout")
+      : input_shape_(input_shape), axis_(axis), data_format_(data_format) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("softmax_net_builder");
+    auto x = builder.CreateInput(Float(32), input_shape_, "X");
+    auto y = builder.Softmax(x, axis_, data_format_);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+  int axis_;
+  std::string data_format_;
+};
+
+class ScaleProgramBuilder : public ProgramCaseBuilder {
+ public:
+  ScaleProgramBuilder(const std::vector<int32_t>& input_shape,
+                      float scale           = 1.0f,
+                      float bias            = 0.0f,
+                      bool bias_after_scale = true)
+      : input_shape_(input_shape), scale_(scale), bias_(bias), bias_after_scale_(bias_after_scale) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("scale_net_builder");
+    auto x = builder.CreateInput(Float(32), input_shape_, "X");
+    auto y = builder.Scale(x, scale_, bias_, bias_after_scale_);
+
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> input_shape_;
+  float scale_;
+  float bias_;
+  bool bias_after_scale_;
+};
+
 }  // namespace auto_schedule
 }  // namespace cinn

--- a/cinn/auto_schedule/tests/single_op_program_builder.h
+++ b/cinn/auto_schedule/tests/single_op_program_builder.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/auto_schedule/tests/program_case_builder.h"
+#include "cinn/frontend/net_builder.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+class AddProgramBuilder : public ProgramCaseBuilder {
+ public:
+  AddProgramBuilder(int M, int N) : M_(M), N_(N) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("add_net_builder");
+    auto x = builder.CreateInput(Float(32), {M_, N_}, "X");
+    auto y = builder.CreateInput(Float(32), {M_, N_}, "Y");
+
+    auto mul_out = builder.Add(x, y);
+    return builder.Build();
+  }
+
+ private:
+  int M_;
+  int N_;
+};
+
+class MulProgramBuilder : public ProgramCaseBuilder {
+ public:
+  MulProgramBuilder(int M, int K, int N) : M_(M), K_(K), N_(N) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("mul_net_builder");
+    auto x = builder.CreateInput(Float(32), {M_, K_}, "X");
+    auto y = builder.CreateInput(Float(32), {N_, K_}, "Y");
+
+    auto mul_out = builder.Mul(x, y, 1, 1);
+    return builder.Build();
+  }
+
+ private:
+  int M_;
+  int K_;
+  int N_;
+};
+
+class MatmulProgramBuilder : public ProgramCaseBuilder {
+ public:
+  MatmulProgramBuilder(int M, int K, int N) : M_(M), K_(K), N_(N) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("matmul_net_builder");
+    auto x = builder.CreateInput(Float(32), {M_, K_}, "X");
+    auto y = builder.CreateInput(Float(32), {K_, N_}, "Y");
+
+    auto mul_out = builder.Matmul(x, y);
+    return builder.Build();
+  }
+
+ private:
+  int M_;
+  int K_;
+  int N_;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/tests/single_op_program_builder.h
+++ b/cinn/auto_schedule/tests/single_op_program_builder.h
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include "cinn/auto_schedule/tests/program_case_builder.h"
+#include "cinn/auto_schedule/tests/test_program_builder.h"
 #include "cinn/frontend/net_builder.h"
 
 namespace cinn {
 namespace auto_schedule {
 
-class AddProgramBuilder : public ProgramCaseBuilder {
+class AddProgramBuilder : public TestProgramBuilder {
  public:
   AddProgramBuilder(const std::vector<int32_t>& input_shape_x, const std::vector<int32_t>& input_shape_y)
       : input_shape_x_(input_shape_x), input_shape_y_(input_shape_y) {}
@@ -39,7 +39,7 @@ class AddProgramBuilder : public ProgramCaseBuilder {
   std::vector<int32_t> input_shape_y_;
 };
 
-class MulProgramBuilder : public ProgramCaseBuilder {
+class MulProgramBuilder : public TestProgramBuilder {
  public:
   MulProgramBuilder(const std::vector<int32_t>& input_shape_x,
                     const std::vector<int32_t>& input_shape_y,
@@ -66,7 +66,7 @@ class MulProgramBuilder : public ProgramCaseBuilder {
   int y_num_col_dims_;
 };
 
-class MatmulProgramBuilder : public ProgramCaseBuilder {
+class MatmulProgramBuilder : public TestProgramBuilder {
  public:
   MatmulProgramBuilder(const std::vector<int32_t>& input_shape_x,
                        const std::vector<int32_t>& input_shape_y,
@@ -96,7 +96,7 @@ class MatmulProgramBuilder : public ProgramCaseBuilder {
   float alpha_;
 };
 
-class ReluProgramBuilder : public ProgramCaseBuilder {
+class ReluProgramBuilder : public TestProgramBuilder {
  public:
   ReluProgramBuilder(std::vector<int32_t> input_shape) : input_shape_(input_shape) {}
 
@@ -112,7 +112,7 @@ class ReluProgramBuilder : public ProgramCaseBuilder {
   std::vector<int32_t> input_shape_;
 };
 
-class Conv2dProgramBuilder : public ProgramCaseBuilder {
+class Conv2dProgramBuilder : public TestProgramBuilder {
  public:
   Conv2dProgramBuilder(const std::vector<int32_t>& input_shape,
                        const std::vector<int32_t>& weight_shape,
@@ -151,7 +151,7 @@ class Conv2dProgramBuilder : public ProgramCaseBuilder {
   std::string padding_algorithm_;
 };
 
-class Pool2dProgramBuilder : public ProgramCaseBuilder {
+class Pool2dProgramBuilder : public TestProgramBuilder {
  public:
   Pool2dProgramBuilder(const std::vector<int32_t>& input_shape,
                        const std::string& pooling_type,
@@ -208,7 +208,7 @@ class Pool2dProgramBuilder : public ProgramCaseBuilder {
   std::string padding_algorithm_;
 };
 
-class BatchNormProgramBuilder : public ProgramCaseBuilder {
+class BatchNormProgramBuilder : public TestProgramBuilder {
  public:
   BatchNormProgramBuilder(const std::vector<int32_t>& input_shape,
                           const std::vector<int32_t>& scale_shape,
@@ -253,7 +253,7 @@ class BatchNormProgramBuilder : public ProgramCaseBuilder {
   bool is_test_;
 };
 
-class ReshapeProgramBuilder : public ProgramCaseBuilder {
+class ReshapeProgramBuilder : public TestProgramBuilder {
  public:
   ReshapeProgramBuilder(const std::vector<int32_t>& input_shape, const std::vector<int32_t>& output_shape)
       : input_shape_(input_shape), output_shape_(output_shape) {}
@@ -271,7 +271,7 @@ class ReshapeProgramBuilder : public ProgramCaseBuilder {
   std::vector<int32_t> output_shape_;
 };
 
-class SoftmaxProgramBuilder : public ProgramCaseBuilder {
+class SoftmaxProgramBuilder : public TestProgramBuilder {
  public:
   SoftmaxProgramBuilder(const std::vector<int32_t>& input_shape,
                         int axis                       = -1,
@@ -292,7 +292,7 @@ class SoftmaxProgramBuilder : public ProgramCaseBuilder {
   std::string data_format_;
 };
 
-class ScaleProgramBuilder : public ProgramCaseBuilder {
+class ScaleProgramBuilder : public TestProgramBuilder {
  public:
   ScaleProgramBuilder(const std::vector<int32_t>& input_shape,
                       float scale           = 1.0f,

--- a/cinn/auto_schedule/tests/single_op_program_builder.h
+++ b/cinn/auto_schedule/tests/single_op_program_builder.h
@@ -22,58 +22,78 @@ namespace auto_schedule {
 
 class AddProgramBuilder : public ProgramCaseBuilder {
  public:
-  AddProgramBuilder(int M, int N) : M_(M), N_(N) {}
+  AddProgramBuilder(const std::vector<int32_t>& input_shape_x, const std::vector<int32_t>& input_shape_y)
+      : input_shape_x_(input_shape_x), input_shape_y_(input_shape_y) {}
 
   frontend::Program operator()() override {
     frontend::NetBuilder builder("add_net_builder");
-    auto x = builder.CreateInput(Float(32), {M_, N_}, "X");
-    auto y = builder.CreateInput(Float(32), {M_, N_}, "Y");
+    auto x = builder.CreateInput(Float(32), input_shape_x_, "X");
+    auto y = builder.CreateInput(Float(32), input_shape_y_, "Y");
 
     auto mul_out = builder.Add(x, y);
     return builder.Build();
   }
 
  private:
-  int M_;
-  int N_;
+  std::vector<int32_t> input_shape_x_;
+  std::vector<int32_t> input_shape_y_;
 };
 
 class MulProgramBuilder : public ProgramCaseBuilder {
  public:
-  MulProgramBuilder(int M, int K, int N) : M_(M), K_(K), N_(N) {}
+  MulProgramBuilder(const std::vector<int32_t>& input_shape_x,
+                    const std::vector<int32_t>& input_shape_y,
+                    int x_num_col_dims = 1,
+                    int y_num_col_dims = 1)
+      : input_shape_x_(input_shape_x),
+        input_shape_y_(input_shape_y),
+        x_num_col_dims_(x_num_col_dims),
+        y_num_col_dims_(y_num_col_dims) {}
 
   frontend::Program operator()() override {
     frontend::NetBuilder builder("mul_net_builder");
-    auto x = builder.CreateInput(Float(32), {M_, K_}, "X");
-    auto y = builder.CreateInput(Float(32), {N_, K_}, "Y");
+    auto x = builder.CreateInput(Float(32), input_shape_x_, "X");
+    auto y = builder.CreateInput(Float(32), input_shape_y_, "Y");
 
-    auto mul_out = builder.Mul(x, y, 1, 1);
+    auto mul_out = builder.Mul(x, y, x_num_col_dims_, y_num_col_dims_);
     return builder.Build();
   }
 
  private:
-  int M_;
-  int K_;
-  int N_;
+  std::vector<int32_t> input_shape_x_;
+  std::vector<int32_t> input_shape_y_;
+  int x_num_col_dims_;
+  int y_num_col_dims_;
 };
 
 class MatmulProgramBuilder : public ProgramCaseBuilder {
  public:
-  MatmulProgramBuilder(int M, int K, int N) : M_(M), K_(K), N_(N) {}
+  MatmulProgramBuilder(const std::vector<int32_t>& input_shape_x,
+                       const std::vector<int32_t>& input_shape_y,
+                       bool trans_x = false,
+                       bool trans_y = false,
+                       float alpha  = 1.0f)
+      : input_shape_x_(input_shape_x),
+        input_shape_y_(input_shape_y),
+        trans_x_(trans_x),
+        trans_y_(trans_y),
+        alpha_(alpha) {}
 
   frontend::Program operator()() override {
     frontend::NetBuilder builder("matmul_net_builder");
-    auto x = builder.CreateInput(Float(32), {M_, K_}, "X");
-    auto y = builder.CreateInput(Float(32), {K_, N_}, "Y");
+    auto x = builder.CreateInput(Float(32), input_shape_x_, "X");
+    auto y = builder.CreateInput(Float(32), input_shape_y_, "Y");
 
-    auto mul_out = builder.Matmul(x, y);
+    auto mul_out = builder.Matmul(x, y, trans_x_, trans_y_, alpha_);
     return builder.Build();
   }
 
  private:
-  int M_;
-  int K_;
-  int N_;
+  std::vector<int32_t> input_shape_x_;
+  std::vector<int32_t> input_shape_y_;
+  bool trans_x_;
+  bool trans_y_;
+  float alpha_;
 };
 
 class ReluProgramBuilder : public ProgramCaseBuilder {

--- a/cinn/auto_schedule/tests/test_program_builder.h
+++ b/cinn/auto_schedule/tests/test_program_builder.h
@@ -17,7 +17,7 @@
 namespace cinn {
 namespace auto_schedule {
 
-class ProgramCaseBuilder {
+class TestProgramBuilder {
  public:
   virtual frontend::Program operator()() = 0;
 };


### PR DESCRIPTION
1.改造AutoTuner联调测试用例基类接口，将program的构造从PerformanceTester中分离出来，不同program的构造分别实现接口，PerformanceTester中调用BuildAndRun()时传入构造好的program。
2.将ResNet50模型中的算子分别以单算子的形式添加测试case。