### PR TITLE
fix auto_schedule test_performance_comparison

### DIFF
--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -28,6 +28,7 @@
 #include "cinn/hlir/framework/graph_compiler.h"
 #include "cinn/hlir/framework/node.h"
 #include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/pass/op_fusion_pass.h"
 #include "cinn/ir/ir_base.h"
 #include "cinn/runtime/flags.h"
 #include "cinn/utils/data_util.h"
@@ -56,52 +57,51 @@ class PerformanceTester : public ::testing::Test {
     // times of compiled runtime program will be executed repeatedly.
     int repeat_times = 2;
     // the num_tuning_rounds for auto tuning
-    int num_tuning_rounds = 10;
+    int num_tuning_rounds = 1;
     // knobs to control which schedules will be measured, refer to FLAGS_evaluate_knobs explanation
     std::bitset<3> evaluate_knobs = 7UL;
   };
 
+  void SetUp() override { FLAGS_cinn_parallel_compile_size = 0; }
+
   void Evaluate(const frontend::Program& program) {
-    VLOG(3) << "Initialize graph.";
-    graph_ = std::make_shared<hlir::framework::Graph>(program, target_);
-    VLOG(3) << "Apply graph pass.";
-    // hlir::framework::ApplyPass(graph_.get(), "InferShape");
-    // hlir::framework::ApplyPass(graph_.get(), "OpFusionPass");
     if (FLAGS_evaluate_knobs >= 0) {
       options_.evaluate_knobs = FLAGS_evaluate_knobs;
     }
     VLOG(3) << "evaluate_knobs = " << options_.evaluate_knobs;
 
-    if (options_.evaluate_knobs.test(0)) {
-      VLOG(3) << "Build no schedule program.";
-      auto scope           = BuildScope(target_, graph_);
-      auto graph_compiler  = std::make_unique<GraphCompiler>(target_, scope, graph_);
-      auto runtime_program = BuildNoScheduleProgram(graph_compiler.get());
-      VLOG(3) << "Execute no schedule program.";
+    auto worker_fn = [this, &program](const std::string& schedule_name, BuildRuntimeProgramFn build_fn) {
+      Context::Global().ResetNameId();
+      VLOG(3) << "Initialize graph.";
+      auto graph = std::make_shared<hlir::framework::Graph>(program, target_);
+      VLOG(3) << "Apply graph pass.";
+      hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+      VLOG(3) << "Build " << schedule_name << " program.";
+      auto scope           = BuildScope(target_, graph);
+      auto graph_compiler  = std::make_unique<GraphCompiler>(target_, scope, graph);
+      auto runtime_program = (this->*build_fn)(graph.get(), graph_compiler.get());
+      VLOG(3) << "Execute " << schedule_name << " program.";
       runtime_program->ExecuteTest(options_.repeat_times);
+    };
+
+    if (options_.evaluate_knobs.test(0)) {
+      worker_fn("no schedule", &PerformanceTester::BuildNoScheduleProgram);
     }
     if (options_.evaluate_knobs.test(1)) {
-      VLOG(3) << "Build manual schedule program.";
-      auto scope           = BuildScope(target_, graph_);
-      auto graph_compiler  = std::make_unique<GraphCompiler>(target_, scope, graph_);
-      auto runtime_program = BuildManualScheduleProgram(graph_compiler.get());
-      VLOG(3) << "Execute manual schedule program.";
-      runtime_program->ExecuteTest(options_.repeat_times);
+      worker_fn("manual schedule", &PerformanceTester::BuildManualScheduleProgram);
     }
     if (options_.evaluate_knobs.test(2)) {
-      VLOG(3) << "Build auto schedule program.";
-      auto scope           = BuildScope(target_, graph_);
-      auto graph_compiler  = std::make_unique<GraphCompiler>(target_, scope, graph_);
-      auto runtime_program = BuildAutoScheduleProgram(graph_compiler.get(), options_.num_tuning_rounds);
-      VLOG(3) << "Execute auto schedule program.";
-      runtime_program->ExecuteTest(options_.repeat_times);
+      worker_fn("auto schedule", &PerformanceTester::BuildAutoScheduleProgram);
     }
   }
 
  protected:
-  std::unique_ptr<hlir::framework::Program> BuildNoScheduleProgram(GraphCompiler* graph_compiler) {
-    const auto& dtype_dict = graph_->GetAttrs<absl::flat_hash_map<std::string, common::Type>>("inferdtype");
-    const auto& shape_dict = graph_->GetAttrs<absl::flat_hash_map<std::string, hlir::framework::shape_t>>("infershape");
+  using BuildRuntimeProgramFn = std::unique_ptr<hlir::framework::Program> (PerformanceTester::*)(Graph*,
+                                                                                                 GraphCompiler*);
+
+  std::unique_ptr<hlir::framework::Program> BuildNoScheduleProgram(Graph* graph, GraphCompiler* graph_compiler) {
+    const auto& dtype_dict = graph->GetAttrs<absl::flat_hash_map<std::string, common::Type>>("inferdtype");
+    const auto& shape_dict = graph->GetAttrs<absl::flat_hash_map<std::string, hlir::framework::shape_t>>("infershape");
 
     std::shared_ptr<hlir::framework::OpLowerer> op_lowerer =
         std::make_unique<hlir::framework::OpLowerer>(dtype_dict, shape_dict, target_);
@@ -109,45 +109,14 @@ class PerformanceTester : public ::testing::Test {
     GraphCompiler::CompileOptions compile_options;
     compile_options.with_instantiate_variables = true;
 
-    if (graph_->fusion_groups.empty()) {
-      std::tuple<std::vector<common::GraphNode*>, std::vector<common::GraphEdge*>> topo_result =
-          graph_->topological_order();
-      const std::vector<common::GraphNode*>& nodes_in_order = std::get<0>(topo_result);
-      for (auto graph_node : nodes_in_order) {
-        // n must be an op node
-        auto node = graph_node->safe_as<hlir::framework::Node>();
-        if (node) {
-          auto group = std::make_shared<Graph::Group>();
-          // init group
-          group->nodes.push_back(node);
-          group->nodes_set.insert(node);
-          group->output_nodes.insert(node);
-          // input node
-          for (auto& edge : node->inlinks()) {
-            auto input_graph_node = edge->source();
-            auto input_node_data  = input_graph_node->safe_as<hlir::framework::NodeData>();
-            CHECK(input_node_data);
-            // input data has no source node
-            if (input_node_data->source_node.get()) {
-              group->input_nodes[input_node_data->source_node.get()] = 1;
-            }
-          }
-
-          // group type
-          group->op_pattern_kind = hlir::framework::kNonFusible;
-          // use current node as master node for schedule
-          group->master_nodes.insert(node);
-          group->group_id = node->id();
-
-          compile_options.groups.push_back(group);
-          compile_options.lowered_funcs.push_back(op_lowerer->LowerWithoutSchedule(group));
-        }
-      }
+    if (graph->fusion_groups.empty()) {
+      compile_options.groups = hlir::pass::BuildNonFusedGroups(graph);
     } else {
-      compile_options.groups = graph_->fusion_groups;
-      for (auto group : graph_->fusion_groups) {
-        compile_options.lowered_funcs.push_back(op_lowerer->LowerWithoutSchedule(group));
-      }
+      compile_options.groups = graph->fusion_groups;
+    }
+
+    for (auto group : graph->fusion_groups) {
+      compile_options.lowered_funcs.push_back(op_lowerer->LowerWithoutSchedule(group));
     }
 
     VLOG(3) << "===========================No Schedule LoweredFunc Begin===========================";
@@ -161,17 +130,18 @@ class PerformanceTester : public ::testing::Test {
     return graph_compiler->Build(compile_options).runtime_program;
   }
 
-  std::unique_ptr<hlir::framework::Program> BuildManualScheduleProgram(GraphCompiler* graph_compiler) {
+  std::unique_ptr<hlir::framework::Program> BuildManualScheduleProgram(Graph* graph, GraphCompiler* graph_compiler) {
     return graph_compiler->Build();
   }
 
-  std::unique_ptr<hlir::framework::Program> BuildAutoScheduleProgram(GraphCompiler* graph_compiler,
-                                                                     int num_tuning_rounds) {
-    auto tuner = std::make_unique<AutoTuner>(target_, graph_.get());
+  std::unique_ptr<hlir::framework::Program> BuildAutoScheduleProgram(Graph* graph, GraphCompiler* graph_compiler) {
+    auto tuner = std::make_unique<AutoTuner>(target_, graph);
 
     AutoTuner::Config tuning_config;
     TuningOptions tuning_options;
-    tuning_options.num_tuning_rounds = num_tuning_rounds;
+    tuning_options.num_tuning_rounds         = options_.num_tuning_rounds;
+    tuning_options.num_measure_trials        = 2;
+    tuning_options.num_samples_per_iteration = 2;
 
     tuner->Initialize(tuning_config, graph_compiler);
     TuningResult tuning_result = tuner->Tune(tuning_options);
@@ -196,18 +166,16 @@ class PerformanceTester : public ::testing::Test {
 #else
   Target target_ = common::DefaultHostTarget();
 #endif
-  std::shared_ptr<Graph> graph_;
   Options options_;
 };
 
-constexpr int batch_size = 4;
+constexpr int batch_size = 2;
 
 TEST_F(PerformanceTester, Mul) {
   int M = 32;
   int K = 16;
   int N = 32;
 
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(MulProgramBuilder({M, K}, {N, K})());
 }
 
@@ -218,7 +186,6 @@ TEST_F(PerformanceTester, Matmul) {
   int K = 2048;
   int N = 1000;
 
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(MatmulProgramBuilder({M, K}, {K, N})());
 }
 
@@ -234,7 +201,6 @@ TEST_F(PerformanceTester, Conv2d) {
   std::string data_format       = "NCHW";
   std::string padding_algorithm = "EXPLICIT";
 
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(Conv2dProgramBuilder(
       input_shape, weight_shape, strides, paddings, dilations, groups, data_format, padding_algorithm)());
 }
@@ -252,8 +218,6 @@ TEST_F(PerformanceTester, Pool2d) {
   bool adaptive                 = false;
   std::string padding_algorithm = "EXPLICIT";
 
-  options_.evaluate_knobs          = 0UL;
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(Pool2dProgramBuilder(input_shape,
                                 pooling_type,
                                 ksize,
@@ -278,7 +242,6 @@ TEST_F(PerformanceTester, BatchNorm) {
   const std::string& data_layout = "NCHW";
   bool is_test                   = true;
 
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(BatchNormProgramBuilder(
       input_shape, scale_shape, bias_shape, mean_shape, variance_shape, epsilon, momentum, data_layout, is_test)());
 }
@@ -295,8 +258,6 @@ TEST_F(PerformanceTester, Softmax) {
   int axis                = -1;
   std::string data_format = "AnyLayout";
 
-  options_.evaluate_knobs          = 5UL;
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(SoftmaxProgramBuilder(input_shape, axis, data_format)());
 }
 
@@ -306,7 +267,6 @@ TEST_F(PerformanceTester, Scale) {
   float bias            = 0.0f;
   bool bias_after_scale = true;
 
-  FLAGS_cinn_parallel_compile_size = 0;
   Evaluate(ScaleProgramBuilder(input_shape, scale, bias, bias_after_scale)());
 }
 
@@ -316,8 +276,7 @@ TEST_F(PerformanceTester, ResNet50) {
   std::vector<std::vector<int>> input_shapes = {{batch_size, 3, 224, 224}};
   CHECK_NE(FLAGS_resnet50_model_dir, "");
 
-  options_.evaluate_knobs          = 0UL;
-  FLAGS_cinn_parallel_compile_size = 0;
+  options_.evaluate_knobs = 0UL;
   Evaluate(PaddleModelProgramBuilder(FLAGS_resnet50_model_dir, input_names, input_shapes)());
 }
 

--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -37,6 +37,7 @@ void Instruction::UpdateArgsCache(const std::map<std::string, cinn_pod_value_t>*
     if (name2podargs != nullptr) {
       for (const auto& arg : all_args) {
         CHECK_NE(name2podargs->count(arg), 0) << "Argument [" << arg << "] not found in the name2podargs";
+        VLOG(5) << "Get a argument, name=" << arg << ",type_code=" << name2podargs->at(arg).type_code();
         builder.Add(name2podargs->at(arg));
       }
     } else {
@@ -46,6 +47,7 @@ void Instruction::UpdateArgsCache(const std::map<std::string, cinn_pod_value_t>*
 
         // TODO(Superjomn) Support other types.
         auto& tensor = absl::get<Tensor>(*var);
+        VLOG(5) << "Get a argument, name=" << arg;
         builder.Add(tensor->buffer());
       }
     }

--- a/cinn/hlir/framework/parallel_compiler.cc
+++ b/cinn/hlir/framework/parallel_compiler.cc
@@ -25,6 +25,7 @@
 #include "cinn/backends/llvm/runtime_symbol_registry.h"
 #include "cinn/backends/nvrtc_util.h"
 #include "cinn/common/context.h"
+#include "cinn/hlir/pass/op_fusion_pass.h"
 #include "cinn/ir/module.h"
 
 DECLARE_int32(cinn_parallel_compile_size);
@@ -40,7 +41,7 @@ std::vector<std::unique_ptr<Instruction>> ParallelCompiler::operator()() {
     return std::vector<std::unique_ptr<Instruction>>();
   }
   if (graph_->fusion_groups.size() == 0) {
-    CreateFusionGroup();
+    graph_->fusion_groups = pass::BuildNonFusedGroups(graph_.get());
   }
   // Task Spilt
   SplitTask();
@@ -63,37 +64,6 @@ OpPatternKind GetOpKind(const framework::Node* node) {
   }
 
   return kind;
-}
-
-void ParallelCompiler::CreateFusionGroup() {
-  auto nodes_inorder = std::get<0>(graph_->topological_order());
-  for (auto graph_node : nodes_inorder) {
-    auto node = graph_node->safe_as<Node>();
-    if (node) {
-      auto group = std::make_shared<Graph::Group>();
-      // init group
-      group->nodes.push_back(node);
-      group->nodes_set.insert(node);
-      group->output_nodes.insert(node);
-      // input node
-      for (auto& edge : node->inlinks()) {
-        auto input_graph_node = edge->source();
-        auto input_node_data  = input_graph_node->safe_as<NodeData>();
-        CHECK(input_node_data);
-        // input data has no source node
-        if (input_node_data->source_node.get()) {
-          group->input_nodes[input_node_data->source_node.get()] = 1;
-        }
-      }
-
-      // group type
-      group->op_pattern_kind = GetOpKind(node);
-      // use current node as master node for schedule
-      group->master_nodes.insert(node);
-      group->group_id = node->id();
-      graph_->fusion_groups.push_back(group);
-    }
-  }
 }
 
 void ParallelCompiler::SplitTask() {

--- a/cinn/hlir/framework/parallel_compiler.h
+++ b/cinn/hlir/framework/parallel_compiler.h
@@ -47,7 +47,6 @@ class ParallelCompiler {
  private:
   void SplitTask();
   void LaunchTask();
-  void CreateFusionGroup();
   std::vector<std::unique_ptr<Instruction>> MergeResult();
 
  public:

--- a/cinn/hlir/pass/op_fusion_pass.cc
+++ b/cinn/hlir/pass/op_fusion_pass.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cinn/hlir/pass/op_fusion_pass.h"
+
 #include "cinn/common/type.h"
 #include "cinn/hlir/pass/fusion_helper_base.h"
 namespace cinn {
@@ -77,9 +79,11 @@ class OpFusionPassHelper : public FusionHelperBase {
   }
 
   // return a vector of groups in topological order.
-  GroupList operator()() {
+  GroupList operator()(bool do_fusion = true) {
     // do op fusion.
-    DoOpFusion();
+    if (do_fusion) {
+      DoOpFusion();
+    }
 
     // find all fusion group.
     GroupList fusion_groups;
@@ -580,6 +584,12 @@ void OpFusionPassInternal(Graph* graph) {
     }
   }
   VLOG(3) << "OpFusionPass Finish...!";
+}
+
+std::vector<std::shared_ptr<framework::Graph::Group>> BuildNonFusedGroups(const framework::Graph* graph) {
+  auto op_fusion_helper = OpFusionPassHelper(graph);
+  VLOG(3) << "Apply OpFusionPass to generate initial non-fusion groups";
+  return op_fusion_helper(false);
 }
 
 }  // namespace pass

--- a/cinn/hlir/pass/op_fusion_pass.h
+++ b/cinn/hlir/pass/op_fusion_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/hlir/framework/graph.h"
+
+namespace cinn {
+namespace hlir {
+namespace pass {
+
+// create a new group for every single node of the graph
+std::vector<std::shared_ptr<framework::Graph::Group>> BuildNonFusedGroups(const framework::Graph* graph);
+
+}  // namespace pass
+}  // namespace hlir
+}  // namespace cinn

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -994,7 +994,7 @@ std::vector<Tensor> PoolImpl(const Tensor &tensor,
 
           return lang::ReduceMax(temp(indices), {daxis}, min_value);
         },
-        UniqName(output_name));
+        output_name);
   } else if (pool_type == "avg") {
     // Pad the input tensor with pad_value zero
     temp = do_pad ? Pad(tensor, pad_before, pad_after, 0, UniqName("pad_temp")) : tensor;
@@ -1032,7 +1032,7 @@ std::vector<Tensor> PoolImpl(const Tensor &tensor,
             return lang::ReduceSum(ir::Div::Make(temp(indices), cast(temp_factor, Float(32))), daxis);
           }
         },
-        UniqName(output_name));
+        output_name);
   } else {
     LOG(ERROR) << "Unrecognized pool_type: " << pool_type;
   }
@@ -1074,7 +1074,7 @@ std::vector<Tensor> PoolImpl(const Tensor &tensor,
           Expr divide_factor = Max::Make(temp_factor, make_const(Int(32), 1));
           return lang::ReduceSum(ir::Div::Make(temp(indices), cast(divide_factor, Float(32))), {reduce_axis});
         },
-        UniqName(output_name));
+        output_name);
   }
   if (do_pad) {
     return {res, temp};
@@ -1102,16 +1102,8 @@ std::vector<Tensor> Pool1d(const Tensor &tensor,
   }
   CHECK_EQ(tensor->shape.size(), 3U) << "pool1d requires tensor's shape_size to be 3\n";
   std::vector<int> axis = {width_axis};
-  return PoolImpl(tensor,
-                  kernel_size,
-                  stride_size,
-                  padding_size,
-                  pool_type,
-                  axis,
-                  ceil_mode,
-                  exclusive,
-                  false,
-                  UniqName(output_name));
+  return PoolImpl(
+      tensor, kernel_size, stride_size, padding_size, pool_type, axis, ceil_mode, exclusive, false, output_name);
 }
 
 std::vector<Tensor> GlobalPool2d(const Tensor &tensor, const std::string &pool_type, const std::string &output_name) {

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -750,6 +750,7 @@ std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string
         return lang::ReduceSum(lang::Exp(A(new_indice)), {reduce_axis});
       },
       UniqName("softmax_temp_out"));
+  temp->WithBuffer("local");
 
   ir::Tensor out = Compute(
       A->shape,
@@ -762,7 +763,7 @@ std::vector<ir::Tensor> Softmax(const ir::Tensor &A, int axis, const std::string
         }
         return lang::Exp(A(indice)) / temp(new_indice);
       },
-      UniqName("softmax_out"));
+      output_name);
   return {out, temp};
 }
 
@@ -790,7 +791,7 @@ std::vector<ir::Tensor> SoftmaxMKLDNN(const ir::Tensor &A, int axis, const std::
                                     A,           // input
                                 });
       },
-      UniqName("softmax_mkldnn_out"));
+      output_name);
   auto out = call->TupleGet(0);
   out->WithBuffer(A->type());
   return {out, call};
@@ -1182,16 +1183,8 @@ std::vector<Tensor> Pool2d(const Tensor &tensor,
   CHECK(tensor->shape.size() == 4U || tensor->shape.size() == 5U)
       << "pool2d requires tensor's shape_size to be 4 or 5\n";
   std::vector<int> axis = {height_axis, width_axis};
-  return PoolImpl(tensor,
-                  kernel_size,
-                  stride_size,
-                  padding_size,
-                  pool_type,
-                  axis,
-                  ceil_mode,
-                  exclusive,
-                  adaptive,
-                  UniqName(output_name));
+  return PoolImpl(
+      tensor, kernel_size, stride_size, padding_size, pool_type, axis, ceil_mode, exclusive, adaptive, output_name);
 }
 
 std::vector<Tensor> Pool3d(const Tensor &tensor,

--- a/cinn/lang/lower.cc
+++ b/cinn/lang/lower.cc
@@ -33,59 +33,50 @@ namespace lang {
 using ir::Tensor;
 using poly::Stage;
 
-// Returns true if input string to_check is prefix([_0-9])*
-bool IsUniqRename(const std::string& to_check, const std::string& prefix) {
-  if (to_check.rfind(prefix, 0) != 0) {
-    return false;
-  }
-  for (int i = prefix.size(); i < to_check.size(); ++i) {
-    if (to_check[i] != '_' && (to_check[i] < '0' || to_check[i] > '9')) {
-      return false;
-    }
-  }
-  return true;
-}
-
 std::vector<ir::Argument> GetArgs(const Expr& func_body, const std::vector<std::string>& input_output_nodes) {
-  std::map<std::string, const ir::Store*> name_to_store;
-  auto store_nodes = ir::CollectIRNodesWithoutTensor(func_body, [&](const Expr* x) {
-    const ir::Store* p = x->As<ir::Store>();
-    if (p) {
-      name_to_store[p->tensor.as_tensor_ref()->name] = p;
-    }
-    return p;
-  });
-
-  std::map<std::string, const ir::Load*> name_to_load;
-  auto load_nodes = ir::CollectIRNodesWithoutTensor(func_body, [&](const Expr* x) {
-    const ir::Load* p = x->As<ir::Load>();
-    if (p) {
-      name_to_load[p->tensor.as_tensor_ref()->name] = p;
-    }
-    return p;
-  });
-
   std::vector<ir::Argument> res;
-  for (const std::string& i : input_output_nodes) {
-    for (const auto& name_load_pair : name_to_load) {
-      const std::string& name = name_load_pair.first;
-      if (IsUniqRename(name, i) && name_to_store.find(name) == name_to_store.end()) {
-        auto load_tensor = name_load_pair.second->tensor.as_tensor_ref();
-        res.emplace_back(load_tensor->buffer, ir::Argument::IO::kInput);
-      }
-    }
+  std::map<std::string, std::set<const ir::Load*>> name2loads;
+  std::map<std::string, std::set<const ir::Store*>> name2stores;
+  auto load_or_store_nodes = ir::CollectIRNodesWithoutTensor(
+      func_body, [&](const Expr* x) { return x->As<ir::Store>() || x->As<ir::Load>(); });
 
-    for (const auto& name_store_pair : name_to_store) {
-      const std::string& name = name_store_pair.first;
-      if (IsUniqRename(name, i)) {
-        auto store_tensor = name_store_pair.second->tensor.as_tensor_ref();
-        res.emplace_back(store_tensor->buffer, ir::Argument::IO::kOutput);
+  for (auto&& e : load_or_store_nodes) {
+    if (e.As<ir::Load>()) {
+      auto&& tensor_name = e.As<ir::Load>()->tensor.as_tensor()->name;
+      name2loads[tensor_name].insert(e.As<ir::Load>());
+    } else {  // Store node
+      auto&& tensor_name = e.As<ir::Store>()->tensor.as_tensor()->name;
+      name2stores[tensor_name].insert(e.As<ir::Store>());
+    }
+  }
+
+  for (auto&& node_name : input_output_nodes) {
+    auto load_it  = name2loads.find(node_name);
+    auto store_it = name2stores.find(node_name);
+    // if a node is ir::Load and also ir::Store, then process it as a ir::Store in priority.
+    if (store_it != name2stores.end()) {  //
+      for (auto&& node : store_it->second) {
+        const auto* tensor = node->tensor.as_tensor();
+        if (tensor->buffer.defined()) {
+          res.emplace_back(tensor->buffer, ir::Argument::IO::kOutput);
+          break;
+        }
+      }
+    } else if (load_it != name2loads.end()) {
+      for (auto&& node : load_it->second) {
+        const auto* tensor = node->tensor.as_tensor();
+        if (tensor->buffer.defined()) {
+          res.emplace_back(tensor->buffer, ir::Argument::IO::kInput);
+          break;
+        }
       }
     }
   }
 
-  for (auto& i : input_output_nodes) VLOG(3) << "In input_output_nodes, arg has : " << i;
-  for (auto& i : res) VLOG(3) << "In res, arg has : " << i.name();
+  if (VLOG_IS_ON(3)) {
+    for (auto& i : input_output_nodes) VLOG(3) << "In input_output_nodes, arg has : " << i;
+    for (auto& i : res) VLOG(3) << "In res, arg has : " << i.name();
+  }
   return res;
 }
 


### PR DESCRIPTION
1. 调整auto schedule的performance_comparison_test.cc单测no schedule、manual schedule、auto schedule三种模式下开启op fusion的实现方式，支持单测中单算子默认开启op fusion
2. 在op_fusion_pass.h中增加BuildNonFusedGroups接口，实现对图的每个算子构建一个默认的Graph::Group，并将parallel_compiler、auto schedule中需要该功能的地方统一使用该接口
3. 修复pool2d、pool1d的手工schedule中未使用输出名字导致的单测fail