### PR TITLE
fix power support float type

### DIFF
--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -597,9 +597,11 @@ void CodeGenC::Visit(const ir::_LoweredFunc_ *op) {
 
   Print(func_body);
 }
+
 void CodeGenC::PrintIncludes() {
   os() << "#include <cinn_runtime.h>\n";
   os() << "#include <stdio.h>\n";
+  os() << "#include <math.h>\n";
   os() << "\n";
 }
 

--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -600,8 +600,8 @@ void CodeGenC::Visit(const ir::_LoweredFunc_ *op) {
 
 void CodeGenC::PrintIncludes() {
   os() << "#include <cinn_runtime.h>\n";
-  os() << "#include <stdio.h>\n";
   os() << "#include <math.h>\n";
+  os() << "#include <stdio.h>\n";
   os() << "\n";
 }
 

--- a/cinn/backends/codegen_c_test.cc
+++ b/cinn/backends/codegen_c_test.cc
@@ -78,6 +78,7 @@ TEST(CodeGenC, module) {
 
     std::string target_str = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void add1(void* _args, int32_t num_args)
@@ -109,6 +110,7 @@ void add1(void* _args, int32_t num_args)
 #define _MODULE1_CINN_H_
 
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void add1(void* _args, int32_t num_args);
@@ -174,6 +176,7 @@ TEST(CodeGenC, module_with_transform) {
 
   auto tgt = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void add1(void* _args, int32_t num_args)
@@ -271,6 +274,7 @@ TEST(CodeGenC, matmul) {
 
   auto tgt = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void matmul(void* _args, int32_t num_args)
@@ -382,6 +386,7 @@ TEST(CodeGenC, matmul_tile) {
 
   auto target_out = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void matmul(void* _args, int32_t num_args)
@@ -463,6 +468,7 @@ TEST(CodeGenC, matmul_packed) {
 
   auto target_out = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void matmul_with_packing(void* _args, int32_t num_args)

--- a/cinn/backends/extern_func_jit_register.h
+++ b/cinn/backends/extern_func_jit_register.h
@@ -68,7 +68,7 @@
  * Register a sourced function(No function address, called in generated source code).
  */
 #define REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(fn__, target__, in_type1__, in_type2__, out_type__) \
-  REGISTER_EXTERN_FUNC_HELPER(fn__, target__)                                                      \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(fn__, target__)                                               \
       .SetRetType<out_type__>()                                                                    \
       .AddInputType<in_type1__>()                                                                  \
       .AddInputType<in_type2__>()                                                                  \

--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -75,6 +75,7 @@ TEST(IrSchedule, split_and_fuse1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_split_and_fuse1(void* _args, int32_t num_args)
@@ -134,6 +135,7 @@ TEST(IrSchedule, split_and_fuse2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_split_and_fuse2(void* _args, int32_t num_args)
@@ -196,6 +198,7 @@ TEST(IrSchedule, reorder1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_reorder1(void* _args, int32_t num_args)
@@ -261,6 +264,7 @@ TEST(IrSchedule, reorder2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_reorder2(void* _args, int32_t num_args)
@@ -328,6 +332,7 @@ TEST(IrSchedule, reorder3) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_reorder3(void* _args, int32_t num_args)
@@ -399,6 +404,7 @@ TEST(IrSchedule, reorder4) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_reorder4(void* _args, int32_t num_args)
@@ -466,6 +472,7 @@ TEST(IrSchedule, parallel) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_parallel(void* _args, int32_t num_args)
@@ -553,6 +560,7 @@ function test_vectorize (_A, _B)
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_vectorize(void* _args, int32_t num_args)
@@ -629,6 +637,7 @@ function test_unroll (_A, _B)
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_unroll(void* _args, int32_t num_args)
@@ -734,6 +743,7 @@ TEST(IrSchedule, compute_at1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_compute_at1(void* _args, int32_t num_args)
@@ -805,6 +815,7 @@ TEST(IrSchedule, compute_at2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_compute_at2(void* _args, int32_t num_args)
@@ -882,6 +893,7 @@ TEST(IrSchedule, compute_at3) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_compute_at3(void* _args, int32_t num_args)
@@ -1178,6 +1190,7 @@ TEST(IrSchedule, cache_read1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_cache_read1(void* _args, int32_t num_args)
@@ -1264,6 +1277,7 @@ TEST(IrSchedule, cache_read2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_cache_read2(void* _args, int32_t num_args)
@@ -1330,6 +1344,7 @@ TEST(IrSchedule, cache_write1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_cache_write1(void* _args, int32_t num_args)
@@ -1414,6 +1429,7 @@ TEST(IrSchedule, cache_write2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_cache_write2(void* _args, int32_t num_args)
@@ -1811,6 +1827,7 @@ function test_rfactor (_A, _B)
   LOG(INFO) << "rfactor source code is :\n" << source_code;
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_rfactor(void* _args, int32_t num_args)
@@ -1941,6 +1958,7 @@ function test_rfactor (_A, _B)
   LOG(INFO) << "rfactor source code is :\n" << source_code;
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_rfactor(void* _args, int32_t num_args)
@@ -2070,6 +2088,7 @@ function test_rfactor (_A, _B, _C)
   LOG(INFO) << "rfactor source code is :\n" << source_code;
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_rfactor(void* _args, int32_t num_args)
@@ -2150,6 +2169,7 @@ TEST(IrSchedule, compute_inline1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_compute_inline1(void* _args, int32_t num_args)
@@ -2218,6 +2238,7 @@ TEST(IrSchedule, compute_inline2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_compute_inline2(void* _args, int32_t num_args)
@@ -2431,6 +2452,7 @@ TEST(IrSchedule, copytransform1) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_copytransform1(void* _args, int32_t num_args)
@@ -2520,6 +2542,7 @@ TEST(IrSchedule, copytransform2) {
 
   std::string target_code = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void test_copytransform2(void* _args, int32_t num_args)

--- a/cinn/common/cas.cc
+++ b/cinn/common/cas.cc
@@ -1984,7 +1984,8 @@ Expr ConvertCasToCinn(Expr expr) {
           return;
         }
       } else {
-        CINN_NOT_IMPLEMENTED
+        // Todo: When b is not constant in power(a,b), we don't do any simplify.
+        return;
       }
     }
   };

--- a/cinn/common/cas.cc
+++ b/cinn/common/cas.cc
@@ -1965,7 +1965,7 @@ Expr ConvertCasToCinn(Expr expr) {
       Visit(&b);
 
       auto* node = expr->As<ir::Power>();
-      if (b.is_constant()) {
+      if (b.type().is_int() && b.is_constant()) {
         if (b.get_constant() == 1) {
           *expr = a;
         } else if (b.get_constant() == 0) {

--- a/cinn/common/cas_test.cc
+++ b/cinn/common/cas_test.cc
@@ -35,7 +35,7 @@ using namespace ir;  // NOLINT
 TEST(CAS, SimplifyPower_0) {
   {  // x^0 = 1
     Var x   = ir::_Var_::Make("x", Float(32));
-    auto p0 = ir::Power::Make(x, Expr(0));
+    auto p0 = ir::Power::Make(x, Expr(0.0f));
     LOG(INFO) << "p0 " << p0;
     auto p2 = CasSimplify(p0);
     LOG(INFO) << "simplified " << p2;
@@ -43,7 +43,7 @@ TEST(CAS, SimplifyPower_0) {
   }
   {  // x^1 = x
     Var x   = ir::_Var_::Make("x", Float(32));
-    auto p0 = ir::Power::Make(x, Expr(1));
+    auto p0 = ir::Power::Make(x, Expr(1.0f));
     auto p2 = CasSimplify(p0);
     EXPECT_EQ(GetStreamCnt(p2), "x");
   }
@@ -56,7 +56,7 @@ TEST(CAS, SimplifyPower_0) {
   }
 
   {  // 1.^x = 1.
-    Var x   = ir::_Var_::Make("x", Int(32));
+    Var x   = ir::_Var_::Make("x", Float(32));
     auto p0 = ir::Power::Make(make_const(1.f), x);
     LOG(INFO) << "p0 " << p0;
     auto p2 = CasSimplify(p0);
@@ -74,8 +74,8 @@ TEST(CAS, SimplifyPower_0) {
   }
 
   {  // 0.^x = 0
-    Var x   = ir::_Var_::Make("x", Int(32));
-    auto p0 = ir::Power::Make(make_const(0.f), x);
+    Var x   = ir::_Var_::Make("x", Float(32));
+    auto p0 = ir::Power::Make(make_const(0.0f), x);
     LOG(INFO) << "p0 " << p0;
     auto p2 = CasSimplify(p0);
     LOG(INFO) << "simplified " << p2;
@@ -91,9 +91,9 @@ TEST(CAS, number_cal) {
 
 TEST(CAS, SimplifyPower) {
   Var x   = ir::_Var_::Make("x", Float(32));
-  auto p0 = ir::Power::Make(x, Expr(2));
+  auto p0 = ir::Power::Make(x, Expr(2.0f));
   LOG(INFO) << "p0 " << p0;
-  auto p1 = ir::Power::Make(p0, Expr(3));
+  auto p1 = ir::Power::Make(p0, Expr(3.0f));
 
   LOG(INFO) << "power: " << p1;
 
@@ -173,8 +173,8 @@ TEST(CAS, SimplifyProduct) {
 
   EXPECT_EQ(GetStreamCnt(u1), "1");
   EXPECT_EQ(GetStreamCnt(u2), "(-1 * x * y * z)");
-  EXPECT_EQ(GetStreamCnt(u3), "((x^-1) * y * z)");
-  EXPECT_EQ(GetStreamCnt(u4), "(x^5)");
+  EXPECT_EQ(GetStreamCnt(u3), "(powf(x, -1) * y * z)");
+  EXPECT_EQ(GetStreamCnt(u4), "powf(x, 5)");
   LOG(INFO) << u4;
 }
 
@@ -196,7 +196,7 @@ TEST(CAS, SimplifyMod) {
   EXPECT_EQ(GetStreamCnt(u1), "0");
   EXPECT_EQ(GetStreamCnt(u2), "((x + y + z) % 2)");
   EXPECT_EQ(GetStreamCnt(u3), "1");
-  EXPECT_EQ(GetStreamCnt(u4), "(1 + (x^3) + y)");
+  EXPECT_EQ(GetStreamCnt(u4), "(1 + powf(x, 3) + y)");
 }
 
 TEST(CAS, ConvertCinnToCAS) {

--- a/cinn/hlir/op/broadcast.cc
+++ b/cinn/hlir/op/broadcast.cc
@@ -92,7 +92,7 @@ std::shared_ptr<OpStrategy> StrategyForBroadcast(
 
 std::vector<shape_t> InferShapeForBroadcast(const std::vector<shape_t> &inputs_shape,
                                             const framework::AttrMapType &attrs) {
-  CHECK_EQ(inputs_shape.size(), 2UL);
+  CHECK_EQ(inputs_shape.size(), 2UL) << "The broadcast op should has  two input! Please check.";
   std::vector<int> out_shape;
 
   int axis = -1;
@@ -110,7 +110,10 @@ std::vector<shape_t> InferShapeForBroadcast(const std::vector<shape_t> &inputs_s
 }
 
 std::vector<Type> InferDtypeForBroadcast(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
-  CHECK(!inputs_type.empty()) << "The input's type size is 0! Please check again.";
+  CHECK_EQ(inputs_type.size(), 2UL) << "The broadcast op should has two inputs! Please check.";
+  CHECK(inputs_type[0] == inputs_type[1])
+      << "The two inputs of broadcast op should have the same dtype, but here x:" << inputs_type[0]
+      << ", y:" << inputs_type[1];
   std::vector<Type> res{inputs_type[0]};
   return res;
 }
@@ -212,6 +215,12 @@ std::vector<shape_t> InferShapeForBroadcastTo(const std::vector<shape_t> &inputs
 
   VLOG(3) << "broadcast out shape: " << utils::Join(out_shape, ", ");
   return {out_shape};
+}
+
+std::vector<Type> InferDtypeForBroadcastTo(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
+  CHECK_EQ(inputs_type.size(), 1UL) << "The broadcast op should has one inputs! Please check.";
+  std::vector<Type> res{inputs_type[0]};
+  return res;
 }
 
 std::vector<std::vector<std::string>> InferLayoutForBroadcastTo(const std::vector<std::vector<int>> &input_shapes,
@@ -426,7 +435,7 @@ CINN_REGISTER_HELPER(broadcast_ops) {
       .set_num_outputs(1)
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForBroadcastTo)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForBroadcastTo))
-      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForBroadcast))
+      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForBroadcastTo))
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForBroadcastTo))
 #endif

--- a/cinn/hlir/op/contrib/argmax_test.cc
+++ b/cinn/hlir/op/contrib/argmax_test.cc
@@ -65,6 +65,7 @@ TEST(GenerateCode_Cpu, Argmax_Keep) {
   std::string code   = codegen.Compile(builder.Build(), backends::CodeGenC::OutputKind::CImpl);
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Argmax_Keep(void* _args, int32_t num_args)

--- a/cinn/hlir/op/contrib/argmin_test.cc
+++ b/cinn/hlir/op/contrib/argmin_test.cc
@@ -65,6 +65,7 @@ TEST(GenerateCode_Cpu, Argmin_Keep) {
   std::string code   = codegen.Compile(builder.Build(), backends::CodeGenC::OutputKind::CImpl);
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Argmin_Keep(void* _args, int32_t num_args)

--- a/cinn/hlir/op/contrib/gather_test.cc
+++ b/cinn/hlir/op/contrib/gather_test.cc
@@ -63,6 +63,7 @@ TEST(GenerateCode_Cpu, Gather) {
   VLOG(6) << "Cpu Codegen result:";
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Gather(void* _args, int32_t num_args)
@@ -123,6 +124,7 @@ TEST(GenerateCode_Cpu, GatherNd) {
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_GatherNd(void* _args, int32_t num_args)

--- a/cinn/hlir/op/contrib/one_hot_test.cc
+++ b/cinn/hlir/op/contrib/one_hot_test.cc
@@ -69,6 +69,7 @@ TEST(GenerateCode_Cpu, OneHot) {
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_OneHot(void* _args, int32_t num_args)

--- a/cinn/hlir/op/contrib/repeat_test.cc
+++ b/cinn/hlir/op/contrib/repeat_test.cc
@@ -88,6 +88,7 @@ function TestGenerateCodeCpu_Repeat (_test_repeat)
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Repeat(void* _args, int32_t num_args)

--- a/cinn/hlir/op/contrib/scatter_test.cc
+++ b/cinn/hlir/op/contrib/scatter_test.cc
@@ -66,6 +66,7 @@ TEST(GenerateCode_Cpu, Scatter) {
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Scatter(void* _args, int32_t num_args)
@@ -130,6 +131,7 @@ TEST(GenerateCode_Cpu, ScatterNd) {
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Scatter(void* _args, int32_t num_args)

--- a/cinn/hlir/op/contrib/sort_test.cc
+++ b/cinn/hlir/op/contrib/sort_test.cc
@@ -90,6 +90,7 @@ TEST(GenerateCode_Cpu, Sort) {
   std::string code   = codegen.Compile(builder.Build(), backends::CodeGenC::OutputKind::CImpl);
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void TestGenerateCodeCpu_Sort(void* _args, int32_t num_args)

--- a/cinn/hlir/pe/broadcast.cc
+++ b/cinn/hlir/pe/broadcast.cc
@@ -234,7 +234,6 @@ HLIR_IMP_BC_PE(Mod, return a % b;);
 HLIR_IMP_BC_PE(FloorMod, return a - lang::Floor(a / b) * b;);
 HLIR_IMP_BC_PE(Maximum, return ir::Max::Make(a, b););
 HLIR_IMP_BC_PE(Minimum, return ir::Min::Make(a, b););
-HLIR_IMP_BC_PE(Power, return ir::Power::Make(a, b););
 HLIR_IMP_BC_PE(LeftShift, return a << b;);
 HLIR_IMP_BC_PE(RightShift, return a >> b;);
 HLIR_IMP_BC_PE(LogicalAnd, return a && b;);
@@ -249,6 +248,8 @@ HLIR_IMP_BC_PE(Equal, return ir::EQ::Make(a, b););
 HLIR_IMP_BC_PE(NotEqual, return ir::NE::Make(a, b););
 HLIR_IMP_BC_PE(GreaterEqual, return a >= b;);
 HLIR_IMP_BC_PE(LessEqual, return a <= b;);
+HLIR_IMP_BC_PE(Power,
+               return a.type().is_float() ? ir::Power::Make(a, b) : lang::CallExtern("cinn_nvgpu_pow_int32", {a, b}););
 
 Tensor BroadcastTo(const Tensor& A,
                    const std::vector<int>& out_shape,

--- a/cinn/ir/ir.cc
+++ b/cinn/ir/ir.cc
@@ -677,10 +677,10 @@ Expr FracOp::Make(Expr n, Expr d) {
 }
 
 Expr Power::Make(Expr n, Expr d) {
+  CHECK(d.type() == n.type()) << "n's type is " << n.type() << " but d's type is " << d.type();
   auto *node          = make_shared<Power>();
   node->operands()[0] = n;
   node->operands()[1] = d;
-  CHECK(d.type().is_int());
 
   node->set_type(n->type());
 

--- a/cinn/ir/ir.cc
+++ b/cinn/ir/ir.cc
@@ -796,7 +796,6 @@ void Broadcast::Verify() const { CHECK(value.defined()); }
 void Power::Verify() const {
   CHECK(a().defined());
   CHECK(b().defined());
-  CHECK(b().type() == type_of<int32_t>());
 }
 
 void MultiOperandVerify(llvm::ArrayRef<Expr> operands) {

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -364,9 +364,9 @@ void IrPrinter::Visit(const FracOp *x) {
 }
 
 void IrPrinter::Visit(const Power *x) {
-  os() << "(";
+  os() << "powf(";
   Print(x->a());
-  os() << "^";
+  os() << ", ";
   Print(x->b());
   os() << ")";
 }

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -368,6 +368,8 @@ void IrPrinter::Visit(const Power *x) {
     os() << "powf(";
   } else if (x->a().type().is_float(64)) {
     os() << "pow(";
+  } else if (x->a().type().is_int()) {
+    os() << "powf(";
   } else {
     CINN_NOT_IMPLEMENTED
   }

--- a/cinn/ir/ir_printer.cc
+++ b/cinn/ir/ir_printer.cc
@@ -364,7 +364,13 @@ void IrPrinter::Visit(const FracOp *x) {
 }
 
 void IrPrinter::Visit(const Power *x) {
-  os() << "powf(";
+  if (x->a().type().is_float(32)) {
+    os() << "powf(";
+  } else if (x->a().type().is_float(64)) {
+    os() << "pow(";
+  } else {
+    CINN_NOT_IMPLEMENTED
+  }
   Print(x->a());
   os() << ", ";
   Print(x->b());

--- a/cinn/ir/tensor_test.cc
+++ b/cinn/ir/tensor_test.cc
@@ -103,6 +103,7 @@ TEST(Tensor, Reshape) {
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void fn(void* _args, int32_t num_args)
@@ -150,6 +151,7 @@ TEST(Tensor, ReshapeCopied) {
 
   auto target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void fn(void* _args, int32_t num_args)

--- a/cinn/optim/transform_polyfor_to_for_test.cc
+++ b/cinn/optim/transform_polyfor_to_for_test.cc
@@ -74,6 +74,7 @@ TEST(Expr, basic) {
 
     auto target_out = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void matmul(void* _args, int32_t num_args)

--- a/cinn/optim/vectorize_loops_test.cc
+++ b/cinn/optim/vectorize_loops_test.cc
@@ -67,6 +67,7 @@ TEST(Vectorize, replace_var) {
   auto out        = codegen.Compile(builder.Build(), CodeGenC::OutputKind::CImpl);
   auto target_out = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void matmul(void* _args, int32_t num_args)
@@ -139,6 +140,7 @@ TEST(Vectorize, TestMarkVectorize) {
 
   auto target_out = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void matmul(const struct cinn_buffer_t *_A, const struct cinn_buffer_t *_B, struct cinn_buffer_t *_C)

--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -39,6 +39,14 @@ __device__ inline float FN(min)(float a, float b) { return min(a, b); }
 
 #undef FN
 
+__host__ __device__ inline int cinn_nvgpu_pow_int32(int a, int b) {
+  int res = 1;
+  for (int i = 0; i < b; ++i) {
+    res *= a;
+  }
+  return res;
+}
+
 __device__ inline float cinn_sum(const float left, const float right) { return left + right; }
 __device__ inline float cinn_prod(const float left, const float right) { return left * right; }
 __device__ inline float cinn_max(const float left, const float right) { return max(left, right); }

--- a/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -61,6 +61,21 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
 
 #undef REGISTER_EXTERN_FUNC_1_IN_1_OUT_BOOL
 
+#define REGISTER_EXTERN_FUNC_2_IN_1_OUT_FLOAT(func__) \
+  REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(cinn_nvgpu_##func__##_fp32, target, float, float, float);
+
+  REGISTER_EXTERN_FUNC_2_IN_1_OUT_FLOAT(max);
+  REGISTER_EXTERN_FUNC_2_IN_1_OUT_FLOAT(min);
+
+#undef REGISTER_EXTERN_FUNC_2_IN_1_OUT_FLOAT
+
+#define REGISTER_EXTERN_FUNC_2_IN_1_OUT_INT(func__) \
+  REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(cinn_nvgpu_##func__##_int32, target, int, int, int);
+
+  REGISTER_EXTERN_FUNC_2_IN_1_OUT_INT(pow);
+
+#undef REGISTER_EXTERN_FUNC_2_IN_1_OUT_INT
+
   FunctionProto::shape_inference_t inference_shape_globalpool = [](const std::vector<cinn::ir::Expr> &args,
                                                                    int offset) {
     auto t = args[0].as_tensor();

--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -216,6 +216,18 @@ class OpTest(unittest.TestCase):
         else:
             raise Exception("Not supported yet.")
 
+    @staticmethod
+    def nptype2cinntype(dtype):
+        switch_map = {
+            "float32": Float(32),
+            "float64": Float(64),
+            "int32": Int(32),
+            "int64": Int(64),
+            "bool": Bool()
+        }
+        assert str(dtype) in switch_map, dtype + " not support in CINN"
+        return switch_map[str(dtype)]
+
 
 class OpTestTool:
     @classmethod

--- a/python/tests/ops/test_pow_op.py
+++ b/python/tests/ops/test_pow_op.py
@@ -32,22 +32,25 @@ class TestPowOp(OpTest):
     def init_case(self):
         self.inputs = {
             "x": self.random([32, 64], "float32"),
-            "y": self.random([32, 64], "float32", 2.0, 5.0)
+            "y": self.random([32, 64], "float32", 1.0, 5.0)
         }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        y = paddle.to_tensor(
-            self.inputs["y"].astype("float32"), stop_gradient=False)
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
 
         out = paddle.pow(x, y)
 
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
-        builder = NetBuilder("add")
-        x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
-        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+        builder = NetBuilder("power")
+        x = builder.create_input(
+            self.nptype2cinntype(self.inputs["x"].dtype),
+            self.inputs["x"].shape, "x")
+        y = builder.create_input(
+            self.nptype2cinntype(self.inputs["y"].dtype),
+            self.inputs["y"].shape, "y")
         out = builder.power(x, y)
 
         prog = builder.build()
@@ -58,6 +61,22 @@ class TestPowOp(OpTest):
 
     def test_check_results(self):
         self.check_outputs_and_grads()
+
+
+class TestPowCase1(TestPowOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "int32", 2, 10),
+            "y": self.random([32, 64], "int32", 1, 5)
+        }
+
+
+class TestPowCase2(TestPowOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "int32", 2, 10),
+            "y": self.random([1], "int32", 1, 5)
+        }
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_pow_op.py
+++ b/python/tests/ops/test_pow_op.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestPowOp(OpTest):
+    def setUp(self):
+        self.init_case()
+
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "float32"),
+            "y": self.random([32, 64], "float32", 2.0, 5.0)
+        }
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
+        y = paddle.to_tensor(
+            self.inputs["y"].astype("float32"), stop_gradient=False)
+
+        out = paddle.pow(x, y)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("add")
+        x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
+        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+        out = builder.power(x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.inputs["x"], self.inputs["y"]], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tutorials/matmul.cc
+++ b/tutorials/matmul.cc
@@ -77,6 +77,7 @@ function fn0 (_A, _B, _C)
   //! @ROC[c++]
   target_source = R"ROC(
 #include <cinn_runtime.h>
+#include <math.h>
 #include <stdio.h>
 
 void fn0(void* _args, int32_t num_args)


### PR DESCRIPTION
现cinn中`power`函数要求第二个参数（即幂数）必须为int类型，本PR改为了和paddle保持一致，支持int和float类型，但要求x和y的数据类型必须保持一致。 