### PR TITLE
Update SearchState definition to derive from common::Shared

### DIFF
--- a/cinn/auto_schedule/cost_model/expr_cost_model.cc
+++ b/cinn/auto_schedule/cost_model/expr_cost_model.cc
@@ -30,7 +30,7 @@ namespace auto_schedule {
 
 float ExprCostModel::Predict(const ir::ModuleExpr& sample, const common::Target& target) const {
   if (trained_times_.load() == 0) {
-    return SearchState::NOT_INIT_COST;
+    return _SearchState_::NOT_INIT_COST;
   }
   FeatureExtractor extractor;
   Feature feature                    = extractor.Extract(sample, target);

--- a/cinn/auto_schedule/cost_model/expr_cost_model.cc
+++ b/cinn/auto_schedule/cost_model/expr_cost_model.cc
@@ -30,7 +30,7 @@ namespace auto_schedule {
 
 float ExprCostModel::Predict(const ir::ModuleExpr& sample, const common::Target& target) const {
   if (trained_times_.load() == 0) {
-    return _SearchState_::NOT_INIT_COST;
+    return SearchState::NOT_INIT_COST;
   }
   FeatureExtractor extractor;
   Feature feature                    = extractor.Extract(sample, target);

--- a/cinn/auto_schedule/database/database.cc
+++ b/cinn/auto_schedule/database/database.cc
@@ -56,16 +56,19 @@ std::unique_ptr<Database> Database::Make(const DatabaseConfig& config) {
   return nullptr;
 }
 
-bool Database::AddRecord(TuningRecord&& record) {
-  CHECK(!record.task_key.empty()) << "task_key of TuningRecord can't be empty";
-  Commit(record);
-
+void Database::Insert(const TuningRecord record) {
   auto& records = key2record_[record.task_key];
-  records.emplace(std::move(record));
+  records.emplace(record);
   if (records.size() > capacity_per_task_) {
     records.erase(std::prev(records.end()));
   }
-  return true;
+}
+
+bool Database::AddRecord(const TuningRecord& record) {
+  CHECK(!record.task_key.empty()) << "task_key of TuningRecord can't be empty";
+
+  Insert(record);
+  return Commit(record);
 }
 
 std::vector<TuningRecord> Database::LookUp(const std::string& task_key) {

--- a/cinn/auto_schedule/database/database.cc
+++ b/cinn/auto_schedule/database/database.cc
@@ -34,8 +34,8 @@ proto::TuningRecord TuningRecord::ToProto() const {
   proto::TuningRecord record_proto;
   record_proto.set_task_key(task_key);
   record_proto.set_execution_cost(execution_cost);
-  record_proto.set_predicted_cost(state.predicted_cost);
-  auto trace_proto = state.ir_schedule.GetTraceDesc().ToProto();
+  record_proto.set_predicted_cost(state->predicted_cost);
+  auto trace_proto = state->ir_schedule.GetTraceDesc().ToProto();
   record_proto.mutable_trace()->Swap(&trace_proto);
 
   return record_proto;
@@ -89,7 +89,7 @@ std::vector<SearchState> Database::GetTopK(const std::string& task_key, int k) {
     return {};
   }
   if (k > capacity_per_task_) {
-    LOG(WARNING) << "Input k:" << k << " is greater than the capacity";
+    LOG(WARNING) << "Top k=" << k << " is greater than the capacity, will adjust k=" << capacity_per_task_;
     k = capacity_per_task_;
   }
 

--- a/cinn/auto_schedule/database/database.cc
+++ b/cinn/auto_schedule/database/database.cc
@@ -56,7 +56,7 @@ std::unique_ptr<Database> Database::Make(const DatabaseConfig& config) {
   return nullptr;
 }
 
-void Database::Insert(const TuningRecord record) {
+void Database::Insert(const TuningRecord& record) {
   auto& records = key2record_[record.task_key];
   records.emplace(record);
   if (records.size() > capacity_per_task_) {

--- a/cinn/auto_schedule/database/database.h
+++ b/cinn/auto_schedule/database/database.h
@@ -43,10 +43,8 @@ struct TuningRecord {
 
   TuningRecord() = default;
 
-  TuningRecord(const std::string& task_key, double execution_cost, double predicted_cost, ir::IRSchedule ir_sch)
-      : task_key(task_key), execution_cost(execution_cost), state(std::move(ir_sch)) {
-    state.predicted_cost = predicted_cost;
-  }
+  TuningRecord(const std::string& task_key, double execution_cost, SearchState state)
+      : task_key(task_key), execution_cost(execution_cost), state(state) {}
 
   // convert to proto object
   proto::TuningRecord ToProto() const;
@@ -73,7 +71,7 @@ class Database {
   static std::unique_ptr<Database> Make(const DatabaseConfig& config);
 
   // add a record into the database
-  bool AddRecord(TuningRecord&& record);
+  bool AddRecord(const TuningRecord& record);
   // return all records whose task_keys are equal to the specified key
   std::vector<TuningRecord> LookUp(const std::string& task_key);
   // return the states of the top k in sorted candidates
@@ -86,6 +84,8 @@ class Database {
  protected:
   // commit the newly added record into underlying storage
   virtual bool Commit(const TuningRecord& record) { return true; }
+  // insert a newly added record into memory storage
+  void Insert(const TuningRecord record);
 
   // map task_key to its records
   std::unordered_map<std::string, std::multiset<TuningRecord, TuningRecord::Compare>> key2record_;

--- a/cinn/auto_schedule/database/database.h
+++ b/cinn/auto_schedule/database/database.h
@@ -85,7 +85,7 @@ class Database {
   // commit the newly added record into underlying storage
   virtual bool Commit(const TuningRecord& record) { return true; }
   // insert a newly added record into memory storage
-  void Insert(const TuningRecord record);
+  void Insert(const TuningRecord& record);
 
   // map task_key to its records
   std::unordered_map<std::string, std::multiset<TuningRecord, TuningRecord::Compare>> key2record_;

--- a/cinn/auto_schedule/database/database_test.cc
+++ b/cinn/auto_schedule/database/database_test.cc
@@ -28,7 +28,7 @@ namespace auto_schedule {
 class TestDatabase : public ::testing::Test {
  public:
   TestDatabase() : test_db(2) {
-    auto state = _SearchState_::Make(ir::IRSchedule());
+    auto state = SearchState(ir::IRSchedule());
     test_db.AddRecord(TuningRecord("k1", 1.0, state));
     test_db.AddRecord(TuningRecord("k2", 2.0, state));
     test_db.AddRecord(TuningRecord("k2", 3.0, state));
@@ -57,8 +57,8 @@ TEST_F(TestDatabase, GetTopK) {
   ASSERT_TRUE(test_db.GetTopK("k5", 2).empty());
   ASSERT_EQ(test_db.GetTopK("k4", 3).size(), 1);
 
-  test_db.AddRecord(TuningRecord("k4", 2.0, _SearchState_::Make(ir::IRSchedule(), 1.2)));
-  test_db.AddRecord(TuningRecord("k4", 3.0, _SearchState_::Make(ir::IRSchedule(), 1.0)));
+  test_db.AddRecord(TuningRecord("k4", 2.0, SearchState(ir::IRSchedule(), 1.2)));
+  test_db.AddRecord(TuningRecord("k4", 3.0, SearchState(ir::IRSchedule(), 1.0)));
 
   auto states = test_db.GetTopK("k4", 3);
   ASSERT_EQ(states.size(), 2);

--- a/cinn/auto_schedule/database/database_test.cc
+++ b/cinn/auto_schedule/database/database_test.cc
@@ -28,13 +28,14 @@ namespace auto_schedule {
 class TestDatabase : public ::testing::Test {
  public:
   TestDatabase() : test_db(2) {
-    test_db.AddRecord(TuningRecord("k1", 1.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
-    test_db.AddRecord(TuningRecord("k2", 2.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
-    test_db.AddRecord(TuningRecord("k2", 3.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
-    test_db.AddRecord(TuningRecord("k3", 3.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
-    test_db.AddRecord(TuningRecord("k3", 4.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
-    test_db.AddRecord(TuningRecord("k3", 5.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
-    test_db.AddRecord(TuningRecord("k4", 4.0, 0.0, ir::IRSchedule(ir::ModuleExpr())));
+    auto state = _SearchState_::Make(ir::IRSchedule());
+    test_db.AddRecord(TuningRecord("k1", 1.0, state));
+    test_db.AddRecord(TuningRecord("k2", 2.0, state));
+    test_db.AddRecord(TuningRecord("k2", 3.0, state));
+    test_db.AddRecord(TuningRecord("k3", 3.0, state));
+    test_db.AddRecord(TuningRecord("k3", 4.0, state));
+    test_db.AddRecord(TuningRecord("k3", 5.0, state));
+    test_db.AddRecord(TuningRecord("k4", 4.0, state));
   }
 
   void SetUp() override {}
@@ -56,13 +57,13 @@ TEST_F(TestDatabase, GetTopK) {
   ASSERT_TRUE(test_db.GetTopK("k5", 2).empty());
   ASSERT_EQ(test_db.GetTopK("k4", 3).size(), 1);
 
-  test_db.AddRecord(TuningRecord("k4", 2.0, 1.2, ir::IRSchedule(ir::ModuleExpr())));
-  test_db.AddRecord(TuningRecord("k4", 3.0, 1.0, ir::IRSchedule(ir::ModuleExpr())));
+  test_db.AddRecord(TuningRecord("k4", 2.0, _SearchState_::Make(ir::IRSchedule(), 1.2)));
+  test_db.AddRecord(TuningRecord("k4", 3.0, _SearchState_::Make(ir::IRSchedule(), 1.0)));
 
   auto states = test_db.GetTopK("k4", 3);
   ASSERT_EQ(states.size(), 2);
-  EXPECT_FLOAT_EQ(states[0].predicted_cost, 1.2);
-  EXPECT_FLOAT_EQ(states[1].predicted_cost, 1.0);
+  EXPECT_FLOAT_EQ(states[0]->predicted_cost, 1.2);
+  EXPECT_FLOAT_EQ(states[1]->predicted_cost, 1.0);
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/database/jsonfile_database.cc
+++ b/cinn/auto_schedule/database/jsonfile_database.cc
@@ -72,8 +72,9 @@ JSONFileDatabase::JSONFileDatabase(int capacity_per_task, const std::string& rec
     if (task_registry->Has(task_key)) {
       ir::IRSchedule ir_sch(optim::IRCopy(task_registry->Get(task_key)->module_expr));
       ir::ScheduleDesc::ReplayWithProto(record_proto.trace(), &ir_sch);
-      Insert(
-          TuningRecord(record_proto.task_key(), record_proto.execution_cost(), _SearchState_::Make(std::move(ir_sch))));
+      Insert(TuningRecord(record_proto.task_key(),
+                          record_proto.execution_cost(),
+                          SearchState(std::move(ir_sch), record_proto.predicted_cost())));
     }
   }
 }

--- a/cinn/auto_schedule/database/jsonfile_database.cc
+++ b/cinn/auto_schedule/database/jsonfile_database.cc
@@ -72,13 +72,8 @@ JSONFileDatabase::JSONFileDatabase(int capacity_per_task, const std::string& rec
     if (task_registry->Has(task_key)) {
       ir::IRSchedule ir_sch(optim::IRCopy(task_registry->Get(task_key)->module_expr));
       ir::ScheduleDesc::ReplayWithProto(record_proto.trace(), &ir_sch);
-
-      auto& records = this->key2record_[task_key];
-      records.emplace(
-          record_proto.task_key(), record_proto.execution_cost(), record_proto.predicted_cost(), std::move(ir_sch));
-      if (records.size() > this->capacity_per_task_) {
-        records.erase(std::prev(records.end()));
-      }
+      Insert(
+          TuningRecord(record_proto.task_key(), record_proto.execution_cost(), _SearchState_::Make(std::move(ir_sch))));
     }
   }
 }

--- a/cinn/auto_schedule/database/jsonfile_database_test.cc
+++ b/cinn/auto_schedule/database/jsonfile_database_test.cc
@@ -88,7 +88,7 @@ TEST_F(TestJSONFileDatabase, Serialize) {
   auto fused            = ir_sch.Fuse("B", {0, 1});
   VLOG(3) << "after Fuse, Expr: " << fused;
 
-  TuningRecord record1("test", 1.0, _SearchState_::Make(std::move(ir_sch), 2.0));
+  TuningRecord record1("test", 1.0, SearchState(std::move(ir_sch), 2.0));
   std::string str = test_db.RecordToJSON(record1);
   VLOG(3) << "RecordToJSON: " << str;
   // Because the serialization of protobuf does not guarantee the order, we give all possible results.
@@ -108,8 +108,8 @@ TEST_F(TestJSONFileDatabase, SaveLoad) {
   auto fused1            = ir_sch1.Fuse("B", {0, 1});
   ir::IRSchedule ir_sch2 = MakeIRSchedule(lowered_funcs, "k2");
 
-  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(std::move(ir_sch1), 1.5)));
-  test_db.AddRecord(TuningRecord("k1", 3.0, _SearchState_::Make(std::move(ir_sch2), 3.5)));
+  test_db.AddRecord(TuningRecord("k1", 1.0, SearchState(std::move(ir_sch1), 1.5)));
+  test_db.AddRecord(TuningRecord("k2", 3.0, SearchState(std::move(ir_sch2), 3.5)));
 
   std::vector<std::string> strs = ReadLinesFromFile(record_file_path);
   ASSERT_EQ(strs.size(), 2);
@@ -127,13 +127,13 @@ TEST_F(TestJSONFileDatabase, SaveLoad) {
 }
 
 TEST_F(TestJSONFileDatabase, Basic) {
-  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k1"), 1.0)));
-  test_db.AddRecord(TuningRecord("k2", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
-  test_db.AddRecord(TuningRecord("k2", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
-  test_db.AddRecord(TuningRecord("k3", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 8.0)));
-  test_db.AddRecord(TuningRecord("k3", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 7.0)));
-  test_db.AddRecord(TuningRecord("k3", 5.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 6.0)));
-  test_db.AddRecord(TuningRecord("k4", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 1.0)));
+  test_db.AddRecord(TuningRecord("k1", 1.0, SearchState(MakeIRSchedule(lowered_funcs, "k1"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 2.0, SearchState(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 3.0, SearchState(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 3.0, SearchState(MakeIRSchedule(lowered_funcs, "k3"), 8.0)));
+  test_db.AddRecord(TuningRecord("k3", 4.0, SearchState(MakeIRSchedule(lowered_funcs, "k3"), 7.0)));
+  test_db.AddRecord(TuningRecord("k3", 5.0, SearchState(MakeIRSchedule(lowered_funcs, "k3"), 6.0)));
+  test_db.AddRecord(TuningRecord("k4", 4.0, SearchState(MakeIRSchedule(lowered_funcs, "k4"), 1.0)));
 
   ASSERT_EQ(test_db.Size(), 6);
   auto records = test_db.LookUp("k3");
@@ -146,15 +146,15 @@ TEST_F(TestJSONFileDatabase, Basic) {
 }
 
 TEST_F(TestJSONFileDatabase, GetTopK) {
-  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k1"), 1.0)));
-  test_db.AddRecord(TuningRecord("k2", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
-  test_db.AddRecord(TuningRecord("k2", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
-  test_db.AddRecord(TuningRecord("k3", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
-  test_db.AddRecord(TuningRecord("k3", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
-  test_db.AddRecord(TuningRecord("k3", 5.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
-  test_db.AddRecord(TuningRecord("k4", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 2.0)));
-  test_db.AddRecord(TuningRecord("k4", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 1.2)));
-  test_db.AddRecord(TuningRecord("k4", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 1.0)));
+  test_db.AddRecord(TuningRecord("k1", 1.0, SearchState(MakeIRSchedule(lowered_funcs, "k1"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 2.0, SearchState(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 3.0, SearchState(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 3.0, SearchState(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 4.0, SearchState(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 5.0, SearchState(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
+  test_db.AddRecord(TuningRecord("k4", 4.0, SearchState(MakeIRSchedule(lowered_funcs, "k4"), 2.0)));
+  test_db.AddRecord(TuningRecord("k4", 2.0, SearchState(MakeIRSchedule(lowered_funcs, "k4"), 1.2)));
+  test_db.AddRecord(TuningRecord("k4", 3.0, SearchState(MakeIRSchedule(lowered_funcs, "k4"), 1.0)));
 
   auto states = test_db.GetTopK("k4", 3);
   ASSERT_EQ(states.size(), 2);
@@ -165,8 +165,8 @@ TEST_F(TestJSONFileDatabase, GetTopK) {
 TEST_F(TestJSONFileDatabase, Reload) {
   ir::IRSchedule ir_sch = MakeIRSchedule(lowered_funcs, "k1");
   auto fused            = ir_sch.Fuse("B", {0, 1});
-  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(std::move(ir_sch), 1.0)));
-  test_db.AddRecord(TuningRecord("k2", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k1", 1.0, SearchState(std::move(ir_sch), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 2.0, SearchState(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
   auto records = test_db.LookUp("k1");
   ASSERT_EQ(records.size(), 1);
 

--- a/cinn/auto_schedule/database/jsonfile_database_test.cc
+++ b/cinn/auto_schedule/database/jsonfile_database_test.cc
@@ -1,8 +1,5 @@
-// Copyright (c) 2022 CINN Authors. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.  // // Licensed under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -91,7 +88,7 @@ TEST_F(TestJSONFileDatabase, Serialize) {
   auto fused            = ir_sch.Fuse("B", {0, 1});
   VLOG(3) << "after Fuse, Expr: " << fused;
 
-  TuningRecord record1("test", 1.0, 2.0, std::move(ir_sch));
+  TuningRecord record1("test", 1.0, _SearchState_::Make(std::move(ir_sch), 2.0));
   std::string str = test_db.RecordToJSON(record1);
   VLOG(3) << "RecordToJSON: " << str;
   // Because the serialization of protobuf does not guarantee the order, we give all possible results.
@@ -111,8 +108,8 @@ TEST_F(TestJSONFileDatabase, SaveLoad) {
   auto fused1            = ir_sch1.Fuse("B", {0, 1});
   ir::IRSchedule ir_sch2 = MakeIRSchedule(lowered_funcs, "k2");
 
-  test_db.AddRecord(TuningRecord("k1", 1.0, 1.5, std::move(ir_sch1)));
-  test_db.AddRecord(TuningRecord("k2", 3.0, 3.5, std::move(ir_sch2)));
+  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(std::move(ir_sch1), 1.5)));
+  test_db.AddRecord(TuningRecord("k1", 3.0, _SearchState_::Make(std::move(ir_sch2), 3.5)));
 
   std::vector<std::string> strs = ReadLinesFromFile(record_file_path);
   ASSERT_EQ(strs.size(), 2);
@@ -130,13 +127,13 @@ TEST_F(TestJSONFileDatabase, SaveLoad) {
 }
 
 TEST_F(TestJSONFileDatabase, Basic) {
-  test_db.AddRecord(TuningRecord("k1", 1.0, 1.0, MakeIRSchedule(lowered_funcs, "k1")));
-  test_db.AddRecord(TuningRecord("k2", 2.0, 1.0, MakeIRSchedule(lowered_funcs, "k2")));
-  test_db.AddRecord(TuningRecord("k2", 3.0, 1.0, MakeIRSchedule(lowered_funcs, "k2")));
-  test_db.AddRecord(TuningRecord("k3", 3.0, 8.0, MakeIRSchedule(lowered_funcs, "k3")));
-  test_db.AddRecord(TuningRecord("k3", 4.0, 7.0, MakeIRSchedule(lowered_funcs, "k3")));
-  test_db.AddRecord(TuningRecord("k3", 5.0, 6.0, MakeIRSchedule(lowered_funcs, "k3")));
-  test_db.AddRecord(TuningRecord("k4", 4.0, 1.0, MakeIRSchedule(lowered_funcs, "k4")));
+  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k1"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 8.0)));
+  test_db.AddRecord(TuningRecord("k3", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 7.0)));
+  test_db.AddRecord(TuningRecord("k3", 5.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 6.0)));
+  test_db.AddRecord(TuningRecord("k4", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 1.0)));
 
   ASSERT_EQ(test_db.Size(), 6);
   auto records = test_db.LookUp("k3");
@@ -149,27 +146,27 @@ TEST_F(TestJSONFileDatabase, Basic) {
 }
 
 TEST_F(TestJSONFileDatabase, GetTopK) {
-  test_db.AddRecord(TuningRecord("k1", 1.0, 1.0, MakeIRSchedule(lowered_funcs, "k1")));
-  test_db.AddRecord(TuningRecord("k2", 2.0, 1.0, MakeIRSchedule(lowered_funcs, "k2")));
-  test_db.AddRecord(TuningRecord("k2", 3.0, 1.0, MakeIRSchedule(lowered_funcs, "k2")));
-  test_db.AddRecord(TuningRecord("k3", 3.0, 1.0, MakeIRSchedule(lowered_funcs, "k3")));
-  test_db.AddRecord(TuningRecord("k3", 4.0, 1.0, MakeIRSchedule(lowered_funcs, "k3")));
-  test_db.AddRecord(TuningRecord("k3", 5.0, 1.0, MakeIRSchedule(lowered_funcs, "k3")));
-  test_db.AddRecord(TuningRecord("k4", 4.0, 2.0, MakeIRSchedule(lowered_funcs, "k4")));
-  test_db.AddRecord(TuningRecord("k4", 2.0, 1.2, MakeIRSchedule(lowered_funcs, "k4")));
-  test_db.AddRecord(TuningRecord("k4", 3.0, 1.0, MakeIRSchedule(lowered_funcs, "k4")));
+  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k1"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
+  test_db.AddRecord(TuningRecord("k3", 5.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k3"), 1.0)));
+  test_db.AddRecord(TuningRecord("k4", 4.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 2.0)));
+  test_db.AddRecord(TuningRecord("k4", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 1.2)));
+  test_db.AddRecord(TuningRecord("k4", 3.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k4"), 1.0)));
 
   auto states = test_db.GetTopK("k4", 3);
   ASSERT_EQ(states.size(), 2);
-  EXPECT_FLOAT_EQ(states[0].predicted_cost, 1.2);
-  EXPECT_FLOAT_EQ(states[1].predicted_cost, 1.0);
+  EXPECT_FLOAT_EQ(states[0]->predicted_cost, 1.2);
+  EXPECT_FLOAT_EQ(states[1]->predicted_cost, 1.0);
 }
 
 TEST_F(TestJSONFileDatabase, Reload) {
   ir::IRSchedule ir_sch = MakeIRSchedule(lowered_funcs, "k1");
   auto fused            = ir_sch.Fuse("B", {0, 1});
-  test_db.AddRecord(TuningRecord("k1", 1.0, 1.0, std::move(ir_sch)));
-  test_db.AddRecord(TuningRecord("k2", 2.0, 1.0, MakeIRSchedule(lowered_funcs, "k2")));
+  test_db.AddRecord(TuningRecord("k1", 1.0, _SearchState_::Make(std::move(ir_sch), 1.0)));
+  test_db.AddRecord(TuningRecord("k2", 2.0, _SearchState_::Make(MakeIRSchedule(lowered_funcs, "k2"), 1.0)));
   auto records = test_db.LookUp("k1");
   ASSERT_EQ(records.size(), 1);
 
@@ -179,11 +176,11 @@ TEST_F(TestJSONFileDatabase, Reload) {
   ASSERT_EQ(records.size(), loaded_records.size());
   EXPECT_EQ(records[0].task_key, loaded_records[0].task_key);
   EXPECT_EQ(records[0].execution_cost, loaded_records[0].execution_cost);
-  EXPECT_EQ(records[0].state.predicted_cost, loaded_records[0].state.predicted_cost);
+  EXPECT_EQ(records[0].state->predicted_cost, loaded_records[0].state->predicted_cost);
 
   // check the equality of trace info between original TuningRecord and the loaded TuningRecord
-  const auto& lhs_trace = records[0].state.ir_schedule.GetTraceDesc();
-  const auto& rhs_trace = loaded_records[0].state.ir_schedule.GetTraceDesc();
+  const auto& lhs_trace = records[0].state->ir_schedule.GetTraceDesc();
+  const auto& rhs_trace = loaded_records[0].state->ir_schedule.GetTraceDesc();
   std::string lhs, rhs;
   lhs_trace.ToProto().SerializeToString(&lhs);
   rhs_trace.ToProto().SerializeToString(&rhs);
@@ -191,8 +188,8 @@ TEST_F(TestJSONFileDatabase, Reload) {
 
   // check the equality of module expr between original TuningRecord
   // and the loaded TuningRecord by replaying with tracing ScheduleDesc
-  auto lhs_exprs = records[0].state.ir_schedule.GetModule().GetExprs();
-  auto rhs_exprs = loaded_records[0].state.ir_schedule.GetModule().GetExprs();
+  auto lhs_exprs = records[0].state->ir_schedule.GetModule().GetExprs();
+  auto rhs_exprs = loaded_records[0].state->ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(lhs_exprs.size(), rhs_exprs.size());
   for (auto i = 0; i < lhs_exprs.size(); ++i) {
     std::string lhs          = utils::GetStreamCnt(lhs_exprs.at(i));

--- a/cinn/auto_schedule/measure/schedule_measurer.cc
+++ b/cinn/auto_schedule/measure/schedule_measurer.cc
@@ -34,7 +34,7 @@ std::vector<MeasureResult> ScheduleMeasurer::Measure(const std::vector<MeasureIn
 
   // define how to build a candidate with the specified index
   auto build_fn = [builder = builder_, &inputs, &build_results, &results](int index) {
-    VLOG(6) << "Build candidate: " << index;
+    VLOG(6) << "Build candidate index: " << index;
     auto m_start = std::chrono::steady_clock::now();
     try {
       build_results[index] = builder->Build(inputs[index]);
@@ -47,7 +47,7 @@ std::vector<MeasureResult> ScheduleMeasurer::Measure(const std::vector<MeasureIn
 
   // define how to run a candidate with the specified index
   auto run_fn = [runner = runner_, &inputs, &build_results, &results](int index) {
-    VLOG(6) << "Run candidate: " << index;
+    VLOG(6) << "Run candidate index: " << index;
     auto m_start = std::chrono::steady_clock::now();
     try {
       // if error occured in building, then skip running

--- a/cinn/auto_schedule/measure/simple_builder.cc
+++ b/cinn/auto_schedule/measure/simple_builder.cc
@@ -27,8 +27,8 @@ BuildResult SimpleBuilder::Build(const MeasureInput& input) {
   compile_options.groups                  = input.task->task_graph;
   compile_options.lowered_funcs           = input.lowered_funcs;
   compile_options.remove_unused_variables = false;
-  VLOG(5) << "call GraphCompiler to Build with " << compile_options.groups.size() << " groups, "
-          << compile_options.lowered_funcs.size() << " lowered_funcs";
+  VLOG(5) << "call GraphCompiler to Build with Graph::Group size=" << compile_options.groups.size()
+          << ", lowered_funcs group size=" << compile_options.lowered_funcs.size();
   GraphCompiler::CompilationResult compiled_result = graph_compiler_->Build(compile_options);
 
   BuildResult build_result;

--- a/cinn/auto_schedule/measure/simple_runner.cc
+++ b/cinn/auto_schedule/measure/simple_runner.cc
@@ -117,13 +117,10 @@ std::map<std::string, cinn_pod_value_t> SimpleRunner::PrepareArgs(const MeasureI
     // allocate a new buffer for this argument and store it in
     // the temporary scope to be released at proper time.
     auto compiled_tensor = compiled_scope->GetTensor(param);
-    // auto buffer          = AllocBuffer(target, compiled_tensor->type(), compiled_tensor->shape());
+    auto buffer          = AllocBuffer(target, compiled_tensor->type(), compiled_tensor->shape());
     temp_scope->Var<Tensor>(param);
     auto temp_tensor = temp_scope->GetTensor(param);
-    temp_tensor->Resize(Shape(compiled_tensor->shape().data()));
-    temp_tensor->set_type(compiled_tensor->type());
-    temp_tensor->mutable_data(target, temp_tensor->type());
-    // temp_tensor->set_buffer(buffer);
+    temp_tensor->set_buffer(buffer);
     result.emplace(param, temp_tensor->buffer());
   };
 

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.cc
@@ -31,7 +31,7 @@ int AutoGenRule::NumberApplicable() const {
   return num_applicable_;
 }
 
-ir::IRSchedule AutoGenRule::ApplyRandomly() {
+void AutoGenRule::ApplyRandomly() {
   CHECK_GT(num_applicable_, 0) << "Call " << GetRuleName() << "::ApplyRandomly() with NumberApplicable() == 0";
   int index = rand() % num_applicable_;
   return Apply(index);

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h
@@ -49,7 +49,7 @@ class AutoGenRule {
 
   // Initailize the AutoGenRule, it must be called before further actions.
   // Returns false if the rule cannot be applied on the mod_expr, true otherwise.
-  virtual RuleApplyType Init(const ir::IRSchedule& init_schedule) = 0;
+  virtual RuleApplyType Init(ir::IRSchedule* ir_schedule) = 0;
 
   // CINN IRSchedule can contain many ScheduleBlock(s) and Loop(s), so
   // a auto gen rule may be suitable to different number of
@@ -58,24 +58,22 @@ class AutoGenRule {
   virtual int NumberApplicable() const;
 
   // Applies rule on the ir::ModuleExpr for a schedule block randomly
-  virtual ir::IRSchedule ApplyRandomly();
+  virtual void ApplyRandomly();
 
   // Applies rule on the ir::ModuleExpr for a schedule block specified by index
   // between 0 (inclusive) and NumberApplicable() (exclusive)
-  virtual ir::IRSchedule Apply(int index) = 0;
+  virtual void Apply(int index) = 0;
 
   // Returns the name of the rule, used for debug.
   virtual std::string GetRuleName() const = 0;
-
-  // Returns a pointer pointing to the rule. This class doesn't own the
-  // pointer, caller should manage the life time of the pointer.
-  virtual AutoGenRule* NewPointer() const = 0;
 
  protected:
   // number of ScheduleBlock that can apply this auto gen rule
   int num_applicable_ = -1;
   // Target, not owned.
   const common::Target* target_;
+  // IRSchedule, not owned;
+  ir::IRSchedule* ir_schedule_;
 };
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.cc
@@ -122,8 +122,8 @@ AutoInlineType AutoInline::AnalyzeInlineType(const Expr& sche_block_realize_expr
   return AutoInlineType::kCannotInline;
 }
 
-RuleApplyType AutoInline::Init(const ir::IRSchedule& init_schedule) {
-  ir_schedule_        = std::make_unique<ir::IRSchedule>(optim::IRCopy(init_schedule));
+RuleApplyType AutoInline::Init(ir::IRSchedule* ir_schedule) {
+  ir_schedule_        = ir_schedule;
   all_block_realizes_ = ir_schedule_->GetAllBlocks();
   apply_indices_and_type_.clear();
   num_applicable_ = 0;
@@ -141,7 +141,7 @@ RuleApplyType AutoInline::Init(const ir::IRSchedule& init_schedule) {
   return num_applicable_ > 0 ? RuleApplyType::kApply : RuleApplyType::kCannotApply;
 }
 
-ir::IRSchedule AutoInline::Apply(int index) {
+void AutoInline::Apply(int index) {
   CHECK(ir_schedule_ != nullptr) << "Run AutoInline::Apply without Init";
   CHECK(num_applicable_ > 0 && apply_indices_and_type_.size() == num_applicable_)
       << "AutoInline::Apply pre-condition doesn't meet";
@@ -175,12 +175,10 @@ ir::IRSchedule AutoInline::Apply(int index) {
     sche_block->write_buffers                    = {};
     AnalyzeScheduleBlockReadWriteBuffer(sche_block);
   }
-  return optim::IRCopy(*ir_schedule_);
+  return;
 }
 
 std::string AutoInline::GetRuleName() const { return "AutoInline"; }
-
-AutoGenRule* AutoInline::NewPointer() const { return new AutoInline(*target_, no_inline_output_names_); }
 
 }  // namespace auto_schedule
 }  // namespace cinn

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.h
@@ -44,20 +44,17 @@ class AutoInline : public AutoGenRule {
   AutoInline(const common::Target& target, const std::unordered_set<std::string>& no_inline_output_names);
   ~AutoInline() = default;
 
-  RuleApplyType Init(const ir::IRSchedule& init_schedule) override;
+  RuleApplyType Init(ir::IRSchedule* ir_schedule) override;
 
-  ir::IRSchedule Apply(int index) override;
+  void Apply(int index) override;
 
   std::string GetRuleName() const override;
-
-  AutoGenRule* NewPointer() const override;
 
   AutoInlineType AnalyzeInlineType(const Expr& sche_block_realize_expr) const;
 
   bool CanInlineIntoConsumer(const Expr& sche_block_realize_expr) const;
 
  private:
-  std::unique_ptr<ir::IRSchedule> ir_schedule_;
   std::vector<ir::Expr> all_block_realizes_;
   std::vector<std::pair<int, AutoInlineType>> apply_indices_and_type_;
   std::unordered_set<std::string> no_inline_output_names_;

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline_test.cc
@@ -80,11 +80,11 @@ TEST(AutoInline, SingleLoopInline) {
   VLOG(6) << mod_expr_before_inline.GetExprs()[0];
 
   AutoInline auto_inline(target, {"C"});
-  EXPECT_EQ(auto_inline.Init(ir_sch), RuleApplyType::kApply);
+  EXPECT_EQ(auto_inline.Init(&ir_sch), RuleApplyType::kApply);
   EXPECT_EQ(auto_inline.NumberApplicable(), 1);
 
-  ir::IRSchedule applied_sch  = auto_inline.ApplyRandomly();
-  std::vector<ir::Expr> exprs = applied_sch.GetModule().GetExprs();
+  auto_inline.ApplyRandomly();
+  std::vector<ir::Expr> exprs = ir_sch.GetModule().GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
 
   std::stringstream ss;
@@ -114,7 +114,7 @@ TEST(AutoInline, SingleLoopInline) {
   EXPECT_EQ(expr_str, target_str);
 
   // Cannot inline above expr again
-  EXPECT_EQ(auto_inline.Init(applied_sch), RuleApplyType::kCannotApply);
+  EXPECT_EQ(auto_inline.Init(&ir_sch), RuleApplyType::kCannotApply);
 }
 
 TEST(AutoInline, AddReluInline) {
@@ -148,11 +148,11 @@ TEST(AutoInline, AddReluInline) {
   ir::IRSchedule ir_sch(mod_expr_before_inline);
 
   AutoInline auto_inline(target, {"var_2"});
-  EXPECT_EQ(auto_inline.Init(ir_sch), RuleApplyType::kApply);
+  EXPECT_EQ(auto_inline.Init(&ir_sch), RuleApplyType::kApply);
   EXPECT_EQ(auto_inline.NumberApplicable(), 2);
 
-  ir::IRSchedule sch_after_inline      = auto_inline.Apply(1);
-  ir::ModuleExpr mod_expr_after_inline = sch_after_inline.GetModule();
+  auto_inline.Apply(1);
+  ir::ModuleExpr mod_expr_after_inline = ir_sch.GetModule();
   std::vector<ir::Expr> exprs          = mod_expr_after_inline.GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
 
@@ -164,11 +164,11 @@ TEST(AutoInline, AddReluInline) {
   VLOG(6) << expr_str;
 
   // Auto Inline again
-  EXPECT_EQ(auto_inline.Init(sch_after_inline), RuleApplyType::kApply);
+  EXPECT_EQ(auto_inline.Init(&ir_sch), RuleApplyType::kApply);
   EXPECT_EQ(auto_inline.NumberApplicable(), 1);
 
-  ir::IRSchedule final_sch      = auto_inline.Apply(0);
-  ir::ModuleExpr final_mod_expr = final_sch.GetModule();
+  auto_inline.Apply(0);
+  ir::ModuleExpr final_mod_expr = ir_sch.GetModule();
   exprs                         = final_mod_expr.GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
 
@@ -205,7 +205,7 @@ TEST(AutoInline, AddReluInline) {
   EXPECT_EQ(expr_str, target_str);
 
   // Cannot inline above expr again
-  EXPECT_EQ(auto_inline.Init(final_sch), RuleApplyType::kCannotApply);
+  EXPECT_EQ(auto_inline.Init(&ir_sch), RuleApplyType::kCannotApply);
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.cc
@@ -60,8 +60,8 @@ bool AutoUnroll::MeetCondition(const ir::ScheduleBlock* schedule_block) {
   return !find_target_exprs.empty();
 }
 
-RuleApplyType AutoUnroll::Init(const ir::IRSchedule& init_schedule) {
-  ir_schedule_        = std::make_unique<ir::IRSchedule>(optim::IRCopy(init_schedule));
+RuleApplyType AutoUnroll::Init(ir::IRSchedule* ir_schedule) {
+  ir_schedule_        = ir_schedule;
   auto block_realizes = ir_schedule_->GetAllBlocks();
 
   // A schedule block can perform `auto_unroll` rule should meet two conditions:
@@ -87,12 +87,12 @@ RuleApplyType AutoUnroll::Init(const ir::IRSchedule& init_schedule) {
   return num_applicable_ > 0 ? RuleApplyType::kApplyAndSkipThisRule : RuleApplyType::kCannotApply;
 }
 
-ir::IRSchedule AutoUnroll::Apply(int index) {
+void AutoUnroll::Apply(int index) {
   CHECK_LT(index, applicable_schedule_blocks_.size()) << "invalid apply index:" << index;
   auto applied_block = applicable_schedule_blocks_.at(index);
   int max_step       = auto_unroll_options[std::rand() % auto_unroll_options.size()];
   ir_schedule_->Annotate(applied_block, ir::attr::auto_unroll_max_step, max_step);
-  return optim::IRCopy(*ir_schedule_);
+  return;
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.h
@@ -33,19 +33,16 @@ class AutoUnroll : public AutoGenRule {
   AutoUnroll(const common::Target& target) : AutoGenRule(target) {}
   ~AutoUnroll() = default;
 
-  RuleApplyType Init(const ir::IRSchedule& init_schedule) override;
+  RuleApplyType Init(ir::IRSchedule* init_schedule) override;
 
-  ir::IRSchedule Apply(int index) override;
+  void Apply(int index) override;
 
   std::string GetRuleName() const override { return "AutoUnroll"; }
-
-  AutoGenRule* NewPointer() const override { return new AutoUnroll(*target_); }
 
  private:
   bool MeetCondition(const ir::ScheduleBlock* schedule_block);
 
  private:
-  std::unique_ptr<ir::IRSchedule> ir_schedule_;
   std::vector<Expr> applicable_schedule_blocks_;
 };
 

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll_test.cc
@@ -45,7 +45,7 @@ TEST(AutoUnroll, Init) {
   ir::IRSchedule init_schedule(ir::ModuleExpr({ast_expr}));
   AutoUnroll test_rule(target);
   // not meet specific condition
-  ASSERT_EQ(test_rule.Init(init_schedule), RuleApplyType::kCannotApply);
+  ASSERT_EQ(test_rule.Init(&init_schedule), RuleApplyType::kCannotApply);
 }
 
 TEST(AutoUnroll, UnrollableApply) {
@@ -76,12 +76,12 @@ TEST(AutoUnroll, UnrollableApply) {
   VLOG(6) << "Before auto-unroll:\n" << ast_expr;
 
   AutoUnroll test_rule(target);
-  ir::IRSchedule init_schedule(ir::ModuleExpr({ast_expr}));
-  ASSERT_EQ(test_rule.Init(init_schedule), RuleApplyType::kApplyAndSkipThisRule);
+  ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
+  ASSERT_EQ(test_rule.Init(&ir_schedule), RuleApplyType::kApplyAndSkipThisRule);
   EXPECT_EQ(test_rule.NumberApplicable(), 1);
-  ir::IRSchedule applied_schedule = test_rule.ApplyRandomly();
+  test_rule.ApplyRandomly();
 
-  Expr applied_expr            = applied_schedule.GetModule().GetExprs().front();
+  Expr applied_expr            = ir_schedule.GetModule().GetExprs().front();
   auto* applied_block_realize  = applied_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>();
   auto* applied_schedule_block = applied_block_realize->schedule_block.As<ir::ScheduleBlock>();
   ASSERT_FALSE(applied_schedule_block->attrs.empty());
@@ -90,8 +90,7 @@ TEST(AutoUnroll, UnrollableApply) {
   const int* max_step    = absl::get_if<int>(&attr_value);
   EXPECT_NE(max_step, nullptr);
   EXPECT_LE(*max_step, 128);
-  VLOG(6) << "After auto-unroll:max_step=" << *max_step << ", Ast:\n"
-          << applied_schedule.GetModule().GetExprs().front();
+  VLOG(6) << "After auto-unroll:max_step=" << *max_step << ", Ast:\n" << ir_schedule.GetModule().GetExprs().front();
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.cc
@@ -99,8 +99,8 @@ bool MultiLevelTiling::MeetCondition(const ir::ScheduleBlockRealize& sche_block_
   return total_unused_iter_vars >= 1;
 }
 
-RuleApplyType MultiLevelTiling::Init(const ir::IRSchedule& init_schedule) {
-  ir_schedule_        = std::make_unique<ir::IRSchedule>(optim::IRCopy(init_schedule));
+RuleApplyType MultiLevelTiling::Init(ir::IRSchedule* ir_schedule) {
+  ir_schedule_        = ir_schedule;
   all_block_realizes_ = ir_schedule_->GetAllBlocks();
   applicable_indices_.clear();
   num_applicable_ = 0;
@@ -116,7 +116,7 @@ RuleApplyType MultiLevelTiling::Init(const ir::IRSchedule& init_schedule) {
   return num_applicable_ > 0 ? RuleApplyType::kApplyAndSkipThisRule : RuleApplyType::kCannotApply;
 }
 
-ir::IRSchedule MultiLevelTiling::Apply(int index) {
+void MultiLevelTiling::Apply(int index) {
   CHECK(ir_schedule_ != nullptr) << "Run MultiLevelTiling::Apply without Init";
   CHECK(num_applicable_ > 0 && applicable_indices_.size() == num_applicable_)
       << "MultiLevelTiling::Apply pre-condition doesn't meet";
@@ -175,12 +175,10 @@ ir::IRSchedule MultiLevelTiling::Apply(int index) {
   }
 
   VLOG(4) << "Returning the result of MultiLevelTiling";
-  return optim::IRCopy(*ir_schedule_);
+  return;
 }
 
 std::string MultiLevelTiling::GetRuleName() const { return "MultiLevelTiling"; }
-
-AutoGenRule* MultiLevelTiling::NewPointer() const { return new MultiLevelTiling(*target_); }
 
 }  // namespace auto_schedule
 }  // namespace cinn

--- a/cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h
@@ -38,18 +38,14 @@ class MultiLevelTiling : public AutoGenRule {
 
   // initailize the AutoGenRule, it must be called before further actions.
   // Returns false if the rule cannot be applied on the mod_expr, true otherwise
-  RuleApplyType Init(const ir::IRSchedule& init_schedule) override;
+  RuleApplyType Init(ir::IRSchedule* init_schedule) override;
 
   // Applies rule on the ir::ModuleExpr for a schedule block specified by index
   // between 0 (inclusive) and NumberApplicable() (exclusive)
-  ir::IRSchedule Apply(int index) override;
+  void Apply(int index) override;
 
   // Returns the name of the rule, used for debug.
   std::string GetRuleName() const override;
-
-  // Returns a pointer pointing to this rule. This class doesn't own the
-  // pointer, caller should manage the life time of the pointer.
-  AutoGenRule* NewPointer() const override;
 
   // Returns true if sche_block_realize is applicable by MultiLevelTiling
   bool MeetCondition(const ir::ScheduleBlockRealize& sche_block_realize) const;
@@ -95,7 +91,6 @@ class MultiLevelTiling : public AutoGenRule {
   }
 
  private:
-  std::unique_ptr<ir::IRSchedule> ir_schedule_;
   std::vector<ir::Expr> all_block_realizes_;
   std::vector<int> applicable_indices_;
 

--- a/cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling_test.cc
@@ -106,12 +106,12 @@ TEST(MultiLevelTile, SimpleLoops) {
   VLOG(6) << ast_expr;
 
   MultiLevelTiling multi_level_tiling(target);
-  ir::IRSchedule init_schedule(ir::ModuleExpr({ast_expr}));
-  EXPECT_EQ(multi_level_tiling.Init(init_schedule), RuleApplyType::kApplyAndSkipThisRule);
+  ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
+  EXPECT_EQ(multi_level_tiling.Init(&ir_schedule), RuleApplyType::kApplyAndSkipThisRule);
 
   EXPECT_EQ(multi_level_tiling.NumberApplicable(), 1);
-  ir::IRSchedule applied_schedule = multi_level_tiling.ApplyRandomly();
-  std::vector<ir::Expr> exprs     = applied_schedule.GetModule().GetExprs();
+  multi_level_tiling.ApplyRandomly();
+  std::vector<ir::Expr> exprs = ir_schedule.GetModule().GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
 
   std::stringstream ss;
@@ -150,13 +150,13 @@ TEST(MulitLevelTile, MatrixMultiply) {
   VLOG(6) << ast_expr;
 
   MultiLevelTiling multi_level_tiling(target);
-  ir::IRSchedule init_schedule(ir::ModuleExpr({ast_expr}));
-  EXPECT_EQ(multi_level_tiling.Init(init_schedule), RuleApplyType::kApplyAndSkipThisRule);
+  ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
+  EXPECT_EQ(multi_level_tiling.Init(&ir_schedule), RuleApplyType::kApplyAndSkipThisRule);
 
   EXPECT_EQ(multi_level_tiling.NumberApplicable(), 1);
 
-  ir::IRSchedule appied_schedule = multi_level_tiling.ApplyRandomly();
-  std::vector<ir::Expr> exprs    = appied_schedule.GetModule().GetExprs();
+  multi_level_tiling.ApplyRandomly();
+  std::vector<ir::Expr> exprs = ir_schedule.GetModule().GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
 
   std::stringstream ss;

--- a/cinn/auto_schedule/search_space/auto_gen_rule/skip_rule.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/skip_rule.cc
@@ -26,17 +26,13 @@ namespace auto_schedule {
 
 SkipRule::SkipRule(const common::Target& target) : AutoGenRule(target) {}
 
-RuleApplyType SkipRule::Init(const ir::IRSchedule& init_schedule) {
-  ir_schedule_    = std::make_unique<ir::IRSchedule>(optim::IRCopy(init_schedule));
+RuleApplyType SkipRule::Init(ir::IRSchedule* ir_schedule) {
+  ir_schedule_    = ir_schedule;
   num_applicable_ = 1;
   return RuleApplyType::kApply;
 }
 
-ir::IRSchedule SkipRule::Apply(int index) { return optim::IRCopy(*ir_schedule_); }
-
 std::string SkipRule::GetRuleName() const { return "SikpRule"; }
-
-AutoGenRule* SkipRule::NewPointer() const { return new SkipRule(*target_); }
 
 }  // namespace auto_schedule
 }  // namespace cinn

--- a/cinn/auto_schedule/search_space/auto_gen_rule/skip_rule.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/skip_rule.h
@@ -28,16 +28,11 @@ class SkipRule : public AutoGenRule {
   SkipRule(const common::Target& target);
   ~SkipRule() = default;
 
-  RuleApplyType Init(const ir::IRSchedule& init_schedule) override;
+  RuleApplyType Init(ir::IRSchedule* init_schedule) override;
 
-  ir::IRSchedule Apply(int index) override;
+  void Apply(int index) override {}
 
   std::string GetRuleName() const override;
-
-  AutoGenRule* NewPointer() const override;
-
- private:
-  std::unique_ptr<ir::IRSchedule> ir_schedule_;
 };
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/auto_gen_rule/skip_rule_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/skip_rule_test.cc
@@ -60,12 +60,12 @@ TEST(SkipRule, Basic) {
   VLOG(6) << ast_expr;
 
   SkipRule skip_rule(target);
-  ir::IRSchedule init_schedule(ir::ModuleExpr({ast_expr}));
-  EXPECT_EQ(skip_rule.Init(init_schedule), RuleApplyType::kApply);
+  ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
+  EXPECT_EQ(skip_rule.Init(&ir_schedule), RuleApplyType::kApply);
 
   EXPECT_EQ(skip_rule.NumberApplicable(), 1);
-  ir::IRSchedule applied_schedule = skip_rule.ApplyRandomly();
-  std::vector<ir::Expr> exprs     = applied_schedule.GetModule().GetExprs();
+  skip_rule.ApplyRandomly();
+  std::vector<ir::Expr> exprs = ir_schedule.GetModule().GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
 
   EXPECT_EQ(ast_expr, exprs[0]);

--- a/cinn/auto_schedule/search_space/search_space.cc
+++ b/cinn/auto_schedule/search_space/search_space.cc
@@ -57,7 +57,7 @@ std::vector<SearchState> SearchSpace::GetRandomInitialSketch(int num) {
 
   std::vector<SearchState> result;
   while (result.size() < num) {
-    SearchState state = _SearchState_::Make(init_rules, init_schedule);
+    SearchState state = _SearchState_::Make(init_schedule, _SearchState_::NOT_INIT_COST, init_rules);
     for (int i = 0; i < init_sketch_random_depth_; ++i) {
       VLOG(5) << "Generating random sketch at depth: " << i;
       state = RandomScheduleMutate(state);

--- a/cinn/auto_schedule/search_space/search_space.cc
+++ b/cinn/auto_schedule/search_space/search_space.cc
@@ -22,6 +22,10 @@
 
 #include "cinn/auto_schedule/cost_model/expr_cost_model.h"
 #include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/skip_rule.h"
 #include "cinn/auto_schedule/task/tune_task.h"
 #include "cinn/ir/ir_base.h"
 #include "cinn/ir/ir_schedule.h"
@@ -33,24 +37,36 @@ DECLARE_bool(auto_schedule_use_cost_model);
 namespace cinn {
 namespace auto_schedule {
 
-SearchSpace::SearchSpace(const TuneTask& tune_task) : tune_task_(tune_task) {}
+SearchSpace::SearchSpace(const TuneTask& tune_task) : tune_task_(tune_task) {
+  const auto& target = tune_task_.target;
+  // initialize a set of rules and they are commonly used by all states
+  // TODO(zhhsplendid): pass correct output names to AutoInline
+  sketch_rules_.emplace_back(new AutoInline(target, tune_task_.output_names));
+  sketch_rules_.emplace_back(new MultiLevelTiling(target));
+  sketch_rules_.emplace_back(new AutoUnroll(target));
+  sketch_rules_.emplace_back(new SkipRule(target));
+}
 
 std::vector<SearchState> SearchSpace::GetRandomInitialSketch(int num) {
   VLOG(4) << "Start SearchSpace::GetRandomInitialSketch with num:" << num;
-  SearchState init_state(ir::IRSchedule(ir::ModuleExpr(tune_task_.GetLoweredFuncBodyExprs())));
+  ir::IRSchedule init_schedule(ir::ModuleExpr(tune_task_.GetLoweredFuncBodyExprs()));
+  std::vector<AutoGenRule*> init_rules;
+  std::transform(sketch_rules_.begin(), sketch_rules_.end(), std::back_inserter(init_rules), [](const auto& rule) {
+    return rule.get();
+  });
+
   std::vector<SearchState> result;
   while (result.size() < num) {
-    SearchState state(init_state);
-    state.InitAutoGenRules(tune_task_.target, tune_task_.output_names);
+    SearchState state = _SearchState_::Make(init_rules, init_schedule);
     for (int i = 0; i < init_sketch_random_depth_; ++i) {
       VLOG(5) << "Generating random sketch at depth: " << i;
       state = RandomScheduleMutate(state);
-      if (state.applicable_rules.empty()) {
+      if (state->applicable_rules.empty()) {
         break;
       }
     }
     // TODO:(zhhsplendid): De-duplication on the result after we have Expr/ModuleExpr hash;
-    auto debug_str = state.DebugString();
+    auto debug_str = state->DebugString();
     VLOG(5) << "Generate a new state, hash:" << std::hash<std::string>()(debug_str) << ", DebugString:" << debug_str;
     result.emplace_back(std::move(state));
   }
@@ -66,7 +82,7 @@ SearchState SearchSpace::GetScheduleMutate(const SearchState& state, const ExprC
   }
   SearchState ret = RandomScheduleMutate(state);
   if (FLAGS_auto_schedule_use_cost_model) {
-    ret.predicted_cost = cost_model.Predict(ret.ir_schedule.GetModule(), tune_task_.target);
+    ret->predicted_cost = cost_model.Predict(ret->ir_schedule.GetModule(), tune_task_.target);
   }
   return ret;
 }
@@ -81,21 +97,21 @@ SearchState SearchSpace::RandomScheduleMutate(const SearchState& state) {
 
   // 1. Found the schedules which can apply on this Expr
   // 2. Make a distribution on those schedules
-  std::map<int, std::shared_ptr<AutoGenRule>> weight_to_rule;
+  std::map<int, AutoGenRule*> weight_to_rule;
   int cur_weight = 0;
   SearchState ret(state);
-  for (auto iter = ret.applicable_rules.begin(); iter != ret.applicable_rules.end();) {
-    std::shared_ptr<AutoGenRule> rule = *iter;
+  for (auto iter = ret->applicable_rules.begin(); iter != ret->applicable_rules.end();) {
+    AutoGenRule* rule = *iter;
     VLOG(6) << "Evaluate rule:" << rule->GetRuleName();
-    RuleApplyType apply_type = rule->Init(state.ir_schedule);
+    RuleApplyType apply_type = rule->Init(&ret->ir_schedule);
     if (apply_type != RuleApplyType::kCannotApply) {
       weight_to_rule[cur_weight] = rule;
       cur_weight += rule->NumberApplicable();
       if (apply_type == RuleApplyType::kApplyAndSkipThisRule) {
-        iter = ret.applicable_rules.erase(iter);
+        iter = ret->applicable_rules.erase(iter);
         continue;
       } else if (apply_type == RuleApplyType::kApplyAndSkipAllRules) {
-        ret.applicable_rules.clear();
+        ret->applicable_rules.clear();
         break;
       }
     }
@@ -116,11 +132,11 @@ SearchState SearchSpace::RandomScheduleMutate(const SearchState& state) {
     // weight_to_rule must contain key 0, and sample_index >= 0, so --iter won't exceed the beginning.
     --iter;
   }
-  std::shared_ptr<AutoGenRule> sample_rule = iter->second;
+  AutoGenRule* sample_rule = iter->second;
   VLOG(6) << "Apply rule: " << sample_rule->GetRuleName();
 
   // 4. Apply the schedule change
-  ret.ir_schedule = sample_rule->Apply(sample_index - iter->first);
+  sample_rule->Apply(sample_index - iter->first);
   return ret;
 }
 

--- a/cinn/auto_schedule/search_space/search_space.cc
+++ b/cinn/auto_schedule/search_space/search_space.cc
@@ -57,7 +57,7 @@ std::vector<SearchState> SearchSpace::GetRandomInitialSketch(int num) {
 
   std::vector<SearchState> result;
   while (result.size() < num) {
-    SearchState state = _SearchState_::Make(init_schedule, _SearchState_::NOT_INIT_COST, init_rules);
+    SearchState state(init_schedule, SearchState::NOT_INIT_COST, init_rules);
     for (int i = 0; i < init_sketch_random_depth_; ++i) {
       VLOG(5) << "Generating random sketch at depth: " << i;
       state = RandomScheduleMutate(state);

--- a/cinn/auto_schedule/search_space/search_space.h
+++ b/cinn/auto_schedule/search_space/search_space.h
@@ -20,9 +20,6 @@
 
 #include "cinn/auto_schedule/cost_model/expr_cost_model.h"
 #include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
-#include "cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.h"
-#include "cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h"
-#include "cinn/auto_schedule/search_space/auto_gen_rule/skip_rule.h"
 #include "cinn/auto_schedule/search_space/search_state.h"
 #include "cinn/auto_schedule/task/tune_task.h"
 #include "cinn/ir/ir_base.h"
@@ -57,8 +54,9 @@ class SearchSpace {
   SearchState RandomScheduleMutate(const SearchState& state);
 
   const TuneTask& tune_task_;
-
   int init_sketch_random_depth_ = 6;
+  // supported AutoGenRules, every task holds a set
+  std::vector<std::unique_ptr<AutoGenRule>> sketch_rules_;
 };
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/search_state.cc
+++ b/cinn/auto_schedule/search_space/search_state.cc
@@ -27,11 +27,11 @@
 namespace cinn {
 namespace auto_schedule {
 
-SearchState _SearchState_::Make(const std::vector<AutoGenRule*>& rules, ir::IRSchedule ir_sch) {
+SearchState _SearchState_::Make(ir::IRSchedule ir_sch, float cost, const std::vector<AutoGenRule*>& rules) {
   _SearchState_* state    = common::make_shared<_SearchState_>();
-  state->applicable_rules = rules;
-  state->predicted_cost   = _SearchState_::NOT_INIT_COST;
   state->ir_schedule      = std::move(ir_sch);
+  state->applicable_rules = rules;
+  state->predicted_cost   = cost;
   return SearchState(state);
 }
 

--- a/cinn/auto_schedule/search_space/search_state.cc
+++ b/cinn/auto_schedule/search_space/search_state.cc
@@ -27,12 +27,12 @@
 namespace cinn {
 namespace auto_schedule {
 
-SearchState _SearchState_::Make(ir::IRSchedule ir_sch, float cost, const std::vector<AutoGenRule*>& rules) {
-  _SearchState_* state    = common::make_shared<_SearchState_>();
+SearchState::SearchState(ir::IRSchedule ir_sch, float cost, const std::vector<AutoGenRule*>& rules)
+    : common::Shared<_SearchState_>(common::make_shared<_SearchState_>()) {
+  auto* state             = get();
   state->ir_schedule      = std::move(ir_sch);
   state->applicable_rules = rules;
   state->predicted_cost   = cost;
-  return SearchState(state);
 }
 
 std::string _SearchState_::DebugString() const {

--- a/cinn/auto_schedule/search_space/search_state.h
+++ b/cinn/auto_schedule/search_space/search_state.h
@@ -38,18 +38,20 @@ class SearchState : public common::Shared<_SearchState_> {
 
 //! Class to store immediate states during search
 struct _SearchState_ : public common::Object {
-  // The rules that can be applied to the IRSchedule at this state.
-  std::vector<AutoGenRule*> applicable_rules;
   // IRSchedule contains ir::ModuleExpr and trace scheduling process
   ir::IRSchedule ir_schedule;
   // Cost model predicted cost
   float predicted_cost = NOT_INIT_COST;
+  // The rules that can be applied to the IRSchedule at this state.
+  std::vector<AutoGenRule*> applicable_rules;
 
   // return detail string of a SearchState for debug;
   std::string DebugString() const;
 
   // create a new _SearchState_
-  static SearchState Make(const std::vector<AutoGenRule*>& rules, ir::IRSchedule ir_sch);
+  static SearchState Make(ir::IRSchedule ir_sch,
+                          float cost                             = NOT_INIT_COST,
+                          const std::vector<AutoGenRule*>& rules = {});
   // Constant standing for a cost not being initialized
   static constexpr float NOT_INIT_COST = std::numeric_limits<float>::max();
 

--- a/cinn/auto_schedule/search_space/search_state.h
+++ b/cinn/auto_schedule/search_space/search_state.h
@@ -16,57 +16,45 @@
 
 #include <functional>
 #include <limits>
-#include <memory>
-#include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
-#include "cinn/common/target.h"
-#include "cinn/ir/ir_base.h"
+#include "cinn/common/object.h"
+#include "cinn/common/shared.h"
 #include "cinn/ir/ir_schedule.h"
 
 namespace cinn {
 namespace auto_schedule {
 
-/**
- * Class to store immediate states during search
- */
-class SearchState {
+struct _SearchState_;
+//! Shared Wrapper for _SearchState_
+class SearchState : public common::Shared<_SearchState_> {
  public:
-  // The IRSchedule, which contains ir::ModuleExpr and trace scheduling process
+  SearchState() = default;
+  explicit SearchState(_SearchState_* s) : common::Shared<_SearchState_>(s) {}
+
+  friend bool operator<(const SearchState& left, const SearchState& right);
+};
+
+//! Class to store immediate states during search
+struct _SearchState_ : public common::Object {
+  // The rules that can be applied to the IRSchedule at this state.
+  std::vector<AutoGenRule*> applicable_rules;
+  // IRSchedule contains ir::ModuleExpr and trace scheduling process
   ir::IRSchedule ir_schedule;
-
-  // The rules that can be applied to this ModuleExpr at this state.
-  // Initialized by list of all AutoGenRule
-  std::vector<std::shared_ptr<AutoGenRule>> applicable_rules;
-
   // Cost model predicted cost
   float predicted_cost = NOT_INIT_COST;
-
-  // Constant standing for a cost not being initialized
-  static constexpr float NOT_INIT_COST = std::numeric_limits<float>::max();
 
   // return detail string of a SearchState for debug;
   std::string DebugString() const;
 
-  SearchState() = default;
+  // create a new _SearchState_
+  static SearchState Make(const std::vector<AutoGenRule*>& rules, ir::IRSchedule ir_sch);
+  // Constant standing for a cost not being initialized
+  static constexpr float NOT_INIT_COST = std::numeric_limits<float>::max();
 
-  SearchState(const ir::ModuleExpr& mod_expr);
-
-  SearchState(ir::IRSchedule&& ir_sch);
-
-  SearchState(const SearchState& state);
-
-  SearchState(SearchState&& state) = default;
-
-  SearchState& operator=(const SearchState& src);
-
-  friend bool operator<(const SearchState& left, const SearchState& right);
-
-  // Not all ModuleExpr has to be mutated AutoGenRule. For those states which
-  // have ModuleExpr to random mutated by AutoGenRule, initialize it.
-  void InitAutoGenRules(const common::Target& target, const std::unordered_set<std::string>& output_names);
+  const char* type_info() const override { return __type_info__; }
+  static constexpr char* __type_info__ = "auto_schedule_state";
 };
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/search_state.h
+++ b/cinn/auto_schedule/search_space/search_state.h
@@ -31,8 +31,12 @@ struct _SearchState_;
 class SearchState : public common::Shared<_SearchState_> {
  public:
   SearchState() = default;
-  explicit SearchState(_SearchState_* s) : common::Shared<_SearchState_>(s) {}
+  // create a new SearchState
+  SearchState(ir::IRSchedule ir_sch, float cost = NOT_INIT_COST, const std::vector<AutoGenRule*>& rules = {});
 
+  // Constant standing for a cost not being initialized
+  static constexpr float NOT_INIT_COST = std::numeric_limits<float>::max();
+  // compare function for two states
   friend bool operator<(const SearchState& left, const SearchState& right);
 };
 
@@ -41,19 +45,12 @@ struct _SearchState_ : public common::Object {
   // IRSchedule contains ir::ModuleExpr and trace scheduling process
   ir::IRSchedule ir_schedule;
   // Cost model predicted cost
-  float predicted_cost = NOT_INIT_COST;
+  float predicted_cost;
   // The rules that can be applied to the IRSchedule at this state.
   std::vector<AutoGenRule*> applicable_rules;
 
-  // return detail string of a SearchState for debug;
+  // return detail string of content for debug;
   std::string DebugString() const;
-
-  // create a new _SearchState_
-  static SearchState Make(ir::IRSchedule ir_sch,
-                          float cost                             = NOT_INIT_COST,
-                          const std::vector<AutoGenRule*>& rules = {});
-  // Constant standing for a cost not being initialized
-  static constexpr float NOT_INIT_COST = std::numeric_limits<float>::max();
 
   const char* type_info() const override { return __type_info__; }
   static constexpr char* __type_info__ = "auto_schedule_state";

--- a/cinn/auto_schedule/search_space/search_state.h
+++ b/cinn/auto_schedule/search_space/search_state.h
@@ -32,7 +32,7 @@ class SearchState : public common::Shared<_SearchState_> {
  public:
   SearchState() = default;
   // create a new SearchState
-  SearchState(ir::IRSchedule ir_sch, float cost = NOT_INIT_COST, const std::vector<AutoGenRule*>& rules = {});
+  explicit SearchState(ir::IRSchedule ir_sch, float cost = NOT_INIT_COST, const std::vector<AutoGenRule*>& rules = {});
 
   // Constant standing for a cost not being initialized
   static constexpr float NOT_INIT_COST = std::numeric_limits<float>::max();

--- a/cinn/auto_schedule/search_strategy/evolutionary_search.cc
+++ b/cinn/auto_schedule/search_strategy/evolutionary_search.cc
@@ -48,7 +48,7 @@ void PrintStates(const int vlog_level, const std::string& phase_name, const std:
   }
   VLOG(vlog_level) << "EvolutionarySearch-" << phase_name << " states size:" << states.size();
   for (auto i = 0; i < states.size(); ++i) {
-    auto debug_str = states[i].DebugString();
+    auto debug_str = states[i]->DebugString();
     VLOG(vlog_level) << "State-" << i << " hash:" << std::hash<std::string>()(debug_str);
     VLOG(vlog_level + 1) << "****** State-" << i << " Detail ******\n" << debug_str;
     VLOG(vlog_level + 1) << "****** SearchState End ******";
@@ -101,8 +101,8 @@ SearchState EvolutionarySearch::CrossOver(const SearchState& state1, const Searc
   PrintStates(5, "CrossOver", {state1, state2});
   // TODO(CtfGo): tracing CrossOver with IRSchedule
   std::vector<ir::Expr> cross_over_exprs;
-  std::vector<ir::Expr> father_exprs = state1.ir_schedule.GetModule().GetExprs();
-  std::vector<ir::Expr> mother_exprs = state2.ir_schedule.GetModule().GetExprs();
+  std::vector<ir::Expr> father_exprs = state1->ir_schedule.GetModule().GetExprs();
+  std::vector<ir::Expr> mother_exprs = state2->ir_schedule.GetModule().GetExprs();
 
   CHECK_EQ(father_exprs.size(), mother_exprs.size())
       << "CrossOver ModuleExpr in EvolutionarySearch must have same number of AST";
@@ -114,7 +114,7 @@ SearchState EvolutionarySearch::CrossOver(const SearchState& state1, const Searc
       cross_over_exprs.push_back(optim::IRCopy(mother_exprs[i]));
     }
   }
-  return SearchState(ir::ModuleExpr(cross_over_exprs));
+  return SearchState(ir::IRSchedule(ir::ModuleExpr(cross_over_exprs)));
 }
 
 std::vector<SearchState> EvolutionarySearch::Evolve(const std::vector<SearchState>& population,

--- a/cinn/auto_schedule/search_strategy/evolutionary_search_test.cc
+++ b/cinn/auto_schedule/search_strategy/evolutionary_search_test.cc
@@ -54,19 +54,19 @@ class MockSearchSpace : public SearchSpace {
         exprs.push_back(ir::Expr(-i));
       }
       min_expr_value_ = -i;
-      ret.push_back(SearchState(ir::ModuleExpr(exprs)));
+      ret.push_back(SearchState(ir::IRSchedule(ir::ModuleExpr(exprs))));
     }
     return ret;
   }
 
   SearchState GetScheduleMutate(const SearchState& state, const ExprCostModel& cost_model) override {
     float cost                  = 0.0f;
-    std::vector<ir::Expr> exprs = state.ir_schedule.GetModule().GetExprs();
+    std::vector<ir::Expr> exprs = state->ir_schedule.GetModule().GetExprs();
     for (const ir::Expr& expr : exprs) {
       cost += static_cast<float>((expr.as_int32()));
     }
-    SearchState ret(std::move(ir::ModuleExpr(exprs)));
-    ret.predicted_cost = cost;
+    SearchState ret(state->ir_schedule);
+    ret->predicted_cost = cost;
     return ret;
   }
 
@@ -86,7 +86,7 @@ TEST(EvolutionarySearch, GetOneBest) {
   // Ownership is transferred so don't delete mock_search_space
   evolutionary_search.SetSearchSpace(mock_search_space);
   SearchState best_state      = evolutionary_search.SearchModuleExpr(options);
-  std::vector<ir::Expr> exprs = best_state.ir_schedule.GetModule().GetExprs();
+  std::vector<ir::Expr> exprs = best_state->ir_schedule.GetModule().GetExprs();
   EXPECT_GE(exprs.size(), 1UL);
   for (const ir::Expr& e : exprs) {
     EXPECT_EQ(e.as_int32(), mock_search_space->GetMinExprValue());
@@ -108,7 +108,7 @@ TEST(EvolutionarySearch, GetEpsGreedy) {
   EXPECT_GE(search_states.size(), 1UL);
   size_t expr_size = static_cast<size_t>(mock_search_space->GetModuleExprSize());
   for (const SearchState& state : search_states) {
-    EXPECT_EQ(state.ir_schedule.GetModule().GetExprs().size(), expr_size);
+    EXPECT_EQ(state->ir_schedule.GetModule().GetExprs().size(), expr_size);
   }
 }
 

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -42,11 +42,6 @@ using ::cinn::hlir::framework::GraphCompiler;
 using ::cinn::hlir::framework::Instruction;
 using ::cinn::hlir::framework::Scope;
 
-class ProgramBuilder {
-  ProgramBuilder();
-  virtual frontend::Program operator()() = 0;
-};
-
 class PerformanceTester {
  public:
   virtual frontend::Program CreateProgram() = 0;
@@ -88,7 +83,7 @@ class PerformanceTester {
       VLOG(3) << "Start initialize graph.";
       auto program = CreateProgram();
       graph_       = std::make_shared<hlir::framework::Graph>(program, target_);
-      // hlir::framework::ApplyPass(graph_.get(), "InferShape");
+      hlir::framework::ApplyPass(graph_.get(), "InferShape");
       is_graph_initialized_ = true;
       VLOG(3) << "Initialize graph completed.";
     }
@@ -164,7 +159,7 @@ class PerformanceTester {
     manual_schedule_program_ = graph_compiler_->Build();
 
     VLOG(3) << "===========================Manual Schedule LoweredFunc Begin===========================";
-    // graph_compiler_->PrintFunc();
+    graph_compiler_->PrintFunc();
     VLOG(3) << "===========================Manual Schedule LoweredFunc End=============================";
   }
 
@@ -328,7 +323,7 @@ TEST(MatmulPerformanceTest, matmul_32x16x32) {
   int K                  = 16;
   int N                  = 32;
   MatmulPerformanceTester tester(M, K, N);
-  // tester.SetOptionFlags(5UL);
+  tester.SetOptionFlags(5UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 
@@ -338,7 +333,7 @@ TEST(MulPerformanceTest, mul_32x16x32) {
   int K                  = 16;
   int N                  = 32;
   MulPerformanceTester tester(M, K, N);
-  // tester.SetOptionFlags(5UL);
+  tester.SetOptionFlags(5UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 
@@ -347,7 +342,7 @@ TEST(AddPerformanceTest, add_32x16) {
   int M                  = 32;
   int N                  = 16;
   AddPerformanceTester tester(M, N);
-  // tester.SetOptionFlags(5UL);
+  tester.SetOptionFlags(5UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 
@@ -359,7 +354,7 @@ TEST(PaddleModelPerformanceTester, ResNet50) {
   CHECK_NE(FLAGS_resnet50_model_dir, "");
   // ResNet50 can only run manual schedule test now.
   PaddleModelPerformanceTester tester(FLAGS_resnet50_model_dir, input_names, input_shapes);
-  tester.SetOptionFlags(4UL);
+  tester.SetOptionFlags(0UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -42,6 +42,11 @@ using ::cinn::hlir::framework::GraphCompiler;
 using ::cinn::hlir::framework::Instruction;
 using ::cinn::hlir::framework::Scope;
 
+class ProgramBuilder {
+  ProgramBuilder();
+  virtual frontend::Program operator()() = 0;
+};
+
 class PerformanceTester {
  public:
   virtual frontend::Program CreateProgram() = 0;
@@ -83,7 +88,7 @@ class PerformanceTester {
       VLOG(3) << "Start initialize graph.";
       auto program = CreateProgram();
       graph_       = std::make_shared<hlir::framework::Graph>(program, target_);
-      hlir::framework::ApplyPass(graph_.get(), "InferShape");
+      // hlir::framework::ApplyPass(graph_.get(), "InferShape");
       is_graph_initialized_ = true;
       VLOG(3) << "Initialize graph completed.";
     }
@@ -159,7 +164,7 @@ class PerformanceTester {
     manual_schedule_program_ = graph_compiler_->Build();
 
     VLOG(3) << "===========================Manual Schedule LoweredFunc Begin===========================";
-    graph_compiler_->PrintFunc();
+    // graph_compiler_->PrintFunc();
     VLOG(3) << "===========================Manual Schedule LoweredFunc End=============================";
   }
 
@@ -323,7 +328,7 @@ TEST(MatmulPerformanceTest, matmul_32x16x32) {
   int K                  = 16;
   int N                  = 32;
   MatmulPerformanceTester tester(M, K, N);
-  tester.SetOptionFlags(5UL);
+  // tester.SetOptionFlags(5UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 
@@ -333,7 +338,7 @@ TEST(MulPerformanceTest, mul_32x16x32) {
   int K                  = 16;
   int N                  = 32;
   MulPerformanceTester tester(M, K, N);
-  tester.SetOptionFlags(5UL);
+  // tester.SetOptionFlags(5UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 
@@ -342,7 +347,7 @@ TEST(AddPerformanceTest, add_32x16) {
   int M                  = 32;
   int N                  = 16;
   AddPerformanceTester tester(M, N);
-  tester.SetOptionFlags(5UL);
+  // tester.SetOptionFlags(5UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 
@@ -354,7 +359,7 @@ TEST(PaddleModelPerformanceTester, ResNet50) {
   CHECK_NE(FLAGS_resnet50_model_dir, "");
   // ResNet50 can only run manual schedule test now.
   PaddleModelPerformanceTester tester(FLAGS_resnet50_model_dir, input_names, input_shapes);
-  tester.SetOptionFlags(0UL);
+  tester.SetOptionFlags(4UL);
   tester.BuildAndRun(repeat_time, num_tuning_rounds);
 }
 

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -1198,7 +1198,7 @@ void GraphCompiler::RemoveInvalidVariables(const std::vector<std::unique_ptr<Ins
     std::for_each(in_args.begin(), in_args.end(), exclude_arguments_fn);
     std::for_each(out_args.begin(), out_args.end(), exclude_arguments_fn);
 
-    VLOG(3) << "Instruction-" << i << " eliminate " << unused_var_num - invalid_variables.size() << " used variables";
+    VLOG(3) << "Instruction-" << i << " filter " << unused_var_num - invalid_variables.size() << " used variables";
     unused_var_num = invalid_variables.size();
   }
 

--- a/cinn/ir/ir_schedule.cc
+++ b/cinn/ir/ir_schedule.cc
@@ -1445,9 +1445,19 @@ void ScheduleImpl::CopyTransformAndLoopInfo(const Expr& block, const Expr& block
 
 IRSchedule::IRSchedule() {}
 
-IRSchedule::IRSchedule(IRSchedule&& other) : impl_(std::move(other.impl_)), trace_(std::move(other.trace_)) {}
 IRSchedule::IRSchedule(ir::ModuleExpr&& mod_expr, ScheduleDesc&& trace)
     : impl_(std::make_unique<ScheduleImpl>(std::move(mod_expr))), trace_(std::move(trace)) {}
+
+IRSchedule::IRSchedule(const IRSchedule& other)
+    : impl_(std::make_unique<ScheduleImpl>(optim::IRCopy(other.GetModule()))), trace_(other.trace_) {}
+
+IRSchedule& IRSchedule::operator=(const IRSchedule& src) {
+  impl_  = std::make_unique<ScheduleImpl>(optim::IRCopy(src.GetModule()));
+  trace_ = src.trace_;
+  return *this;
+}
+
+IRSchedule::IRSchedule(IRSchedule&& other) : impl_(std::move(other.impl_)), trace_(std::move(other.trace_)) {}
 
 IRSchedule& IRSchedule::operator=(IRSchedule&& src) {
   impl_  = std::move(src.impl_);

--- a/cinn/ir/ir_schedule.cc
+++ b/cinn/ir/ir_schedule.cc
@@ -1445,6 +1445,10 @@ void ScheduleImpl::CopyTransformAndLoopInfo(const Expr& block, const Expr& block
 
 IRSchedule::IRSchedule() {}
 
+IRSchedule::IRSchedule(const ModuleExpr& module_expr, bool debug_flag) {
+  impl_ = std::make_unique<ScheduleImpl>(module_expr, debug_flag);
+}
+
 IRSchedule::IRSchedule(ir::ModuleExpr&& mod_expr, ScheduleDesc&& trace)
     : impl_(std::make_unique<ScheduleImpl>(std::move(mod_expr))), trace_(std::move(trace)) {}
 
@@ -1466,10 +1470,6 @@ IRSchedule& IRSchedule::operator=(IRSchedule&& src) {
 }
 
 IRSchedule::~IRSchedule() {}
-
-IRSchedule::IRSchedule(const ModuleExpr& module_expr, bool debug_flag) {
-  impl_ = std::make_unique<ScheduleImpl>(module_expr, debug_flag);
-}
 
 void IRSchedule::SetExprs(const std::vector<Expr>& exprs) {
   return impl_->SetExprs(exprs);

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -77,7 +77,7 @@ class IRSchedule {
   //! Get the ModuleExpr stored in ScheduleImpl.
   const ModuleExpr& GetModule() const;
 
-  //! Merge multiple Exprs in a ModuleExepr to be one
+  //! Merge multiple Exprs in a ModuleExpr to be one
   void MergeExprs();
 
   //! Get the ScheduleDesc that traces the scheduling process

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -66,6 +66,8 @@ class IRSchedule {
   IRSchedule();
   explicit IRSchedule(const ModuleExpr& modexpr, bool debug_flag = false);
   IRSchedule(ir::ModuleExpr&& mod_expr, ScheduleDesc&& trace);
+  IRSchedule(const IRSchedule& other);
+  IRSchedule& operator=(const IRSchedule& src);
   IRSchedule(IRSchedule&& other);
   IRSchedule& operator=(IRSchedule&& src);
   ~IRSchedule();

--- a/cinn/optim/ir_copy.cc
+++ b/cinn/optim/ir_copy.cc
@@ -472,10 +472,6 @@ std::vector<Expr> IRCopy(const std::vector<Expr>& x) {
 
 ir::ModuleExpr IRCopy(const ir::ModuleExpr& x) { return ir::ModuleExpr(IRCopy(x.GetExprs())); }
 
-ir::IRSchedule IRCopy(const ir::IRSchedule& x) {
-  return ir::IRSchedule(IRCopy(x.GetModule()), ir::ScheduleDesc(x.GetTraceDesc()));
-}
-
 ir::LoweredFunc IRCopy(const ir::LoweredFunc& x) {
   ir::Expr copy_func_expr          = IRCopy(static_cast<ir::Expr>(x));
   ir::_LoweredFunc_* copy_func_ptr = copy_func_expr.As<ir::_LoweredFunc_>();

--- a/cinn/optim/ir_copy.h
+++ b/cinn/optim/ir_copy.h
@@ -24,7 +24,6 @@ namespace cinn {
 
 namespace ir {
 class ModuleExpr;
-class IRSchedule;
 }  // namespace ir
 
 namespace optim {
@@ -35,8 +34,6 @@ Expr IRCopy(Expr x);
 std::vector<Expr> IRCopy(const std::vector<Expr>& x);
 
 ir::ModuleExpr IRCopy(const ir::ModuleExpr& x);
-
-ir::IRSchedule IRCopy(const ir::IRSchedule& x);
 
 ir::LoweredFunc IRCopy(const ir::LoweredFunc& x);
 


### PR DESCRIPTION
1. 更新SearchState类的定义，将其声明为common::Shared子类，减少搜索过程的不要拷贝。
2. 新增_SearchState_类用于存放当前SearchState的数据
3. IRSchedule新增拷贝构造函数，拷贝构造时新对象复制一份ModuleExpr；删除optim::IRCopy中间接拷贝IRSchedule的实现
4. 更新AutoGenRule的公开接口Init、Apply的参数或返回值，当前Rule是有状态的，每次应用时其内部修改的Expr与当前SearchState中IRSchedule一致，所以在Init时保存IRSchedule指针，变换时直接使用
5. 修改Database等其它依赖SearchState类定义的代码