### PR TITLE
fix elementwise fuse broadcast

### DIFF
--- a/cinn/hlir/pass/fusion_merge_pass.cc
+++ b/cinn/hlir/pass/fusion_merge_pass.cc
@@ -838,6 +838,11 @@ class FusionMergePassHelper : public FusionHelperBase {
       if (is_same_shape(first, second)) {
         return true;
       }
+
+      // if first has more than one concumser, can't fuse.
+      if (first->consumer_groups.size() > 1) {
+        return false;
+      }
       // if first's output is not all in second's input
       for (auto output : first->output_nodes) {
         if (!second->input_nodes.count(output)) {


### PR DESCRIPTION
修复elementwise融合broadcast:
如果elementwise有多个consumer，则禁止融合。