### PR TITLE
fix bugs in softmax

### DIFF
--- a/cinn/auto_schedule/tests/CMakeLists.txt
+++ b/cinn/auto_schedule/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
-cc_test(test_performance_comparison
+if (WITH_CUDA AND (NOT WITH_CUDNN))
+  cc_test(test_performance_comparison
           ARGS "--resnet50_model_dir=${THIRD_PARTY_PATH}/ResNet50"
           SRCS performance_comparison_test.cc DEPS cinncore)
+endif()

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -257,7 +257,7 @@ TEST_F(PerformanceTester, Conv2d) {
   std::string data_format       = "NCHW";
   std::string padding_algorithm = "EXPLICIT";
 
-  SetOptionFlags(3UL);
+  SetOptionFlags(0UL);
   BuildAndRun(repeat_time,
               num_tuning_rounds,
               Conv2dProgramBuilder(

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -257,7 +257,7 @@ TEST_F(PerformanceTester, Conv2d) {
   std::string data_format       = "NCHW";
   std::string padding_algorithm = "EXPLICIT";
 
-  SetOptionFlags(0UL);
+  SetOptionFlags(1UL);
   BuildAndRun(repeat_time,
               num_tuning_rounds,
               Conv2dProgramBuilder(
@@ -323,7 +323,7 @@ TEST_F(PerformanceTester, Softmax) {
   int axis                = -1;
   std::string data_format = "AnyLayout";
 
-  SetOptionFlags(3UL);
+  SetOptionFlags(1UL);
   BuildAndRun(repeat_time, num_tuning_rounds, SoftmaxProgramBuilder(input_shape, axis, data_format)());
 }
 

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -33,6 +33,11 @@
 #include "cinn/utils/data_util.h"
 
 DEFINE_string(resnet50_model_dir, "./ResNet50", "the path to paddle model resnet50.");
+// Flags that control which schedule tests will be run.
+// Bit with index 0 controls no schedule test, means options = 1 = "001" will run no schedule test.
+// Bit with index 1 controls manual schedule test, means options = 2 = "010" will run manual schedule test.
+// Bit with index 2 controls auto schedule test, means options = 4 = "100" will run auto schedule test.
+// The default value is 7, which means that all tests will be run.
 DEFINE_uint64(options, 7, "the options to control which schedule tests will be run.");
 DECLARE_bool(cinn_ir_schedule);
 
@@ -246,7 +251,6 @@ TEST_F(PerformanceTester, Conv2d) {
   std::string data_format       = "NCHW";
   std::string padding_algorithm = "EXPLICIT";
 
-  SetOptionFlags(0UL);
   BuildAndRun(repeat_time,
               num_tuning_rounds,
               Conv2dProgramBuilder(
@@ -312,7 +316,7 @@ TEST_F(PerformanceTester, Softmax) {
   int axis                = -1;
   std::string data_format = "AnyLayout";
 
-  SetOptionFlags(0UL);
+  SetOptionFlags(5UL);
   BuildAndRun(repeat_time, num_tuning_rounds, SoftmaxProgramBuilder(input_shape, axis, data_format)());
 }
 

--- a/cinn/hlir/framework/op_lowering.cc
+++ b/cinn/hlir/framework/op_lowering.cc
@@ -1275,13 +1275,25 @@ std::vector<ir::LoweredFunc> OpLowerer::IRLowerOpaqueOp(GroupPtr& group, bool ap
     }
     return res;
   } else {
+    std::vector<Expr> ast_exprs;
     for (auto& f : func) {
-#ifdef CINN_WITH_CUDA
-      optim::OptimizeExprGPU(&(f->body));
-#endif
-      f = optim::Optimize(Expr(f), target_, false).as_lowered_func_ref();
+      ast_exprs.push_back(f->body);
     }
-    return func;
+    ir::ModuleExpr mod_expr(ast_exprs);
+    ir::IRSchedule ir_sch(mod_expr);
+    ir_sch.MergeExprs();
+
+    auto func_body = ir_sch.GetModule().GetExprs().at(0);
+#ifdef CINN_WITH_CUDA
+    optim::OptimizeExprGPU(&(func_body));
+#endif
+
+    auto temp_buffers = lang::GetTempBuffers(inputs, stages, func_body);
+    auto function =
+        ir::_LoweredFunc_::Make(group->GetFuncName(), args, ir_sch.GetModule().GetExprs().at(0), temp_buffers);
+    function->PrepareBufferCastExprs();
+    function = optim::Optimize(Expr(function), target_, false).as_lowered_func_ref();
+    return {function};
   }
 }
 


### PR DESCRIPTION
1.修复softmax 在manual schedule时的bug
报错信息：identifier "ax0" is undefined        
新schedule问题，将compute at放到schedule最前面，然后再进行split操作，并修改绑定到gpu轴的循环，与旧schedule对齐。
2.performance_test默认开启OpFusionPass，在no schedule中添加使用OpFusion后的Group进行Lower的过程。
3.当前performance_test只在开启CUDA且关闭CUDNN的情况下进行测试，将判断条件移到CmakeLists中，不满足条件时不生成该target。
