### PR TITLE
Add cache write rule in auto schedule

### DIFF
--- a/cinn/auto_schedule/search_space/auto_gen_rule/CMakeLists.txt
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/CMakeLists.txt
@@ -6,9 +6,11 @@ gather_srcs(cinnapi_src SRCS
 	auto_unroll.cc
 	multi_level_tiling.cc
 	skip_rule.cc
+  add_cache_write.cc
 	)
 
 cc_test(test_auto_inline SRCS auto_inline_test.cc DEPS cinncore)
 cc_test(test_multi_level_tiling SRCS multi_level_tiling_test.cc DEPS cinncore)
 cc_test(test_skip_rule SRCS skip_rule_test.cc DEPS cinncore)
 cc_test(test_auto_unroll SRCS auto_unroll_test.cc DEPS cinncore)
+cc_test(test_add_cache_write SRCS add_cache_write_test.cc DEPS cinncore)

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.cc
@@ -1,0 +1,140 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cinn/auto_schedule/analysis/analyze_ir.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h"
+#include "cinn/common/target.h"
+#include "cinn/ir/buffer.h"
+#include "cinn/ir/collect_ir_nodes.h"
+#include "cinn/ir/ir.h"
+#include "cinn/ir/ir_base.h"
+#include "cinn/ir/ir_printer.h"
+#include "cinn/ir/ir_schedule.h"
+#include "cinn/ir/ir_schedule_util.h"
+#include "cinn/ir/tensor.h"
+#include "cinn/optim/ir_copy.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+RuleApplyType AddCacheWrite::Init(ir::IRSchedule* ir_schedule) {
+  ir_schedule_        = ir_schedule;
+  auto block_realizes = ir_schedule_->GetAllBlocks();
+  applicable_schedule_blocks_.clear();
+  num_applicable_ = 0;
+  for (size_t i = 0; i < block_realizes.size(); ++i) {
+    ir::ScheduleBlockRealize* sch_block_realize = block_realizes[i].As<ir::ScheduleBlockRealize>();
+    AnalyzeScheduleBlockReadWriteBuffer(sch_block_realize->schedule_block.As<ir::ScheduleBlock>());
+    if (MeetCondition(block_realizes[i])) {
+      ++num_applicable_;
+      applicable_schedule_blocks_.push_back(block_realizes[i]);
+    }
+  }
+  VLOG(6) << "Collect applicable_schedule_blocks_:" << num_applicable_;
+
+  cache_memory_type_ = kMemoryTypes.at(target_->arch);
+
+  if (num_applicable_ > 0) {
+    if (*target_ == common::DefaultNVGPUTarget()) return RuleApplyType::kApplyAndSkipAllRules;
+    if (*target_ == common::DefaultHostTarget()) return RuleApplyType::kApplyAndSkipThisRule;
+  }
+
+  return RuleApplyType::kCannotApply;
+}
+
+void AddCacheWrite::Apply(int index) {
+  ir::Expr sch_block_expr = applicable_schedule_blocks_[index];
+
+  // Do schedule
+  ir::Expr cache_block = ir_schedule_->CacheWrite(sch_block_expr, 0, cache_memory_type_);
+  VLOG(6) << "cache block: " << cache_block;
+}
+
+// TODO: Merge this function and the same function in MultiLevelTiling rule
+bool NeedMultiLevelTiling(const ir::ScheduleBlockRealize& sch_block_realize) {
+  const ir::ScheduleBlock* sche_block = sch_block_realize.schedule_block.As<ir::ScheduleBlock>();
+  const ir::Expr& write_buffer        = sche_block->write_buffers[0].As<ir::_BufferRange_>()->buffer;
+
+  // Enumerate each read region, get the number of schedule block iter vars
+  // which  are not used to index the read region
+  int total_unused_iter_vars = 0;
+
+  for (const ir::Expr& read_buffer_expr : sche_block->read_buffers) {
+    const ir::_BufferRange_* read_buffer = read_buffer_expr.As<ir::_BufferRange_>();
+    // Skip the reduction buffer
+    if (read_buffer->buffer == write_buffer) {
+      continue;
+    }
+    // Collect the vars in schedule block that are used to index the read region
+    std::unordered_set<std::string> vars_index_read;
+    for (const Var& range : read_buffer->ranges) {
+      vars_index_read.insert(range->name);
+    }
+    // Check the block iter vars are not used to index the read region
+    int n_unused_block_vars = 0;
+    for (const ir::Var& block_iter_var : sche_block->iter_vars) {
+      bool iter_var_in_read = false;
+      for (const std::string& var : vars_index_read) {
+        if (var == block_iter_var->name) {
+          iter_var_in_read = true;
+          break;
+        }
+      }
+      if (!iter_var_in_read) {
+        ++n_unused_block_vars;
+      }
+    }
+    total_unused_iter_vars += n_unused_block_vars;
+  }
+
+  return total_unused_iter_vars >= 1;
+}
+
+bool AddCacheWrite::HasSingleElementwiseMatchedConsumer(const ir::Expr& block_expr) const {
+  ir::Expr root_block_expr        = ir_schedule_->GetRootBlock(block_expr);
+  std::vector<ir::Expr> consumers = ir::GetConsumers(block_expr, root_block_expr);
+  VLOG(6) << "xb_debug consumers.size() = " << consumers.size();
+  return false;
+}
+
+bool AddCacheWrite::MeetCondition(const ir::Expr& block_expr) const {
+  const ir::ScheduleBlockRealize* sch_block_realize = block_expr.As<ir::ScheduleBlockRealize>();
+  const ir::ScheduleBlock* sch_block                = sch_block_realize->schedule_block.As<ir::ScheduleBlock>();
+
+  if (sch_block->read_buffers.empty() || sch_block->write_buffers.size() != 1) {
+    return false;
+  }
+
+  if (!NeedMultiLevelTiling(*sch_block_realize)) return false;
+  if (HasSingleElementwiseMatchedConsumer(block_expr)) return false;
+
+  return true;
+}
+
+const std::unordered_map<common::Target::Arch, std::string> AddCacheWrite::kMemoryTypes{
+    {common::Target::Arch::X86, "local"}, {common::Target::Arch::NVGPU, "shared"}};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
+#include "cinn/common/target.h"
+#include "cinn/ir/ir.h"
+#include "cinn/ir/ir_base.h"
+#include "cinn/ir/ir_schedule.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+class AddCacheWrite : public AutoGenRule {
+ public:
+  AddCacheWrite(const common::Target& target) : AutoGenRule(target) {}
+  ~AddCacheWrite() = default;
+
+  // initailize the AddCacheWrite rule, it must be called before further actions.
+  RuleApplyType Init(ir::IRSchedule* init_schedule) override;
+
+  // Applies rule on the ir::ModuleExpr for a schedule block specified by index
+  // between 0 (inclusive) and NumberApplicable() (exclusive)
+  void Apply(int index) override;
+
+  // Return the name of the rule, used for debug.
+  std::string GetRuleName() const override { return "AddCacheWrite"; }
+
+  // Return whether the block has only one consumer and they are elementwise-matched.
+  bool HasSingleElementwiseMatchedConsumer(const ir::Expr& block_expr) const;
+
+  // Return true if the schedule block expr is applicable by AddCacheWrite
+  bool MeetCondition(const ir::Expr& block_expr) const;
+
+ private:
+  std::vector<Expr> applicable_schedule_blocks_;
+  std::string cache_memory_type_;
+
+  static const std::unordered_map<common::Target::Arch, std::string> kMemoryTypes;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.h
@@ -38,14 +38,12 @@ class AddCacheWrite : public AutoGenRule {
   // Return the name of the rule, used for debug.
   std::string GetRuleName() const override { return "AddCacheWrite"; }
 
-  // Return whether the block has only one consumer and they are elementwise-matched.
-  bool HasSingleElementwiseMatchedConsumer(const ir::Expr& block_expr) const;
-
+ private:
   // Return true if the schedule block expr is applicable by AddCacheWrite
   bool MeetCondition(const ir::Expr& block_expr) const;
 
  private:
-  std::vector<Expr> applicable_schedule_blocks_;
+  std::vector<ir::Expr> applicable_schedule_blocks_;
   std::string cache_memory_type_;
 
   static const std::unordered_map<common::Target::Arch, std::string> kMemoryTypes;

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -23,12 +23,8 @@
 
 #include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
 #include "cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h"
-#include "cinn/backends/codegen_cuda_dev.h"
 #include "cinn/backends/compiler.h"
-#include "cinn/backends/nvrtc_util.h"
 #include "cinn/cinn.h"
-#include "cinn/common/cuda_test_helper.h"
-#include "cinn/common/test_helper.h"
 #include "cinn/ir/ir.h"
 #include "cinn/ir/ir_base.h"
 #include "cinn/ir/ir_printer.h"

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -1,0 +1,183 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
+#include "cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h"
+#include "cinn/backends/codegen_c.h"
+#include "cinn/backends/codegen_cuda_dev.h"
+#include "cinn/backends/compiler.h"
+#include "cinn/backends/nvrtc_util.h"
+#include "cinn/cinn.h"
+#include "cinn/common/cuda_test_helper.h"
+#include "cinn/common/test_helper.h"
+#include "cinn/ir/ir.h"
+#include "cinn/ir/ir_base.h"
+#include "cinn/ir/ir_printer.h"
+#include "cinn/ir/ir_schedule.h"
+#include "cinn/ir/module.h"
+#include "cinn/ir/tensor.h"
+#include "cinn/lang/compute.h"
+#include "cinn/lang/lower.h"
+#include "cinn/poly/stage.h"
+#include "cinn/utils/string.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+void naive_matmul(float* A, float* B, float* C, int M, int N, int K) {
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      for (int k = 0; k < K; ++k) {
+        C[i * N + j] += A[i * K + k] * B[k * N + j];
+      }
+    }
+  }
+}
+
+TEST(AddCacheWrite, Init) {
+  srand(0);
+  Context::Global().ResetNameId();
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
+  Target target = common::DefaultHostTarget();
+#endif
+
+  Expr M(32);
+  Expr N(32);
+  Expr K(32);
+
+  // matmul case
+  Placeholder<float> A("A", {M, K});
+  Placeholder<float> B("B", {K, N});
+
+  Var k(K.as_int32(), "reduce_axis_k");
+  ir::Tensor C = Compute(
+      {M, N}, [&](Var i, Var j) { return ReduceSum(A(i, k) * B(k, j), {k}); }, "C");
+
+  poly::StageMap stages = CreateStages({C});
+  std::vector<ir::LoweredFunc> funcs =
+      lang::LowerVec("TestAddCacheWrite_InitTrue", stages, {C}, {}, {}, nullptr, target, true);
+
+  ir::Expr matmul_expr = funcs[0]->body;
+  VLOG(6) << "Matmul Expr before AddCacheWrite: ";
+  VLOG(6) << matmul_expr;
+
+  ir::IRSchedule ir_schedule_matmul(ir::ModuleExpr({matmul_expr}));
+
+  AddCacheWrite add_cache_write(target);
+  EXPECT_EQ(add_cache_write.Init(&ir_schedule_matmul), RuleApplyType::kApplyAndSkipAllRules);
+  EXPECT_EQ(add_cache_write.NumberApplicable(), 1);
+
+  add_cache_write.ApplyRandomly();
+  std::vector<ir::Expr> exprs = ir_schedule_matmul.GetModule().GetExprs();
+  EXPECT_EQ(exprs.size(), 1UL);
+  VLOG(6) << "Matmul Expr after AddCacheWrite: " << exprs[0];
+
+  // add case
+  Placeholder<float> D("D", {M, K});
+  Placeholder<float> E("E", {K, N});
+  ir::Tensor F = Compute(
+      {M, N}, [&](Var i, Var j) { return D(i, j) * E(i, j); }, "F");
+
+  poly::StageMap stages_add = CreateStages({F});
+  std::vector<ir::LoweredFunc> funcs_add =
+      lang::LowerVec("TestAddCacheWrite_InitFalse", stages_add, {F}, {}, {}, nullptr, target, true);
+
+  ir::Expr add_expr = funcs_add[0]->body;
+  VLOG(6) << "Mat Add Expr before AddCacheWrite: ";
+  VLOG(6) << add_expr;
+
+  ir::IRSchedule ir_schedule_add(ir::ModuleExpr({add_expr}));
+
+  AddCacheWrite add_cache_write2(target);
+  EXPECT_EQ(add_cache_write2.Init(&ir_schedule_add), RuleApplyType::kCannotApply);
+  EXPECT_EQ(add_cache_write2.NumberApplicable(), 0);
+}
+
+TEST(AddCacheWrite, MatrixMultiply) {
+  srand(0);
+  Context::Global().ResetNameId();
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
+  Target target = common::DefaultHostTarget();
+#endif
+
+  Expr M(32);
+  Expr N(32);
+  Expr K(32);
+
+  Placeholder<float> A("A", {M, K});
+  Placeholder<float> B("B", {K, N});
+
+  Var k(K.as_int32(), "reduce_axis_k");
+  ir::Tensor C = Compute(
+      {M, N}, [&](Var i, Var j) { return ReduceSum(A(i, k) * B(k, j), {k}); }, "C");
+
+  poly::StageMap stages = CreateStages({C});
+  std::vector<ir::LoweredFunc> funcs =
+      lang::LowerVec("TestAddCacheWrite_MatrixMultiply", stages, {A, B, C}, {}, {}, nullptr, target, true);
+
+  ir::Expr ast_expr = funcs[0]->body;
+  VLOG(6) << "Expr before MultiLevelTiling: ";
+  VLOG(6) << ast_expr;
+
+  ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
+
+  // Apply MultiLevelTiling before AddCacheWrite
+  MultiLevelTiling multi_level_tiling(target);
+  EXPECT_EQ(multi_level_tiling.Init(&ir_schedule), RuleApplyType::kApplyAndSkipThisRule);
+  EXPECT_EQ(multi_level_tiling.NumberApplicable(), 1);
+
+  multi_level_tiling.ApplyRandomly();
+  std::vector<ir::Expr> exprs = ir_schedule.GetModule().GetExprs();
+  EXPECT_EQ(exprs.size(), 1UL);
+  VLOG(6) << "Expr after MultiLevelTiling: " << exprs[0];
+
+  // Apply AddCacheWrite
+  AddCacheWrite add_cache_write(target);
+  EXPECT_EQ(add_cache_write.Init(&ir_schedule), RuleApplyType::kApplyAndSkipAllRules);
+  EXPECT_EQ(add_cache_write.NumberApplicable(), 1);
+
+  add_cache_write.ApplyRandomly();
+  exprs = ir_schedule.GetModule().GetExprs();
+  EXPECT_EQ(exprs.size(), 1UL);
+  VLOG(6) << "Expr after AddCacheWrite: " << exprs[0];
+
+  auto temp_buffers = lang::GetTempBuffers({A, B, C}, stages, exprs[0]);
+  auto func         = ir::_LoweredFunc_::Make(funcs[0]->name, funcs[0]->args, funcs[0]->body, temp_buffers);
+
+  ir::Module::Builder builder("test_bulder", target);
+  builder.AddFunction(func);
+  auto build_module = builder.Build();
+
+  auto compiler = backends::Compiler::Create(target);
+  compiler->Build(build_module);
+
+  auto test_func_ptr =
+      reinterpret_cast<void (*)(void**, int32_t)>(compiler->Lookup("TestAddCacheWrite_MatrixMultiply"));
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -41,16 +41,6 @@
 namespace cinn {
 namespace auto_schedule {
 
-void naive_matmul(float* A, float* B, float* C, int M, int N, int K) {
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
-      for (int k = 0; k < K; ++k) {
-        C[i * N + j] += A[i * K + k] * B[k * N + j];
-      }
-    }
-  }
-}
-
 TEST(AddCacheWrite, Init) {
   srand(0);
   Context::Global().ResetNameId();
@@ -181,9 +171,6 @@ TEST(AddCacheWrite, MatrixMultiply) {
 
   auto compiler = backends::Compiler::Create(target);
   compiler->Build(build_module);
-
-  auto test_func_ptr =
-      reinterpret_cast<void (*)(void**, int32_t)>(compiler->Lookup("TestAddCacheWrite_MatrixMultiply"));
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -83,7 +83,12 @@ TEST(AddCacheWrite, Init) {
   ir::IRSchedule ir_schedule_matmul(ir::ModuleExpr({matmul_expr}));
 
   AddCacheWrite add_cache_write(target);
-  EXPECT_EQ(add_cache_write.Init(&ir_schedule_matmul), RuleApplyType::kApplyAndSkipAllRules);
+  auto apply_type = add_cache_write.Init(&ir_schedule_matmul);
+#ifdef CINN_WITH_CUDA
+  EXPECT_EQ(apply_type, RuleApplyType::kApplyAndSkipAllRules);
+#else
+  EXPECT_EQ(apply_type, RuleApplyType::kApplyAndSkipThisRule);
+#endif
   EXPECT_EQ(add_cache_write.NumberApplicable(), 1);
 
   add_cache_write.ApplyRandomly();
@@ -154,7 +159,12 @@ TEST(AddCacheWrite, MatrixMultiply) {
 
   // Apply AddCacheWrite
   AddCacheWrite add_cache_write(target);
-  EXPECT_EQ(add_cache_write.Init(&ir_schedule), RuleApplyType::kApplyAndSkipAllRules);
+  auto apply_type = add_cache_write.Init(&ir_schedule);
+#ifdef CINN_WITH_CUDA
+  EXPECT_EQ(apply_type, RuleApplyType::kApplyAndSkipAllRules);
+#else
+  EXPECT_EQ(apply_type, RuleApplyType::kApplyAndSkipThisRule);
+#endif
   EXPECT_EQ(add_cache_write.NumberApplicable(), 1);
 
   add_cache_write.ApplyRandomly();

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -23,7 +23,6 @@
 
 #include "cinn/auto_schedule/search_space/auto_gen_rule/auto_gen_rule.h"
 #include "cinn/auto_schedule/search_space/auto_gen_rule/multi_level_tiling.h"
-#include "cinn/backends/codegen_c.h"
 #include "cinn/backends/codegen_cuda_dev.h"
 #include "cinn/backends/compiler.h"
 #include "cinn/backends/nvrtc_util.h"
@@ -36,8 +35,6 @@
 #include "cinn/ir/ir_schedule.h"
 #include "cinn/ir/module.h"
 #include "cinn/ir/tensor.h"
-#include "cinn/lang/compute.h"
-#include "cinn/lang/lower.h"
 #include "cinn/poly/stage.h"
 #include "cinn/utils/string.h"
 
@@ -63,9 +60,9 @@ TEST(AddCacheWrite, Init) {
   Target target = common::DefaultHostTarget();
 #endif
 
-  Expr M(32);
-  Expr N(32);
-  Expr K(32);
+  ir::Expr M(32);
+  ir::Expr N(32);
+  ir::Expr K(32);
 
   // matmul case
   Placeholder<float> A("A", {M, K});
@@ -124,9 +121,9 @@ TEST(AddCacheWrite, MatrixMultiply) {
   Target target = common::DefaultHostTarget();
 #endif
 
-  Expr M(32);
-  Expr N(32);
-  Expr K(32);
+  ir::Expr M(32);
+  ir::Expr N(32);
+  ir::Expr K(32);
 
   Placeholder<float> A("A", {M, K});
   Placeholder<float> B("B", {K, N});
@@ -166,7 +163,7 @@ TEST(AddCacheWrite, MatrixMultiply) {
   VLOG(6) << "Expr after AddCacheWrite: " << exprs[0];
 
   auto temp_buffers = lang::GetTempBuffers({A, B, C}, stages, exprs[0]);
-  auto func         = ir::_LoweredFunc_::Make(funcs[0]->name, funcs[0]->args, funcs[0]->body, temp_buffers);
+  auto func         = ir::_LoweredFunc_::Make(funcs[0]->name, funcs[0]->args, exprs[0], temp_buffers);
 
   ir::Module::Builder builder("test_bulder", target);
   builder.AddFunction(func);


### PR DESCRIPTION
This pr add the AddCacheWrite rule in auto schedule.
Now the condition for applying this rule is only one: MultiLevelTiling is required for the block.
When applying this rule, we just call CacheWrite schedule primitives.
The following problems remain:
1. The function NeedMultiLevelTiling() is the same as that in MultiLevelTiling. It needs to be placed in the public area for calling.
2. After we implement the ReverseComputeAt schedule primitive, put the new cache buffer from CacheWrite into the appropriate loop.
3. The accuracy test needs to be added. 