### PR TITLE
optmize constant op

### DIFF
--- a/cinn/common/ir_util.h
+++ b/cinn/common/ir_util.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <absl/container/flat_hash_map.h>
+#include <absl/types/variant.h>
 
 #include <map>
 #include <memory>
@@ -101,16 +102,32 @@ Expr min(Expr a, Expr b);
 template <typename T>
 Expr make_const(Type t, T v) {
   if (t.is_vector()) {
-    if (t.type() == Type::type_t::Int) {
-      return ir::Broadcast::Make(make_shared<ir::IntImm>(t.ElementOf(), v), t.lanes());
+    if (t.is_int(32)) {
+      return ir::Broadcast::Make(make_shared<ir::IntImm>(t.ElementOf(), static_cast<int>(v)), t.lanes());
+    } else if (t.is_int(64)) {
+      return ir::Broadcast::Make(make_shared<ir::IntImm>(t.ElementOf(), static_cast<int64_t>(v)), t.lanes());
+    } else if (t.is_float(32)) {
+      return ir::Broadcast::Make(make_shared<ir::FloatImm>(t.ElementOf(), static_cast<float>(v)), t.lanes());
+    } else if (t.is_float(64)) {
+      return ir::Broadcast::Make(make_shared<ir::FloatImm>(t.ElementOf(), static_cast<double>(v)), t.lanes());
+    } else if (t.is_bool()) {
+      return ir::Broadcast::Make(make_shared<ir::UIntImm>(t.ElementOf(), static_cast<bool>(v)), t.lanes());
     } else {
-      return ir::Broadcast::Make(make_shared<ir::FloatImm>(t.ElementOf(), v), t.lanes());
+      CINN_NOT_IMPLEMENTED
     }
   } else {
-    if (t.type() == Type::type_t::Int) {
-      return make_shared<ir::IntImm>(t, v);
+    if (t.is_int(32)) {
+      return make_shared<ir::IntImm>(t, static_cast<int>(v));
+    } else if (t.is_int(64)) {
+      return make_shared<ir::IntImm>(t, static_cast<int64_t>(v));
+    } else if (t.is_float(32)) {
+      return make_shared<ir::FloatImm>(t, static_cast<float>(v));
+    } else if (t.is_float(64)) {
+      return make_shared<ir::FloatImm>(t, static_cast<double>(v));
+    } else if (t.is_bool()) {
+      return make_shared<ir::UIntImm>(t, static_cast<bool>(v));
     } else {
-      return make_shared<ir::FloatImm>(t, v);
+      CINN_NOT_IMPLEMENTED
     }
   }
   return Expr();

--- a/cinn/common/ir_util.h
+++ b/cinn/common/ir_util.h
@@ -14,7 +14,6 @@
 
 #pragma once
 #include <absl/container/flat_hash_map.h>
-#include <absl/types/variant.h>
 
 #include <map>
 #include <memory>
@@ -102,28 +101,20 @@ Expr min(Expr a, Expr b);
 template <typename T>
 Expr make_const(Type t, T v) {
   if (t.is_vector()) {
-    if (t.is_int(32)) {
-      return ir::Broadcast::Make(make_shared<ir::IntImm>(t.ElementOf(), static_cast<int>(v)), t.lanes());
-    } else if (t.is_int(64)) {
+    if (t.is_int()) {
       return ir::Broadcast::Make(make_shared<ir::IntImm>(t.ElementOf(), static_cast<int64_t>(v)), t.lanes());
-    } else if (t.is_float(32)) {
+    } else if (t.is_float()) {
       return ir::Broadcast::Make(make_shared<ir::FloatImm>(t.ElementOf(), static_cast<float>(v)), t.lanes());
-    } else if (t.is_float(64)) {
-      return ir::Broadcast::Make(make_shared<ir::FloatImm>(t.ElementOf(), static_cast<double>(v)), t.lanes());
     } else if (t.is_bool()) {
       return ir::Broadcast::Make(make_shared<ir::UIntImm>(t.ElementOf(), static_cast<bool>(v)), t.lanes());
     } else {
       CINN_NOT_IMPLEMENTED
     }
   } else {
-    if (t.is_int(32)) {
-      return make_shared<ir::IntImm>(t, static_cast<int>(v));
-    } else if (t.is_int(64)) {
+    if (t.is_int()) {
       return make_shared<ir::IntImm>(t, static_cast<int64_t>(v));
-    } else if (t.is_float(32)) {
+    } else if (t.is_float()) {
       return make_shared<ir::FloatImm>(t, static_cast<float>(v));
-    } else if (t.is_float(64)) {
-      return make_shared<ir::FloatImm>(t, static_cast<double>(v));
     } else if (t.is_bool()) {
       return make_shared<ir::UIntImm>(t, static_cast<bool>(v));
     } else {

--- a/cinn/frontend/op_mappers/paddle/constant.cc
+++ b/cinn/frontend/op_mappers/paddle/constant.cc
@@ -102,15 +102,17 @@ void FillAnyLikeOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperConte
 
 template <typename T>
 std::pair<bool, T> IsArithmeticSequence(const std::vector<T>& vec) {
-  if (vec.empty()) {
-    return {true, static_cast<T>(0)};
+  if (vec.size() <= 1UL || (vec[1] - vec[0]) == 0) {
+    return {false, static_cast<T>(0)};
   }
 
-  std::vector<T> adj_diff;
-  std::adjacent_difference(vec.begin(), vec.end(), std::back_inserter(adj_diff));
-  bool is_diff_same =
-      std::all_of(adj_diff.begin() + 1, adj_diff.end(), [&adj_diff](const T& v) { return v == adj_diff.back(); });
-  return {adj_diff.back() != 0 && is_diff_same, adj_diff.back()};
+  auto first_diff = vec[1] - vec[0];
+  for (int i = 2; i < vec.size(); ++i) {
+    if ((vec[i] - vec[i - 1]) != first_diff) {
+      return {false, first_diff};
+    }
+  }
+  return {true, first_diff};
 }
 
 void AssignValueOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {

--- a/cinn/hlir/op/contrib/arange.cc
+++ b/cinn/hlir/op/contrib/arange.cc
@@ -77,11 +77,7 @@ std::vector<std::vector<int>> InferShapeForArange(const std::vector<std::vector<
   CHECK_NE(step, 0) << "The value of step cann't be 0!";
 
   int num_elem = 0;
-  if (step > 0.0f) {
-    num_elem = static_cast<int>(std::ceil((stop - start) / step));
-  } else if (step < 0.0f) {
-    num_elem = static_cast<int>(std::ceil((start - stop) / (-step)));
-  }
+  num_elem     = static_cast<int>(std::ceil((stop - start) / step));
   VLOG(4) << "Arange with start = " << start << ", stop = " << stop << ", step = " << step << ", total has " << num_elem
           << " elements";
   CHECK_GT(num_elem, 0) << "Invalid arange parameters, start = " << start << ", stop = " << stop << ", step = " << step

--- a/cinn/hlir/op/contrib/arange.cc
+++ b/cinn/hlir/op/contrib/arange.cc
@@ -76,7 +76,14 @@ std::vector<std::vector<int>> InferShapeForArange(const std::vector<std::vector<
 
   CHECK_NE(step, 0) << "The value of step cann't be 0!";
 
-  int num_elem = static_cast<int>(std::ceil((stop - start) / step));
+  int num_elem = 0;
+  if (step > 0.0f) {
+    num_elem = static_cast<int>(std::ceil((stop - start) / step));
+  } else if (step < 0.0f) {
+    num_elem = static_cast<int>(std::ceil((start - stop) / (-step)));
+  }
+  VLOG(4) << "Arange with start = " << start << ", stop = " << stop << ", step = " << step << ", total has " << num_elem
+          << " elements";
   CHECK_GT(num_elem, 0) << "Invalid arange parameters, start = " << start << ", stop = " << stop << ", step = " << step
                         << ", cause num_elem = " << num_elem << " which is negative.";
 
@@ -192,6 +199,7 @@ CINN_REGISTER_HELPER(arange_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForArange)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForArange))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForArange))
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElementWise)
       .set_support_level(4);
 
   return true;

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 
+#include "absl/types/optional.h"
 #include "cinn/hlir/framework/node.h"
 #include "cinn/hlir/framework/op.h"
 #include "cinn/hlir/framework/op_strategy.h"
@@ -345,6 +346,123 @@ std::vector<std::vector<std::string>> InferLayoutForFillConstant(const std::vect
   return {{""}, input_layouts};
 }
 
+#define EXPAND_ATTR_TYPE(MACRO) \
+  MACRO(bool)                   \
+  MACRO(float)                  \
+  MACRO(int)                    \
+  MACRO(int64_t)                \
+  MACRO(double)
+
+std::shared_ptr<OpStrategy> StrategyForAssignValue(const framework::NodeAttr &attrs,
+                                                   const std::vector<ir::Tensor> &inputs,
+                                                   const std::vector<Type> &out_type,
+                                                   const std::vector<std::vector<int>> &output_shapes,
+                                                   const Target &target) {
+  framework::CINNCompute assign_value_compute([=](lang::Args args, lang::RetValue *ret) {
+    CHECK(!args.empty()) << "The input argument of fill_constant compute is empty! Please check.";
+    CHECK(attrs.attr_store.count("values"));
+    const auto &value = attrs.attr_store.at("values");
+
+    CINNValuePack arg_pack  = args[0];
+    std::string tensor_name = arg_pack[0].operator std::string();
+
+    absl::optional<ir::Tensor> out;
+#define EXPAND_VALUE_TO_TENSOR(TYPE)                                                            \
+  else if (absl::get_if<TYPE>(&value)) {                                                        \
+    out = pe::AssignValue(std::vector<TYPE>{absl::get<TYPE>(value)}, out_type[0], tensor_name); \
+  }                                                                                             \
+  else if (absl::get_if<std::vector<TYPE>>(&value)) {                                           \
+    out = pe::AssignValue(absl::get<std::vector<TYPE>>(value), out_type[0], tensor_name);       \
+  }
+
+    if (false) {
+    }
+    EXPAND_ATTR_TYPE(EXPAND_VALUE_TO_TENSOR)
+    else {
+      LOG(FATAL) << "Assign value not support the type " << out_type[0];
+    }
+#undef EXPAND_VALUE_TO_TENSOR
+
+    CHECK(out && out.value().defined()) << "can't create assign_value with the given type " << out_type[0];
+
+    auto stages = CreateStages({out.value()});
+    *ret        = CINNValuePack{{CINNValue(out.value()), CINNValue(stages)}};
+  });
+
+  auto strategy = std::make_shared<framework::OpStrategy>();
+  strategy->AddImpl(
+      assign_value_compute, framework::GetInjectiveScheduleFunc(output_shapes, target), "strategy.assign_value.x86", 1);
+
+  return strategy;
+}
+
+std::vector<shape_t> InferShapeForAssignValue(const std::vector<shape_t> &inputs_shape,
+                                              const framework::AttrMapType &attrs) {
+  CHECK(attrs.count("values"));
+  const auto &value = attrs.at("values");
+
+  shape_t shape;
+#define EXPAND_ATTR_TO_GET_SHAPE(TYPE)                              \
+  else if (absl::get_if<TYPE>(&value)) {                            \
+    shape.emplace_back(1);                                          \
+  }                                                                 \
+  else if (absl::get_if<std::vector<TYPE>>(&value)) {               \
+    shape.emplace_back(absl::get<std::vector<TYPE>>(value).size()); \
+  }
+
+  if (false) {
+  }
+  EXPAND_ATTR_TYPE(EXPAND_ATTR_TO_GET_SHAPE)
+  else {
+    LOG(FATAL) << "Assign value not support the type!";
+  }
+#undef EXPAND_ATTR_TO_GET_SHAPE
+
+  return {shape};
+}
+
+std::vector<Type> InferDtypeForAssignValue(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
+  Type out_type;
+  if (attrs.find("dtype") != attrs.end()) {
+    // attribute [dtype] are given
+    auto dtype_str = absl::get<std::string>(attrs.at("dtype"));
+    out_type       = common::Str2Type(dtype_str);
+  } else {
+    // infer from [values]'s dtype
+    CHECK(attrs.count("values"));
+    const auto &value = attrs.at("values");
+
+#define EXPAND_ATTR_TO_GET_DTYPE(TYPE)                \
+  else if (absl::get_if<TYPE>(&value)) {              \
+    out_type = common::type_of<TYPE>();               \
+  }                                                   \
+  else if (absl::get_if<std::vector<TYPE>>(&value)) { \
+    out_type = common::type_of<TYPE>();               \
+  }
+
+    if (false) {
+    }
+    EXPAND_ATTR_TYPE(EXPAND_ATTR_TO_GET_DTYPE)
+    else {
+      LOG(FATAL) << "Assign value not support the type!";
+    }
+#undef EXPAND_ATTR_TO_GET_DTYPE
+  }
+
+  VLOG(3) << "The data type of assign_value is " << out_type;
+
+  return {out_type};
+}
+
+std::vector<std::vector<std::string>> InferLayoutForAssignValue(const std::vector<framework::shape_t> &input_shapes,
+                                                                const std::vector<std::string> &input_layouts,
+                                                                const framework::NodeAttr &attrs,
+                                                                const Target &target) {
+  return {{""}, input_layouts};
+}
+
+#undef EXPAND_ATTR_TYPE
+
 StrategyForUnary(exp, Exp);
 StrategyForUnary(erf, Erf);
 StrategyForUnary(sqrt, Sqrt);
@@ -495,6 +613,19 @@ CINN_REGISTER_HELPER(elementwise_ops) {
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForFillConstant))
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForFillConstant))
+#endif
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElementWise)
+      .set_support_level(4);
+
+  CINN_REGISTER_OP(assign_value)
+      .describe("create tensor with the given value, type and shape")
+      .set_num_inputs(0)
+      .set_num_outputs(1)
+      .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForAssignValue)
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForAssignValue))
+      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForAssignValue))
+#ifndef CINN_WITH_CUDA
+      .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForAssignValue))
 #endif
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElementWise)
       .set_support_level(4);

--- a/cinn/hlir/pe/elementwise.h
+++ b/cinn/hlir/pe/elementwise.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "cinn/ir/ir.h"
+#include "cinn/lang/builtin.h"
 #include "cinn/lang/compute.h"
 
 namespace cinn {
@@ -74,6 +75,30 @@ HLIR_DCL_UNARY_PE(Reinterpret);
 HLIR_DCL_UNARY_PE(ElementwiseSum);
 HLIR_DCL_UNARY_PE(Full);
 HLIR_DCL_UNARY_PE(FullLike);
+
+template <typename T>
+ir::Tensor AssignValue(const std::vector<T>& values,
+                       const common::Type& type       = common::type_of<T>(),
+                       const std::string& output_name = "T_assign_value_out") {
+  CHECK(!values.empty()) << "The input of pe::AssignValue should not empty! Please check.";
+
+  auto out = lang::Compute(
+      {ir::Expr(static_cast<int>(values.size()))},
+      [=](const std::vector<ir::Expr>& indice) {
+        auto init_value =
+            (type == common::type_of<T>()) ? ir::Expr(values[0]) : common::cast(ir::Expr(values[0]), type);
+        ir::Expr previous = ir::Select::Make(ir::EQ::Make(indice[0], ir::Expr(0)), init_value, lang::Zero(type));
+
+        for (int i = 1; i < values.size(); ++i) {
+          auto val = (type == common::type_of<T>()) ? ir::Expr(values[i]) : common::cast(ir::Expr(values[i]), type);
+          previous = ir::Select::Make(ir::EQ::Make(indice[0], ir::Expr(i)), val, previous);
+        }
+        return previous;
+      },
+      output_name);
+
+  return out;
+}
 
 }  // namespace pe
 }  // namespace hlir

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -339,10 +339,11 @@ void BindFrontend(pybind11::module *m) {
   // clang-format off
 #define PY_REGISTER_CONSTANT_OP(TYPE__)                                              \
      .def("constant",                                                                \
-          static_cast<Variable (NetBuilder::*)(const TYPE__&, const std::string &)>( \
+          static_cast<Variable (NetBuilder::*)(const TYPE__&, const std::string &, const std::string &)>( \
                &NetBuilder::template Constant<TYPE__>),                              \
           py::arg("value"),                                                          \
-          py::arg("name"))
+          py::arg("name"),                                                          \
+          py::arg("dtype") = "")
      EXPAND_CINN_SUPPORT_TYPE(PY_REGISTER_CONSTANT_OP)
 #define EXPAND_ONE_VECTOR(TYPE) PY_REGISTER_CONSTANT_OP(std::vector<TYPE>)
      EXPAND_CINN_SUPPORT_TYPE(EXPAND_ONE_VECTOR)

--- a/python/tests/op_mappers/test_assign_value_op.py
+++ b/python/tests/op_mappers/test_assign_value_op.py
@@ -75,5 +75,25 @@ class TestAssignValueCase5(TestAssignValueOp):
         }
 
 
+class TestAssignValueCase6(TestAssignValueOp):
+    def init_input_data(self):
+        self.feed_data = {'x': np.arange(128, dtype="int64")}
+
+
+class TestAssignValueCase7(TestAssignValueOp):
+    def init_input_data(self):
+        self.feed_data = {'x': np.arange(128, dtype="int32")}
+
+
+class TestAssignValueCase8(TestAssignValueOp):
+    def init_input_data(self):
+        self.feed_data = {'x': np.arange(0.0, 12.8, 0.1, dtype="float32")}
+
+
+class TestAssignValueCase9(TestAssignValueOp):
+    def init_input_data(self):
+        self.feed_data = {'x': np.arange(127, -1, -1, dtype="int32")}
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/op_mappers/test_assign_value_op.py
+++ b/python/tests/op_mappers/test_assign_value_op.py
@@ -63,5 +63,17 @@ class TestAssignValueCase3(TestAssignValueOp):
         self.feed_data = {'x': self.random([10], 'int64', 0, 1000)}
 
 
+class TestAssignValueCase4(TestAssignValueOp):
+    def init_input_data(self):
+        self.feed_data = {'x': self.random([1], 'float32')}
+
+
+class TestAssignValueCase5(TestAssignValueOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([np.random.randint(100, 1000)], 'float32')
+        }
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/ops/test_constant_op.py
+++ b/python/tests/ops/test_constant_op.py
@@ -33,15 +33,16 @@ class TestConstantOp(OpTest):
     def init_case(self):
         self.value = 1.0
         self.name = 'x'
+        self.dtype = "float32"
 
     def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.value)
+        x = paddle.to_tensor(self.value, dtype=self.dtype)
 
         self.paddle_outputs = [x]
 
     def build_cinn_program(self, target):
         builder = NetBuilder("constant")
-        x = builder.constant(self.value, self.name)
+        x = builder.constant(self.value, self.name, self.dtype)
 
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [], [], [x])
@@ -55,36 +56,56 @@ class TestConstantCase1(TestConstantOp):
     def init_case(self):
         self.value = [1.0]
         self.name = 'x'
+        self.dtype = "float32"
 
 
 class TestConstantCase2(TestConstantOp):
     def init_case(self):
         self.value = [1.0, 2.0, 3.0, 4.0, 5.0]
         self.name = 'x'
+        self.dtype = "float32"
 
 
 class TestConstantCase3(TestConstantOp):
     def init_case(self):
         self.value = [[1.0, 2.0], [3.0, 4.0]]
         self.name = 'x'
+        self.dtype = "float32"
 
 
 class TestConstantCase4(TestConstantOp):
     def init_case(self):
         self.value = [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]
         self.name = 'x'
+        self.dtype = "float32"
 
 
 class TestConstantCase5(TestConstantOp):
     def init_case(self):
         self.value = [[[1.0], [3.0]], [[5.0], [7.0]]]
         self.name = 'x'
+        self.dtype = "float32"
 
 
 class TestConstantCase6(TestConstantOp):
     def init_case(self):
         self.value = [[[1.0]]]
         self.name = 'x'
+        self.dtype = "float32"
+
+
+class TestConstantCase7(TestConstantOp):
+    def init_case(self):
+        self.value = self.random([200], "int32", 1, 1000).tolist()
+        self.name = 'x'
+        self.dtype = "int32"
+
+
+class TestConstantCase8(TestConstantOp):
+    def init_case(self):
+        self.value = self.random([10], "int64", 1, 1000).tolist()
+        self.name = 'x'
+        self.dtype = "int64"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As title. 由于`assign_value`是直接使用的`constant`算子，而`constant`又是通过若干`const_scalar` + `concat`实现的，这导致当输入数组长度较大时（比如>100），代码生成过程中会hang住。本PR优化了其实现，通过添加`assign_value`算子，compute采用`select`方式判断，解决了hang住的问题。但若干select无疑还是会导致性能非常慢！