### PR TITLE
add `fill_constant/logical/bitwise/split`'s opmappers

### DIFF
--- a/cinn/frontend/op_mappers/paddle/binary.cc
+++ b/cinn/frontend/op_mappers/paddle/binary.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/op_mapper_registry.h"
+#include "cinn/frontend/op_mappers/common_utils.h"
+
+namespace cinn {
+namespace frontend {
+namespace paddle_mappers {
+
+#define BINARY_OPMAPPER_FUNCTION(OP_NAME)                                                  \
+  void OP_NAME##OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) { \
+    CHECK_EQ(op_desc.Input("X").size(), 1UL);                                              \
+    auto x_name = op_desc.Input("X").front();                                              \
+    CHECK_EQ(op_desc.Input("Y").size(), 1UL);                                              \
+    auto y_name = op_desc.Input("Y").front();                                              \
+    CHECK_EQ(op_desc.Output("Out").size(), 1UL);                                           \
+    auto out_name = op_desc.Output("Out").front();                                         \
+    auto x        = ctx.GetVar(x_name);                                                    \
+    auto y        = ctx.GetVar(y_name);                                                    \
+    auto out      = ctx.Builder()->OP_NAME(x, y);                                          \
+    ctx.AddVar(out_name, out);                                                             \
+    ctx.AddVarModelToProgram(out_name, out->id);                                           \
+  }
+
+BINARY_OPMAPPER_FUNCTION(LogicalAnd)
+BINARY_OPMAPPER_FUNCTION(LogicalOr)
+BINARY_OPMAPPER_FUNCTION(LogicalXor)
+BINARY_OPMAPPER_FUNCTION(BitwiseAnd)
+BINARY_OPMAPPER_FUNCTION(BitwiseOr)
+BINARY_OPMAPPER_FUNCTION(BitwiseXor)
+
+#undef BINARY_OPMAPPER_FUNCTION
+
+}  // namespace paddle_mappers
+}  // namespace frontend
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(paddle_binary) {
+#define BINARY_OPMAPPER_REGISTER(PD_OP, CINN_OP) \
+  CINN_REGISTER_OP_MAPPER(PD_OP, cinn::frontend::paddle_mappers::CINN_OP##OpMapper)
+
+  BINARY_OPMAPPER_REGISTER(logical_and, LogicalAnd)
+  BINARY_OPMAPPER_REGISTER(logical_or, LogicalOr)
+  BINARY_OPMAPPER_REGISTER(logical_xor, LogicalXor)
+  BINARY_OPMAPPER_REGISTER(bitwise_and, BitwiseAnd)
+  BINARY_OPMAPPER_REGISTER(bitwise_or, BitwiseOr)
+  BINARY_OPMAPPER_REGISTER(bitwise_xor, BitwiseXor)
+
+#undef BINARY_OPMAPPER_REGISTER
+
+  return true;
+}

--- a/cinn/frontend/op_mappers/paddle/concat.cc
+++ b/cinn/frontend/op_mappers/paddle/concat.cc
@@ -102,6 +102,48 @@ void StackOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
   ctx.AddVarModelToProgram(out_name, out->id);
 }
 
+void SplitOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+  CHECK_EQ(op_desc.Input("X").size(), 1UL);
+  auto x_name = op_desc.Input("X").front();
+  ;
+  CHECK_GE(op_desc.Output("Out").size(), 1UL);
+  auto out_names = op_desc.Output("Out");
+
+  auto x   = ctx.GetVar(x_name);
+  int rank = x->shape.size();
+
+  auto axis = utils::GetAttrOrDefault<int>(op_desc, "axis", 0);
+  CHECK(axis >= -rank && axis < rank) << "The [axis] should in [-" << rank << ", " << rank << "), but here is " << axis;
+  if (axis < 0) {
+    axis += rank;
+  }
+
+  auto num      = utils::GetAttrOrDefault<int>(op_desc, "num", 0);
+  auto sections = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "sections");
+
+  auto dim = x->shape[axis];
+  CHECK(num != 0 || !sections.empty()) << "The [num_or_sections] in split op should not empty! Please check.";
+  if (num != 0) {
+    CHECK(dim % num == 0) << "The num_or_sections:" << num << " cannot divided by the split axis:" << axis
+                          << " 's dimension:" << dim;
+
+    sections.clear();
+    sections.resize(num, dim / num);
+  }
+  auto sections_sum = std::accumulate(sections.begin(), sections.end(), 0);
+  CHECK_EQ(sections_sum, dim) << "The sum of num_or_sections:[" << cinn::utils::Join(sections, ", ")
+                              << "] not equal to the split axis:" << axis << " 's dimension:" << dim;
+  CHECK_EQ(sections.size(), out_names.size())
+      << "The output number of split op should be " << sections.size() << ", but actual " << out_names.size();
+
+  auto outs = ctx.Builder()->Split(x, sections, axis);
+
+  for (int i = 0; i < out_names.size(); ++i) {
+    ctx.AddVar(out_names[i], outs[i]);
+    ctx.AddVarModelToProgram(out_names[i], outs[i]->id);
+  }
+}
+
 }  // namespace paddle_mappers
 }  // namespace frontend
 }  // namespace cinn
@@ -109,5 +151,6 @@ void StackOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
 CINN_REGISTER_HELPER(paddle_concat) {
   CINN_REGISTER_OP_MAPPER(concat, cinn::frontend::paddle_mappers::ConcatOpMapper)
   CINN_REGISTER_OP_MAPPER(stack, cinn::frontend::paddle_mappers::StackOpMapper)
+  CINN_REGISTER_OP_MAPPER(split, cinn::frontend::paddle_mappers::SplitOpMapper)
   return true;
 }

--- a/cinn/frontend/op_mappers/paddle/constant.cc
+++ b/cinn/frontend/op_mappers/paddle/constant.cc
@@ -16,6 +16,7 @@
 
 #include "cinn/frontend/op_mapper_registry.h"
 #include "cinn/frontend/op_mappers/common_utils.h"
+#include "cinn/frontend/var_type_utils.h"
 
 namespace cinn {
 namespace frontend {
@@ -34,11 +35,72 @@ void ShapeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ct
   ctx.AddVarModelToProgram(out_name, out->id);
 }
 
+void FillConstantOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+  CHECK_EQ(op_desc.Output("Out").size(), 1UL);
+  auto y_name = op_desc.Output("Out").front();
+
+  auto shape     = utils::ToShapeType(utils::GetAttrOrDefault<std::vector<int64_t>>(op_desc, "shape"));
+  auto value     = utils::GetAttrOrDefault<float>(op_desc, "value", 0.0f);
+  auto force_cpu = utils::GetAttrOrDefault<bool>(op_desc, "force_cpu", false);
+
+  auto dtype_id = utils::GetAttrOrDefault<int>(op_desc, "dtype", static_cast<int>(paddle::cpp::VarDescAPI::Type::FP32));
+  auto dtype_pd = static_cast<paddle::cpp::VarDescAPI::Type>(dtype_id);
+  auto dtype_cinn = utils::CppVarType2CommonType(dtype_pd);
+  auto dtype      = common::Type2Str(dtype_cinn);
+
+  VLOG(4) << "fill constant (" << value << ") with shape (" << cinn::utils::Join(shape, ",") << ") and dtype [" << dtype
+          << "]";
+
+  const auto& cinn_name = cinn::utils::TransValidVarName(y_name);
+  CheckVarNameValid(cinn_name);
+
+  auto out = ctx.Builder()->FillConstant(shape, value, cinn_name, dtype, force_cpu);
+
+  ctx.AddVar(y_name, out);
+  ctx.AddVarModelToProgram(y_name, out->id);
+}
+
+void FillAnyLikeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+  CHECK_EQ(op_desc.Input("X").size(), 1UL);
+  auto x_name = op_desc.Input("X").front();
+  auto x      = ctx.GetVar(x_name);
+
+  CHECK_EQ(op_desc.Output("Out").size(), 1UL);
+  auto y_name = op_desc.Output("Out").front();
+
+  auto shape = utils::ToShapeType(x->shape);
+  auto value = utils::GetAttrOrDefault<float>(op_desc, "value");
+
+  auto dtype_id = utils::GetAttrOrDefault<int>(op_desc, "dtype", static_cast<int>(paddle::cpp::VarDescAPI::Type::FP32));
+  cinn::common::Type dtype_cinn;
+  if (dtype_id < 0) {
+    dtype_cinn = x->type;
+  } else {
+    auto dtype_pd = static_cast<paddle::cpp::VarDescAPI::Type>(dtype_id);
+    dtype_cinn    = utils::CppVarType2CommonType(dtype_pd);
+  }
+
+  auto dtype = common::Type2Str(dtype_cinn);
+
+  VLOG(4) << "FillAnyLikeOp: fill constant (" << value << ") with shape (" << cinn::utils::Join(shape, ", ")
+          << ") and dtype [" << dtype << "]";
+
+  const auto& cinn_name = cinn::utils::TransValidVarName(y_name);
+  CheckVarNameValid(cinn_name);
+
+  auto out = ctx.Builder()->FillConstant(shape, value, cinn_name, dtype);
+
+  ctx.AddVar(y_name, out);
+  ctx.AddVarModelToProgram(y_name, out->id);
+}
+
 }  // namespace paddle_mappers
 }  // namespace frontend
 }  // namespace cinn
 
 CINN_REGISTER_HELPER(paddle_constant) {
   CINN_REGISTER_OP_MAPPER(shape, cinn::frontend::paddle_mappers::ShapeOpMapper)
+  CINN_REGISTER_OP_MAPPER(fill_constant, cinn::frontend::paddle_mappers::FillConstantOpMapper)
+  CINN_REGISTER_OP_MAPPER(fill_any_like, cinn::frontend::paddle_mappers::FillAnyLikeOpMapper)
   return true;
 }

--- a/cinn/frontend/op_mappers/paddle/unary.cc
+++ b/cinn/frontend/op_mappers/paddle/unary.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/op_mapper_registry.h"
+#include "cinn/frontend/op_mappers/common_utils.h"
+
+namespace cinn {
+namespace frontend {
+namespace paddle_mappers {
+
+#define UNARY_OPMAPPER_FUNCTION(OP_NAME)                                                   \
+  void OP_NAME##OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) { \
+    CHECK_EQ(op_desc.Input("X").size(), 1UL);                                              \
+    auto x_name = op_desc.Input("X").front();                                              \
+    CHECK_EQ(op_desc.Output("Out").size(), 1UL);                                           \
+    auto out_name = op_desc.Output("Out").front();                                         \
+    auto x        = ctx.GetVar(x_name);                                                    \
+    auto out      = ctx.Builder()->OP_NAME(x);                                             \
+    ctx.AddVar(out_name, out);                                                             \
+    ctx.AddVarModelToProgram(out_name, out->id);                                           \
+  }
+
+UNARY_OPMAPPER_FUNCTION(LogicalNot)
+UNARY_OPMAPPER_FUNCTION(BitwiseNot)
+
+#undef UNARY_OPMAPPER_FUNCTION
+}  // namespace paddle_mappers
+}  // namespace frontend
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(paddle_unary) {
+#define UNARY_OPMAPPER_REGISTER(PD_OP, CINN_OP) \
+  CINN_REGISTER_OP_MAPPER(PD_OP, cinn::frontend::paddle_mappers::CINN_OP##OpMapper)
+
+  UNARY_OPMAPPER_REGISTER(logical_not, LogicalNot)
+  UNARY_OPMAPPER_REGISTER(bitwise_not, BitwiseNot)
+
+#undef UNARY_OPMAPPER_REGISTER
+
+  return true;
+}

--- a/cinn/frontend/op_mappers/science/broadcast.cc
+++ b/cinn/frontend/op_mappers/science/broadcast.cc
@@ -44,40 +44,6 @@ void FillConstantOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperCont
   ctx.AddVarModelToProgram(y_name, out->id);
 }
 
-void FillAnyLikeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
-  CHECK_EQ(op_desc.Input("X").size(), 1UL);
-  auto x_name = op_desc.Input("X").front();
-  auto x      = ctx.GetVar(x_name);
-
-  CHECK_EQ(op_desc.Output("Out").size(), 1UL);
-  auto y_name = op_desc.Output("Out").front();
-
-  auto shape = utils::ToShapeType(x->shape);
-  auto value = utils::GetAttrOrDefault<float>(op_desc, "value");
-
-  auto dtype_id = utils::GetAttrOrDefault<int>(op_desc, "dtype", static_cast<int>(paddle::cpp::VarDescAPI::Type::FP32));
-  cinn::common::Type dtype_cinn;
-  if (dtype_id < 0) {
-    dtype_cinn = x->type;
-  } else {
-    auto dtype_pd = static_cast<paddle::cpp::VarDescAPI::Type>(dtype_id);
-    dtype_cinn    = utils::CppVarType2CommonType(dtype_pd);
-  }
-
-  auto dtype = common::Type2Str(dtype_cinn);
-
-  VLOG(4) << "FillAnyLikeOp: fill constant (" << value << ") with shape (" << cinn::utils::Join(shape, ", ")
-          << ") and dtype [" << dtype << "]";
-
-  const auto& cinn_name = cinn::utils::TransValidVarName(y_name);
-  CheckVarNameValid(cinn_name);
-
-  auto out = ctx.Builder()->FillConstant(shape, value, cinn_name, dtype);
-
-  ctx.AddVar(y_name, out);
-  ctx.AddVarModelToProgram(y_name, out->id);
-}
-
 void BroadcastOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
   CHECK_EQ(op_desc.Input("X").size(), 1UL);
   auto x_name = op_desc.Input("X").front();
@@ -105,7 +71,6 @@ void BroadcastOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
 
 CINN_REGISTER_HELPER(science_broadcast) {
   CINN_REGISTER_OP_MAPPER(fill_constant_p, cinn::frontend::science_mappers::FillConstantOpMapper)
-  CINN_REGISTER_OP_MAPPER(fill_any_like, cinn::frontend::science_mappers::FillAnyLikeOpMapper)
   CINN_REGISTER_OP_MAPPER(broadcast_p, cinn::frontend::science_mappers::BroadcastOpMapper)
 
   return true;

--- a/cinn/frontend/op_mappers/use_op_mappers.h
+++ b/cinn/frontend/op_mappers/use_op_mappers.h
@@ -44,6 +44,8 @@ CINN_USE_REGISTER(paddle_gelu)
 CINN_USE_REGISTER(paddle_unsqueeze)
 CINN_USE_REGISTER(paddle_expand)
 CINN_USE_REGISTER(paddle_take_along_axis)
+CINN_USE_REGISTER(paddle_unary)
+CINN_USE_REGISTER(paddle_binary)
 
 CINN_USE_REGISTER(science_broadcast)
 CINN_USE_REGISTER(science_transform)

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -279,7 +279,9 @@ std::shared_ptr<OpStrategy> StrategyForFillConstant(const framework::NodeAttr &a
     force_cpu = absl::get<bool>(attrs.attr_store.at("force_cpu"));
 
 #ifdef CINN_WITH_CUDA
-    if (force_cpu && target != common::DefaultHostTarget()) CINN_NOT_IMPLEMENTED
+    if (force_cpu && target != common::DefaultHostTarget()) {
+      LOG(WARNING) << "[force_cpu] not supported in CINN! The output will placed on device.";
+    }
 #endif
 
     CINNValuePack arg_pack  = args[0];

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -278,7 +278,10 @@ std::shared_ptr<OpStrategy> StrategyForFillConstant(const framework::NodeAttr &a
     CHECK(attrs.attr_store.count("force_cpu"));
     force_cpu = absl::get<bool>(attrs.attr_store.at("force_cpu"));
 
-    if (force_cpu) CINN_NOT_IMPLEMENTED
+#ifndef CINN_WITH_CUDA
+    if (force_cpu && target != DefaultHostTarget()) CINN_NOT_IMPLEMENTED
+#endif
+
     CINNValuePack arg_pack  = args[0];
     std::string tensor_name = UniqName("fill_constant_Out");
     if (FLAGS_cinn_ir_schedule) {

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -278,8 +278,8 @@ std::shared_ptr<OpStrategy> StrategyForFillConstant(const framework::NodeAttr &a
     CHECK(attrs.attr_store.count("force_cpu"));
     force_cpu = absl::get<bool>(attrs.attr_store.at("force_cpu"));
 
-#ifndef CINN_WITH_CUDA
-    if (force_cpu && target != DefaultHostTarget()) CINN_NOT_IMPLEMENTED
+#ifdef CINN_WITH_CUDA
+    if (force_cpu && target != common::DefaultHostTarget()) CINN_NOT_IMPLEMENTED
 #endif
 
     CINNValuePack arg_pack  = args[0];

--- a/cinn/hlir/pe/broadcast.cc
+++ b/cinn/hlir/pe/broadcast.cc
@@ -238,7 +238,7 @@ HLIR_IMP_BC_PE(LeftShift, return a << b;);
 HLIR_IMP_BC_PE(RightShift, return a >> b;);
 HLIR_IMP_BC_PE(LogicalAnd, return a && b;);
 HLIR_IMP_BC_PE(LogicalOr, return a || b;);
-HLIR_IMP_BC_PE(LogicalXOr, return a ^ b;);
+HLIR_IMP_BC_PE(LogicalXOr, return (a || b) && !(a && b););
 HLIR_IMP_BC_PE(BitwiseAnd, return a & b;);
 HLIR_IMP_BC_PE(BitwiseOr, return a | b;);
 HLIR_IMP_BC_PE(BitwiseXor, return a ^ b;);

--- a/cinn/optim/map_extern_call.cc
+++ b/cinn/optim/map_extern_call.cc
@@ -54,6 +54,10 @@ void MapExternCall(Expr *e, Target target) {
         CHECK_GE(node->read_args.size(), 1UL);
         CHECK_EQ(node->read_args.front().type(), Float(32));
         *expr = lang::CallExtern("cinn_nvgpu_" + node->name + "_fp32", node->read_args);
+      } else if (kExternInt32CallsGPU.count(node->name)) {
+        CHECK_GE(node->read_args.size(), 1UL);
+        CHECK_EQ(node->read_args.front().type(), Int(32));
+        *expr = lang::CallExtern("cinn_nvgpu_" + node->name + "_int32", node->read_args);
       }
       // TODO(Superjomn) deal with int64 intrinsics.
     }

--- a/cinn/optim/map_extern_call.h
+++ b/cinn/optim/map_extern_call.h
@@ -23,12 +23,12 @@ namespace cinn {
 namespace optim {
 
 static const std::set<std::string> kExternFp32CallsGPU{
-    {"exp",         "erf",         "sigmoid",     "sqrt",        "log",        "log2",        "log10",
-     "floor",       "ceil",        "round",       "trunc",       "cos",        "cosh",        "tan",
-     "sin",         "sinh",        "acos",        "acosh",       "asin",       "asinh",       "atan",
-     "atanh",       "isnan",       "tanh",        "isfinite",    "isinf",      "left_shift",  "right_shift",
-     "bitwise_or",  "bitwise_and", "bitwise_xor", "bitwise_not", "left_shift", "right_shift", "bitwise_or",
-     "bitwise_and", "bitwise_xor", "bitwise_not"}};
+    {"exp",   "erf",   "sigmoid", "sqrt",  "log",   "log2", "log10",    "floor", "ceil",
+     "round", "trunc", "cos",     "cosh",  "tan",   "sin",  "sinh",     "acos",  "acosh",
+     "asin",  "asinh", "atan",    "atanh", "isnan", "tanh", "isfinite", "isinf"}};
+
+static const std::set<std::string> kExternInt32CallsGPU{
+    {"left_shift", "right_shift", "bitwise_or", "bitwise_and", "bitwise_xor", "bitwise_not"}};
 
 static const std::set<std::string> kExternFp32CallsCPU = {"erf", "acos", "acosh", "asin", "asinh", "atan", "atanh"};
 

--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -57,6 +57,13 @@ __device__ inline int FN_INT32(pow)(int a, int b) {
   return res;
 }
 
+__device__ inline int FN_INT32(left_shift)(int a, int b) { return a << b; }
+__device__ inline int FN_INT32(right_shift)(int a, int b) { return a >> b; }
+__device__ inline int FN_INT32(bitwise_and)(int a, int b) { return a & b; }
+__device__ inline int FN_INT32(bitwise_or)(int a, int b) { return a | b; }
+__device__ inline int FN_INT32(bitwise_xor)(int a, int b) { return a ^ b; }
+__device__ inline int FN_INT32(bitwise_not)(int a) { return ~a; }
+
 #undef FN_INT32
 
 __device__ inline float cinn_sum(const float left, const float right) { return left + right; }

--- a/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -77,10 +77,22 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
 
 #undef REGISTER_EXTERN_FUNC_2_IN_1_FP64
 
+#define REGISTER_EXTERN_FUNC_1_IN_1_INT32(func__) \
+  REGISTER_EXTERN_SOURCE_FUNC_1_IN_1_OUT(cinn_nvgpu_##func__##_int32, target, int, int);
+
+  REGISTER_EXTERN_FUNC_1_IN_1_INT32(bitwise_not)
+
+#undef REGISTER_EXTERN_FUNC_1_IN_1_INT32
+
 #define REGISTER_EXTERN_FUNC_2_IN_1_INT32(func__) \
   REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(cinn_nvgpu_##func__##_int32, target, int, int, int);
 
   REGISTER_EXTERN_FUNC_2_IN_1_INT32(pow)
+  REGISTER_EXTERN_FUNC_2_IN_1_INT32(left_shift)
+  REGISTER_EXTERN_FUNC_2_IN_1_INT32(right_shift)
+  REGISTER_EXTERN_FUNC_2_IN_1_INT32(bitwise_and)
+  REGISTER_EXTERN_FUNC_2_IN_1_INT32(bitwise_or)
+  REGISTER_EXTERN_FUNC_2_IN_1_INT32(bitwise_xor)
 
 #undef REGISTER_EXTERN_FUNC_2_IN_1_INT32
 

--- a/python/tests/op_mappers/test_bitwise_op.py
+++ b/python/tests/op_mappers/test_bitwise_op.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+paddle.enable_static()
+
+enable_gpu = sys.argv.pop()
+
+
+class TestBitwiseOp(OpMapperTest):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+            self.place = paddle.CUDAPlace(0)
+        else:
+            self.target = DefaultHostTarget()
+            self.place = paddle.CPUPlace()
+
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], "int32", 0, 100000),
+            'y': self.random([32, 64], "int32", 0, 100000),
+        }
+
+    def paddle_func(self, x, y):
+        return paddle.bitwise_and(x, y)
+
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        y = paddle.static.data(
+            name='y',
+            shape=self.feed_data['y'].shape,
+            dtype=self.feed_data['x'].dtype)
+        out = self.paddle_func(x, y)
+
+        return ([x.name, y.name], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestBitwiseAndOp(TestBitwiseOp):
+    def paddle_func(self, x, y):
+        return paddle.bitwise_and(x, y)
+
+
+class TestBitwiseOrOp(TestBitwiseOp):
+    def paddle_func(self, x, y):
+        return paddle.bitwise_or(x, y)
+
+
+class TestBitwiseXOrOp(TestBitwiseOp):
+    def paddle_func(self, x, y):
+        return paddle.bitwise_xor(x, y)
+
+
+class TestBitwiseNotOp(TestBitwiseOp):
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        out = paddle.bitwise_not(x)
+
+        return ([x.name], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/op_mappers/test_compare_op.py
+++ b/python/tests/op_mappers/test_compare_op.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+paddle.enable_static()
+
+enable_gpu = sys.argv.pop()
+
+
+class TestCompareOp(OpMapperTest):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+            self.place = paddle.CUDAPlace(0)
+        else:
+            self.target = DefaultHostTarget()
+            self.place = paddle.CPUPlace()
+
+    def get_input_dtype(self):
+        return "float32"
+
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], self.get_input_dtype(), 0, 10),
+            'y': self.random([32, 64], self.get_input_dtype(), 0, 10),
+        }
+
+    def paddle_func(self, x, y):
+        return paddle.equal(x, y)
+
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        y = paddle.static.data(
+            name='y',
+            shape=self.feed_data['y'].shape,
+            dtype=self.feed_data['x'].dtype)
+        out = self.paddle_func(x, y)
+
+        return ([x.name, y.name], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+test_op_list = [
+    "equal", "not_equal", "greater_than", "less_than", "greater_equal",
+    "less_equal"
+]
+
+for op_name in test_op_list:
+    paddle_module_name = ""
+    if hasattr(paddle, op_name):
+        paddle_module_name = "paddle."
+    elif hasattr(paddle.nn, op_name):
+        paddle_module_name = "paddle.nn."
+    elif hasattr(paddle.nn.functional, op_name):
+        paddle_module_name = "paddle.nn.functional."
+    elif hasattr(paddle.fluid.layers, op_name):
+        paddle_module_name = "paddle.fluid.layers."
+    else:
+        assert False, "Cannot find " + op_name + " in 'paddle' module!"
+
+    attrs = {
+        "paddle_func": lambda _, x, y: eval(paddle_module_name + op_name)(x, y
+                                                                          ),
+    }
+    exec("test_class_" + op_name +
+         " = type('Test' + op_name.title() + 'Op', (TestCompareOp,), attrs)")
+
+    case1_attrs = {"get_input_dtype": lambda _: "int32"}
+    exec(
+        "test_case1_" + op_name +
+        " = type('Test' + op_name.title() + 'Case1', (globals()['test_class_' + op_name],), case1_attrs)"
+    )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/op_mappers/test_fill_constant_op.py
+++ b/python/tests/op_mappers/test_fill_constant_op.py
@@ -59,5 +59,13 @@ class TestFillConstantCase1(TestFillConstantOp):
         self.dtype = "int32"
 
 
+class TestFillConstantCase2(TestFillConstantOp):
+    def set_paddle_program(self):
+        out = paddle.fluid.layers.fill_constant(
+            self.shape, self.dtype, self.value, force_cpu=True)
+
+        return ([], [out])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/op_mappers/test_fill_constant_op.py
+++ b/python/tests/op_mappers/test_fill_constant_op.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+paddle.enable_static()
+
+enable_gpu = sys.argv.pop()
+
+
+class TestFillConstantOp(OpMapperTest):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+            self.place = paddle.CUDAPlace(0)
+        else:
+            self.target = DefaultHostTarget()
+            self.place = paddle.CPUPlace()
+
+    def init_input_data(self):
+        self.feed_data = dict()
+        self.shape = [10, 10]
+        self.value = np.random.default_rng(12345).random()
+        self.dtype = "float32"
+
+    def set_paddle_program(self):
+        out = paddle.full(self.shape, self.value, dtype=self.dtype)
+
+        return ([], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestFillConstantCase1(TestFillConstantOp):
+    def init_input_data(self):
+        self.feed_data = dict()
+        self.shape = [10, 10]
+        self.value = np.random.default_rng(12345).integers(low=0, high=10000)
+        self.dtype = "int32"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/op_mappers/test_logical_op.py
+++ b/python/tests/op_mappers/test_logical_op.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+paddle.enable_static()
+
+enable_gpu = sys.argv.pop()
+
+
+class TestLogicalOp(OpMapperTest):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+            self.place = paddle.CUDAPlace(0)
+        else:
+            self.target = DefaultHostTarget()
+            self.place = paddle.CPUPlace()
+
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], "bool"),
+            'y': self.random([32, 64], "bool"),
+        }
+
+    def paddle_func(self, x, y):
+        return paddle.logical_and(x, y)
+
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        y = paddle.static.data(
+            name='y',
+            shape=self.feed_data['y'].shape,
+            dtype=self.feed_data['x'].dtype)
+        out = self.paddle_func(x, y)
+
+        return ([x.name, y.name], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestLogicalAndOp(TestLogicalOp):
+    def paddle_func(self, x, y):
+        return paddle.logical_and(x, y)
+
+
+class TestLogicalOrOp(TestLogicalOp):
+    def paddle_func(self, x, y):
+        return paddle.logical_or(x, y)
+
+
+class TestLogicalXOrOp(TestLogicalOp):
+    def paddle_func(self, x, y):
+        return paddle.logical_xor(x, y)
+
+
+class TestLogicalNotOp(TestLogicalOp):
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        out = paddle.logical_not(x)
+
+        return ([x.name], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/op_mappers/test_split_op.py
+++ b/python/tests/op_mappers/test_split_op.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+paddle.enable_static()
+
+enable_gpu = sys.argv.pop()
+
+
+class TestSplitOp(OpMapperTest):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+            self.place = paddle.CUDAPlace(0)
+        else:
+            self.target = DefaultHostTarget()
+            self.place = paddle.CPUPlace()
+
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], "float32"),
+        }
+        self.axis = 0
+        self.num_or_sections = 4
+
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        out = paddle.split(x, self.num_or_sections, self.axis)
+
+        return ([x.name], out)
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestSplitCase1(TestSplitOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], "float32"),
+        }
+        self.axis = 0
+        self.num_or_sections = [3, 5, 16, 2, 6]
+
+
+class TestSplitCase2(TestSplitOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], "float32"),
+        }
+        self.axis = -1
+        self.num_or_sections = 8
+
+
+class TestSplitCase3(TestSplitOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], "int32", 0, 10000),
+        }
+        self.axis = 0
+        self.num_or_sections = [4, 4, 16, 8]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_paddle_model_convertor.py
+++ b/python/tests/test_paddle_model_convertor.py
@@ -73,6 +73,8 @@ class TestPaddleModel(OpTest):
             return "float32"
         elif dtype == paddle.int32:
             return "int32"
+        elif dtype == paddle.int64:
+            return "int64"
         elif dtype == paddle.bool:
             return "bool"
         else:


### PR DESCRIPTION
As title. 添加`fill_constant`、`logical_not/or/xor/and`、`bitwise_not/or/xor/and`、`split`算子的opmapper，同时添加对应的单测。同时解决`bitwise_not/or/xor/and`数据类型应该为int类型，而非float类型的bug。