### PR TITLE
introduces stl needed by nvrtc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ include(cmake/external/protobuf.cmake)
 include(cmake/external/mklml.cmake)
 include(cmake/external/mkldnn.cmake)
 include(cmake/external/openmp.cmake)
+include(cmake/external/jitify.cmake)
 find_package(Threads REQUIRED)
 
 set(LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_SOURCE_DIR}/cmake/export.map" CACHE INTERNAL "")
@@ -106,7 +107,8 @@ message(STATUS "PYTHON_LIBRARIES: ${PYTHON_LIBRARIES}")
 message(STATUS "PYTHON_INCLUDE_DIR: ${PYTHON_INCLUDE_DIR}")
 
 INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIR})
-cc_library(cinnapi SHARED SRCS ${cinnapi_src} DEPS glog ${llvm_libs} framework_proto param_proto auto_schedule_proto schedule_desc_proto absl isl ginac pybind)
+cc_library(cinnapi SHARED SRCS ${cinnapi_src} DEPS glog ${llvm_libs} framework_proto param_proto
+ auto_schedule_proto schedule_desc_proto absl isl ginac pybind ${jitify_deps})
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
 
@@ -150,7 +152,8 @@ function(gen_cinncore LINKTYPE)
   endif()
 
   if (WITH_CUDA)
-    target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN})
+    target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN} 
+      ${jitify_deps})
     if (NVTX_FOUND)
       target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVTX_LIB})
     endif()

--- a/cinn/backends/CMakeLists.txt
+++ b/cinn/backends/CMakeLists.txt
@@ -1,11 +1,9 @@
 core_gather_headers()
 
-
 gather_srcs(cinnapi_src SRCS
     outputs.cc
     codegen_c.cc
     codegen_c_x86.cc
-    codegen_cuda_dev.cc
     codegen_cuda_host.cc
     extern_func_emitter.cc
     extern_func_emitter_builtin.cc
@@ -17,13 +15,16 @@ gather_srcs(cinnapi_src SRCS
 )
 
 if (WITH_CUDA)
-  list(APPEND srcs cuda_util.cc nvrtc_util.cc codegen_cuda_util.cc)
+  add_subdirectory(nvrtc)
+  list(APPEND srcs cuda_util.cc codegen_cuda_dev.cc codegen_cuda_util.cc)
 endif()
 
 cc_library(__x86_source_fake_lib SRCS _x86_builtin_source.cc)
 add_subdirectory(llvm)
 
+
 if (WITH_CUDA)
+    
     nv_test(test_raw_cuda_code SRCS raw_cuda_code_test.cu DEPS cinncore)
 endif()
 
@@ -40,7 +41,6 @@ endif()
 if (WITH_CUDA)
   nv_test(test_codegen_cuda_generate SRCS codegen_cuda_generate_test.cc DEPS cinncore)
   nv_test(test_codegen_cuda_dev SRCS codegen_cuda_dev_test.cc ../common/cuda_test_helper.cc DEPS cinncore)
-  nv_test(test_nvrtc_util SRCS nvrtc_util_test.cc DEPS cinncore)
   nv_test(test_codegen_debug SRCS codegen_debug_test.cc DEPS cinncore)
 
   if (WITH_TESTING)

--- a/cinn/backends/codegen_c.cc
+++ b/cinn/backends/codegen_c.cc
@@ -62,7 +62,6 @@ void CodeGenC::Compile(const ir::Module &module, const Outputs &outputs) {
 CodeGenC::CodeGenC(Target target) : ir::IrPrinter(ss_) {}
 
 std::string CodeGenC::Compile(const ir::Module &module, OutputKind output_kind) {
-  ss_.str("");
   if (output_kind == OutputKind::CHeader) {
     GenerateHeaderFile(module);
   } else if (output_kind == OutputKind::CImpl) {

--- a/cinn/backends/codegen_cuda_dev.h
+++ b/cinn/backends/codegen_cuda_dev.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "cinn/backends/codegen_c.h"
+#include "cinn/backends/nvrtc/header_generator.h"
 #include "cinn/common/common.h"
 #include "cinn/ir/ir.h"
 #include "cinn/ir/ir_printer.h"
@@ -65,6 +66,8 @@ class CodeGenCUDA_Dev : public CodeGenC {
 
   std::string Compile(const ir::Module& module, OutputKind output_kind);
 
+  const std::string& GetSourceHeader() const;
+
  protected:
   void Visit(const ir::_Var_* op) override;
   void Visit(const ir::_LoweredFunc_* op) override;
@@ -101,6 +104,8 @@ class CodeGenCUDA_Dev : public CodeGenC {
   // names of vectorized tensors from `Let` statments where dtypes of the tensors
   // are customized_type with customized_type::kcuda_builtin_vector_t prefix
   std::unordered_set<std::string> vectorized_tensor_names_;
+  std::unique_ptr<backends::HeaderGeneratorBase> generator_;
+  static const std::string source_header_;
 };
 
 }  // namespace backends

--- a/cinn/backends/codegen_cuda_dev_test.cc
+++ b/cinn/backends/codegen_cuda_dev_test.cc
@@ -26,7 +26,7 @@
 #include "cinn/backends/extern_func_jit_register.h"
 #include "cinn/backends/llvm/execution_engine.h"
 #include "cinn/backends/llvm/simple_jit.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/cinn.h"
 #include "cinn/common/cuda_test_helper.h"
 #include "cinn/common/ir_util.h"
@@ -132,7 +132,7 @@ TEST(CodeGenCUDA2, test_of_cacheread) {
 
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -210,18 +210,8 @@ TEST(CodeGenCUDA2, test_of_splitcudakernel) {
 
   LOG(INFO) << "compiled test_of_splitcudakernel code:\n\n\n" << source_code;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(200) elementwise_mul_and_add(const float* __restrict__ X, const float* __restrict__ Y, float* __restrict__ C)
@@ -276,18 +266,8 @@ TEST(CodeGenCUDA2, test_of_splitouter) {
 
   LOG(INFO) << "compiled test_of_splitouter code:\n\n\n" << source_code;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(5) elementwise_add_splitouter(const float* __restrict__ X, const float* __restrict__ Y, float* __restrict__ C)
@@ -309,7 +289,7 @@ void __launch_bounds__(5) elementwise_add_splitouter(const float* __restrict__ X
 
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -376,7 +356,7 @@ TEST(GlobalPool, pool2d_max) {
   LOG(INFO) << "compiled global_pool2d_max code:\n\n\n" << source_code;
 
   using runtime::cuda::CUDAModule;
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
   CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
@@ -443,7 +423,7 @@ TEST(GlobalPool, pool2d_avg) {
   LOG(INFO) << "compiled global_pool2d_avg code:\n\n\n" << source_code;
 
   using runtime::cuda::CUDAModule;
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
   CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
@@ -510,7 +490,7 @@ TEST(GlobalPool, pool2d_avg_1_1_7_7) {
   LOG(INFO) << "compiled global_pool2d_avg code:\n\n\n" << source_code;
 
   using runtime::cuda::CUDAModule;
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
   CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
@@ -579,7 +559,7 @@ TEST(GlobalPool, pool2d_avg_1_32_7_7) {
   LOG(INFO) << "compiled global_pool2d_avg code:\n\n\n" << source_code;
 
   using runtime::cuda::CUDAModule;
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
   CUDAModule cuda_module(ptx, CUDAModule::Kind::PTX);
@@ -650,18 +630,8 @@ TEST(CodeGenCUDA2, test_schedule_conv2d_0) {
 
   LOG(INFO) << "compiled schedule_conv2d_0 code:\n\n\n" << source_code;
 
-  std::string source_target        = R"ROC(
+  std::string source_target        = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(224) schedule_conv2d_0(const float* __restrict__ X, const float* __restrict__ Y, float* __restrict__ COD)
@@ -718,7 +688,7 @@ void __launch_bounds__(224) schedule_conv2d_0(const float* __restrict__ X, const
   // ASSERT_EQ(trimed_source_target.substr(start_target), source_code.substr(start_source));
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -796,18 +766,8 @@ TEST(CodeGenCUDA2, test_schedule_conv2d_1) {
 
   LOG(INFO) << "compiled schedule_conv2d_1 code:\n\n\n" << source_code;
 
-  std::string source_target        = R"ROC(
+  std::string source_target        = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(128) schedule_conv2d_1(const float* __restrict__ X, const float* __restrict__ Y, float* __restrict__ Conv2d_out)
@@ -866,7 +826,7 @@ void __launch_bounds__(128) schedule_conv2d_1(const float* __restrict__ X, const
   // ASSERT_EQ(trimed_source_target.substr(start_target), source_code.substr(start_source));
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -972,7 +932,7 @@ void __launch_bounds__(128) schedule_conv2d_1(const float* __restrict__ X, const
   }
   )ROC";
 
-  backends::NVRTC_Compiler compiler_tvm;
+  backends::nvrtc::Compiler compiler_tvm;
 
   auto ptx_tvm = compiler_tvm(source_tvm);
   CHECK(!ptx_tvm.empty());
@@ -1032,18 +992,8 @@ TEST(CodeGenCUDA, test_of_syncthreads) {
 
   LOG(INFO) << "compiled test_of_syncthreads code:\n\n\n" << source_code;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(200) elementwise_add(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -1070,7 +1020,7 @@ void __launch_bounds__(200) elementwise_add(const float* __restrict__ A, const f
   // compile the code
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -1141,18 +1091,8 @@ TEST(CodeGenCUDA3, test_of_mul_cachewrite) {
 
   LOG(INFO) << "compiled CacheWrite and Reduce code:\n\n\n" << source_code;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(4) mul_cache_write(const float* __restrict__ A1, const float* __restrict__ B1, float* __restrict__ C1)
@@ -1183,7 +1123,7 @@ void __launch_bounds__(4) mul_cache_write(const float* __restrict__ A1, const fl
 
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -1263,7 +1203,7 @@ class ElementwiseTester {
     // compile the code
     using runtime::cuda::CUDAModule;
 
-    backends::NVRTC_Compiler compiler;
+    backends::nvrtc::Compiler compiler;
 
     auto ptx = compiler(source_code);
     CHECK(!ptx.empty());
@@ -1488,7 +1428,7 @@ TEST(CodeGenCUDA, jit_host_call_cuda_kernel) {
 
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -1699,7 +1639,7 @@ TEST(elementwise_add1, share_local_cache) {
   CodeGenCUDA_Dev codegen(common::DefaultNVGPUTarget());
   auto source_code = codegen.Compile(builder.Build());
   LOG(INFO) << "device source code elementwise_add1: " << source_code;
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   common::CudaModuleTester tester;
   tester.Compile(module);
@@ -1793,7 +1733,7 @@ TEST(elementwise_add0, share_local_cache) {
 
   LOG(INFO) << "device source code elementwise_add0:\n" << source_code;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   common::CudaModuleTester tester;
   tester.Compile(module);
@@ -1941,18 +1881,8 @@ TEST(ElementwiseAdd, cache_read_local) {
   auto source_code = codegen.Compile(module);
   LOG(INFO) << "source cache_read_local:\n" << source_code;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(10) fn0(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -1977,7 +1907,7 @@ void __launch_bounds__(10) fn0(const float* __restrict__ A, const float* __restr
 )ROC";
   ASSERT_EQ(utils::Trim(source_target), source_code);
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   common::CudaModuleTester tester;
   tester.Compile(module);
@@ -2078,18 +2008,8 @@ TEST(ElementwiseAdd, cache_read1) {
   auto source_code = codegen.Compile(builder.Build());
   std::cout << "CUDA source of ComputeAt2 & CacheRead\n" << source_code << std::endl;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(98) fn1(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -2184,18 +2104,8 @@ TEST(ElementwiseAdd, cache_read_compute_at1) {
   auto source_code = codegen.Compile(builder.Build());
   LOG(INFO) << "CUDA source of cache_read_compute_at1:\n" << source_code << std::endl;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(95) fn_cacheread_computeat1(const float* __restrict__ AA, float* __restrict__ C)
@@ -2287,18 +2197,8 @@ TEST(ElementwiseAdd, cache_read_compute_at2) {
   auto source_code = codegen.Compile(builder.Build());
   LOG(INFO) << "CUDA source of cache_read_compute_at2:\n" << source_code << std::endl;
 
-  std::string source_target = R"ROC(
+  std::string source_target = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(5) fn_cacheread_computeat2(const float* __restrict__ AA, float* __restrict__ C)
@@ -2451,18 +2351,8 @@ TEST(ElementwiseAdd, cache_read_shared) {
   auto source_code = codegen.Compile(builder.Build());
   std::cout << "CUDA source2:\n" << source_code << std::endl;
 
-  auto target_source = R"ROC(
+  std::string target_source = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(1) fn2(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -2535,18 +2425,8 @@ TEST(ElementwiseAdd, cache_write_local) {
   auto source_code = codegen.Compile(builder.Build());
   std::cout << "CUDA source cache_write:\n" << source_code << std::endl;
 
-  auto target_source = R"ROC(
+  std::string target_source = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(4) cache_write_local(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -2621,18 +2501,8 @@ TEST(Cuda, external_function) {
   auto source_code = codegen.Compile(builder.Build());
   std::cout << "CUDA source:\n" << source_code << std::endl;
 
-  auto target_source = R"ROC(
+  std::string target_source = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(4) external_function(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -2702,20 +2572,10 @@ TEST(CodeGenCUDA2, test_schedule_winograd_conv2dc) {
 
   LOG(INFO) << "compiled schedule_wino_conv2d code:\n\n\n" << wino_source_code;
 
-  backends::NVRTC_Compiler wino_compiler;
+  backends::nvrtc::Compiler wino_compiler;
 
-  std::string target_code = R"ROC(
+  std::string target_code = wino_codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(128) schedule_wino_conv2d(const float* __restrict__ X, float* __restrict__ data_pack)
@@ -3039,7 +2899,7 @@ TEST(CodeGenCUDA2, test_of_slice_assign) {
 
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
@@ -3098,18 +2958,8 @@ TEST(Cuda, type_vectorize) {
   auto source_code = codegen.Compile(builder.Build());
   LOG(INFO) << "CUDA source:\n" << source_code;
 
-  auto target_source = R"ROC(
+  std::string target_source = codegen.GetSourceHeader() + R"ROC(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(128) add_vectorize(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)

--- a/cinn/backends/codegen_debug_test.cc
+++ b/cinn/backends/codegen_debug_test.cc
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <vector>
 
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/common/context.h"
 #include "cinn/runtime/cuda/cuda_module.h"
 
@@ -110,7 +110,7 @@ void __launch_bounds__(512) fn_relu_1_kernel(const float* __restrict__ var_1, fl
 }
 )ROC";
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   std::string ptx = compiler(source_code);
   ASSERT_FALSE(ptx.empty());

--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -22,7 +22,7 @@
 #include "cinn/backends/codegen_cuda_dev.h"
 #include "cinn/backends/codegen_cuda_host.h"
 #include "cinn/backends/codegen_cuda_util.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/runtime/cuda/cuda_module.h"
 #include "cinn/runtime/cuda/cuda_util.h"
 #endif
@@ -101,7 +101,7 @@ void Compiler::CompileCudaModule(const Module& module, const std::string& code) 
   }
   using runtime::cuda::CUDAModule;
 
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());

--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -1101,18 +1101,7 @@ TEST(IrSchedule, compute_at4) {
 
   VLOG(1) << "compute_at4 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_compute_at4(const float* __restrict__ A, float* __restrict__ C)
 {
   float _B_temp_buffer [ 32768 ];
@@ -1173,18 +1162,8 @@ TEST(IrSchedule, compute_at5) {
 
   VLOG(1) << "compute_at5 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() +
+                            R"ROC(__global__
 void test_compute_at5(const float* __restrict__ A, float* __restrict__ C)
 {
   float _B_temp_buffer [ 4096 ];
@@ -1251,18 +1230,7 @@ TEST(IrSchedule, compute_at6) {
 
   VLOG(1) << "compute_at6 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_compute_at6(const float* __restrict__ A, float* __restrict__ C)
 {
   float _B_temp_buffer [ 4096 ];
@@ -1632,18 +1600,7 @@ TEST(IrSchedule, cache_read3) {
 
   VLOG(1) << "cache_read3 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_cache_read3(const float* __restrict__ A, float* __restrict__ C)
 {
   float _B_temp_buffer [ 1024 ];
@@ -1725,18 +1682,7 @@ TEST(IrSchedule, cache_write3) {
 
   VLOG(1) << "cache_write3 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_cache_write3(const float* __restrict__ A, float* __restrict__ C)
 {
   __shared__ float _B_temp_buffer [ 2048 ];
@@ -1818,18 +1764,7 @@ TEST(IrSchedule, sync_threads) {
 
   LOG(INFO) << "sync_threads source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_sync_threads(const float* __restrict__ A, float* __restrict__ C)
 {
   __shared__ float _B_temp_buffer [ 2048 ];
@@ -2504,18 +2439,7 @@ TEST(IrSchedule, compute_inline3) {
 
   VLOG(1) << "compute_inline3 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_compute_inline3(const float* __restrict__ A, float* __restrict__ C)
 {
   float _B_temp_buffer [ 32768 ];
@@ -2573,18 +2497,7 @@ TEST(IrSchedule, compute_inline4) {
 
   LOG(INFO) << "compute_inline4 source code is :\n" << source_code;
 
-  std::string target_code = R"ROC(
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
-
-__global__
+  std::string target_code = codegen.GetSourceHeader() + R"ROC(__global__
 void test_compute_inline4(const float* __restrict__ A, float* __restrict__ C)
 {
   float _B_temp_buffer [ 32768 ];

--- a/cinn/backends/nvrtc/CMakeLists.txt
+++ b/cinn/backends/nvrtc/CMakeLists.txt
@@ -1,0 +1,8 @@
+core_gather_headers()
+
+gather_srcs(cinnapi_src SRCS
+  header_generator.cc
+  nvrtc_util.cc
+)
+
+nv_test(test_nvrtc_util SRCS nvrtc_util_test.cc DEPS cinncore)

--- a/cinn/backends/nvrtc/header_generator.cc
+++ b/cinn/backends/nvrtc/header_generator.cc
@@ -1,0 +1,73 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/backends/nvrtc/header_generator.h"
+
+#include "glog/logging.h"
+#include "jitify.hpp"
+
+namespace cinn {
+namespace backends {
+namespace nvrtc {
+namespace {
+#ifdef NVRTC_STL_PATH
+static constexpr char* nvrtc_stl_path = NVRTC_STL_PATH;
+#else
+static constexpr char* nvrtc_stl_path = nullptr;
+#endif
+}  // namespace
+
+JitSafeHeaderGenerator::JitSafeHeaderGenerator() {
+  for (const auto& pair : headers_map_) {
+    header_names_.emplace_back(pair.first);
+  }
+}
+
+JitSafeHeaderGenerator::JitSafeHeaderGenerator(std::vector<std::string> header_names)
+    : header_names_{std::move(header_names)} {}
+
+void JitSafeHeaderGenerator::GenerateFiles(const std::string& dir) const {
+  std::ofstream os;
+  std::ifstream is;
+  // TODO(Shixiaowei02): parallel execution
+  for (const auto& name : header_names_) {
+    is.clear();
+    os.clear();
+    std::string full_path = dir + "/" + name;
+    is.open(full_path);
+    if (is.good()) {
+      is.close();
+      continue;
+    }
+    is.close();
+    os.open(full_path, std::ios_base::out);
+    os << headers_map_.at(name);
+    os.close();
+    if (!os) {
+      LOG(FATAL) << "file writing failed: " << full_path;
+    }
+  }
+}
+
+void JitSafeHeaderGenerator::GenerateFiles() const {
+  CHECK(nvrtc_stl_path) << "The default directory path does not exist.";
+  GenerateFiles(nvrtc_stl_path);
+}
+
+const std::map<std::string, std::string> JitSafeHeaderGenerator::headers_map_ =
+    jitify::detail::get_jitsafe_headers_map();
+
+}  // namespace nvrtc
+}  // namespace backends
+}  // namespace cinn

--- a/cinn/backends/nvrtc/header_generator.h
+++ b/cinn/backends/nvrtc/header_generator.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace cinn {
+namespace backends {
+class HeaderGeneratorBase {
+ public:
+  // Generate header files to the default directory.
+  virtual void GenerateFiles() const = 0;
+  // Generate header files to the specified directory.
+  virtual void GenerateFiles(const std::string& dir) const = 0;
+};
+
+namespace nvrtc {
+
+class JitSafeHeaderGenerator : public HeaderGeneratorBase {
+ public:
+  JitSafeHeaderGenerator();
+  explicit JitSafeHeaderGenerator(std::vector<std::string> header_names);
+  void GenerateFiles(const std::string& dir) const override;
+  void GenerateFiles() const override;
+
+ private:
+  std::vector<std::string> header_names_;
+  static const std::map<std::string, std::string> headers_map_;
+};
+
+}  // namespace nvrtc
+}  // namespace backends
+}  // namespace cinn

--- a/cinn/backends/nvrtc/nvrtc_util.cc
+++ b/cinn/backends/nvrtc/nvrtc_util.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -24,12 +24,20 @@
 
 namespace cinn {
 namespace backends {
+namespace nvrtc {
+namespace {
+#ifdef NVRTC_STL_PATH
+static constexpr char* nvrtc_stl_path = NVRTC_STL_PATH;
+#else
+static constexpr char* nvrtc_stl_path = nullptr;
+#endif
+}  // namespace
 
-std::string NVRTC_Compiler::operator()(const std::string& code, bool include_headers) {
+std::string Compiler::operator()(const std::string& code, bool include_headers) {
   return CompilePTX(code, include_headers);
 }
 
-std::vector<std::string> NVRTC_Compiler::FindCUDAIncludePaths() {
+std::vector<std::string> Compiler::FindCUDAIncludePaths() {
   const std::string delimiter = "/";
   std::string cuda_include_path;
   const char* cuda_path_env = std::getenv("CUDA_PATH");
@@ -52,11 +60,9 @@ std::vector<std::string> NVRTC_Compiler::FindCUDAIncludePaths() {
   return {cuda_include_path};
 }
 
-std::vector<std::string> NVRTC_Compiler::FindCINNRuntimeIncludePaths() {
-  return {Context::Global().runtime_include_dir()};
-}
+std::vector<std::string> Compiler::FindCINNRuntimeIncludePaths() { return {Context::Global().runtime_include_dir()}; }
 
-std::string NVRTC_Compiler::CompilePTX(const std::string& code, bool include_headers) {
+std::string Compiler::CompilePTX(const std::string& code, bool include_headers) {
   std::vector<std::string> compile_options;
   std::vector<const char*> param_cstrings{};
   nvrtcProgram prog;
@@ -73,6 +79,8 @@ std::string NVRTC_Compiler::CompilePTX(const std::string& code, bool include_hea
   }
 
   compile_options.push_back("-arch=compute_" + cc);
+  compile_options.push_back("-std=c++14");
+  compile_options.push_back("-default-device");
 
   if (include_headers) {  // prepare include headers
     auto cuda_headers = FindCUDAIncludePaths();
@@ -83,6 +91,9 @@ std::string NVRTC_Compiler::CompilePTX(const std::string& code, bool include_hea
     }
     for (auto& header : cinn_headers) {
       include_paths.push_back("--include-path=" + header);
+    }
+    if (nvrtc_stl_path) {
+      include_paths.push_back("--include-path=" + std::string{nvrtc_stl_path});
     }
 
     compile_options.insert(std::end(compile_options), include_paths.begin(), include_paths.end());
@@ -115,5 +126,6 @@ std::string NVRTC_Compiler::CompilePTX(const std::string& code, bool include_hea
   return ptx;
 }
 
+}  // namespace nvrtc
 }  // namespace backends
 }  // namespace cinn

--- a/cinn/backends/nvrtc/nvrtc_util.h
+++ b/cinn/backends/nvrtc/nvrtc_util.h
@@ -24,11 +24,12 @@
 
 namespace cinn {
 namespace backends {
+namespace nvrtc {
 
 /**
  * An helper class to call NVRTC. Input CUDA device source code, get PTX string.
  */
-class NVRTC_Compiler {
+class Compiler {
  public:
   /**
    * Compile the \p code and get PTX string.
@@ -59,6 +60,7 @@ class NVRTC_Compiler {
   std::string CompilePTX(const std::string& code, bool include_headers);
 };
 
+}  // namespace nvrtc
 }  // namespace backends
 }  // namespace cinn
 

--- a/cinn/backends/nvrtc/nvrtc_util_test.cc
+++ b/cinn/backends/nvrtc/nvrtc_util_test.cc
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 
 #include <gtest/gtest.h>
 
 namespace cinn {
 namespace backends {
+namespace nvrtc {
 
-TEST(NVRTC_Compiler, basic) {
-  NVRTC_Compiler compiler;
+TEST(Compiler, basic) {
+  Compiler compiler;
 
   std::string source_code = R"ROC(
 extern "C" __global__
@@ -38,5 +39,6 @@ void saxpy(float a, float *x, float *y, float *out, size_t n)
   LOG(INFO) << "ptx:\n" << ptx;
 }
 
+}  // namespace nvrtc
 }  // namespace backends
 }  // namespace cinn

--- a/cinn/common/context.cc
+++ b/cinn/common/context.cc
@@ -20,6 +20,7 @@
 #include <mutex>
 
 #include "cinn/ir/ir.h"
+#include "cinn/utils/string.h"
 
 namespace cinn {
 namespace common {
@@ -34,14 +35,21 @@ Context& Context::Global() {
   return x;
 }
 
-const std::string& Context::runtime_include_dir() {
+const std::vector<std::string>& Context::runtime_include_dir() {
   std::lock_guard<std::mutex> lock(mutex_);
   if (runtime_include_dir_.empty()) {
-    char* env            = std::getenv(kRuntimeIncludeDirEnvironKey);
-    runtime_include_dir_ = env ? env : "";  // Leave empty if no env found.
+    std::string env = std::getenv(kRuntimeIncludeDirEnvironKey);
+    if (env.size()) {
+      VLOG(4) << "-- runtime_include_dir: " << env;
+      runtime_include_dir_ = cinn::utils::Split(env, ":");
+    }
   }
-  VLOG(4) << "-- runtime_include_dir: " << runtime_include_dir_;
   return runtime_include_dir_;
+}
+
+void Context::AddRuntimeIncludeDir(std::string dir) {
+  // TODO(Shixiaowei02): path deduplication
+  runtime_include_dir_.emplace_back(std::move(dir));
 }
 
 const char* kRuntimeIncludeDirEnvironKey = "runtime_include_dir";

--- a/cinn/common/context.h
+++ b/cinn/common/context.h
@@ -64,7 +64,9 @@ class Context {
 
   void ResetNameId() { name_generator_.ResetID(); }
 
-  const std::string& runtime_include_dir();
+  const std::vector<std::string>& runtime_include_dir();
+
+  void AddRuntimeIncludeDir(std::string dir);
 
   /**
    * The global isl ctx.
@@ -79,7 +81,7 @@ class Context {
   Context() = default;
 
   NameGenerator name_generator_;
-  std::string runtime_include_dir_;
+  std::vector<std::string> runtime_include_dir_;
   mutable std::mutex mutex_;
 
   static thread_local isl::ctx ctx_;

--- a/cinn/common/cuda_test_helper.cc
+++ b/cinn/common/cuda_test_helper.cc
@@ -17,7 +17,7 @@
 #include "cinn/backends/codegen_cuda_dev.h"
 #include "cinn/backends/codegen_cuda_host.h"
 #include "cinn/backends/codegen_cuda_util.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/runtime/cuda/cuda_module.h"
 #include "cinn/runtime/cuda/cuda_util.h"
 
@@ -36,7 +36,7 @@ void CudaModuleTester::Compile(const ir::Module& m, const std::string& rewrite_c
   auto source_code = codegen.Compile(device_module);
 
   // compile CUDA kernel.
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   std::string ptx;
   if (rewrite_cuda_code.empty())

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -21,7 +21,7 @@
 #include "cinn/backends/codegen_cuda_util.h"
 #include "cinn/backends/cuda_util.h"
 #include "cinn/backends/llvm/execution_engine.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/common/target.h"
 #include "cinn/frontend/decomposer/test_helper.h"
 

--- a/cinn/hlir/framework/parallel_compiler.cc
+++ b/cinn/hlir/framework/parallel_compiler.cc
@@ -23,7 +23,7 @@
 #include "cinn/backends/codegen_cuda_util.h"
 #include "cinn/backends/llvm/codegen_x86.h"
 #include "cinn/backends/llvm/runtime_symbol_registry.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/common/context.h"
 #include "cinn/hlir/pass/op_fusion_pass.h"
 #include "cinn/ir/module.h"
@@ -175,7 +175,7 @@ void ParallelCompiler::Task::CodegenAndJit() {
     }
 
     using runtime::cuda::CUDAModule;
-    backends::NVRTC_Compiler compiler;
+    backends::nvrtc::Compiler compiler;
     auto ptx = compiler(cuda_c);
     CHECK(!ptx.empty());
 

--- a/cinn/hlir/op/contrib/arange_test.cc
+++ b/cinn/hlir/op/contrib/arange_test.cc
@@ -61,6 +61,7 @@ TEST(GenerateCode_Cpu, Arange) {
   VLOG(6) << code << std::endl;
 }
 
+#ifdef CINN_WITH_CUDA
 TEST(GenerateCode_Cuda, Arange) {
   common::Context::Global().ResetNameId();
 
@@ -88,6 +89,7 @@ TEST(GenerateCode_Cuda, Arange) {
   VLOG(6) << "Cuda Codegen result:";
   VLOG(6) << code << std::endl;
 }
+#endif
 
 }  // namespace op
 }  // namespace hlir

--- a/cinn/hlir/op/op_broadcast_test.cc
+++ b/cinn/hlir/op/op_broadcast_test.cc
@@ -171,18 +171,8 @@ TEST(Operator, Operator_ElementWise_Add_Test1) {
   auto source_code = codegen.Compile(module);
   LOG(INFO) << "Operator_ElementWise_Add_Test1 source code:\n" << source_code;
 
-  std::string target_code = R"ROC(
+  std::string target_code = codegen.GetSourceHeader() + R"(
 extern "C" {
-
-#include "cinn_cuda_runtime_source.cuh"
-
-#ifdef __CUDACC_RTC__
-typedef int int32_t;
-typedef char int8_t;
-typedef long int int64_t;
-#endif
-
-
 
 __global__
 void __launch_bounds__(1024) fn_add2(const float* __restrict__ A, const float* __restrict__ B, float* __restrict__ C)
@@ -197,7 +187,7 @@ void __launch_bounds__(1024) fn_add2(const float* __restrict__ A, const float* _
 }
 
 }
-)ROC";
+)";
   if (FLAGS_cinn_ir_schedule) {
     ASSERT_EQ(utils::Trim(target_code), source_code);
   }

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -27,7 +27,7 @@
 #include "cinn/backends/llvm/execution_engine.h"
 #include "cinn/backends/llvm/runtime_symbol_registry.h"
 #include "cinn/backends/llvm/simple_jit.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/cinn.h"
 #include "cinn/common/target.h"
 #include "cinn/common/test_helper.h"
@@ -279,7 +279,7 @@ void TestCaseForReduce(
   auto source_code = GenReduceCode(shape, dim, test_name, false, op_name).second;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 
@@ -352,7 +352,7 @@ TEST(Operator, Operator_Reduction_Case_6_4) {
   auto host_source = GenReduceCode(shape, dim, func_name);
 
   // compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(host_source.second);
   CHECK(!ptx.empty());
 

--- a/cinn/hlir/op/transform_test.cc
+++ b/cinn/hlir/op/transform_test.cc
@@ -26,7 +26,7 @@
 #include "cinn/backends/llvm/execution_engine.h"
 #include "cinn/backends/llvm/runtime_symbol_registry.h"
 #include "cinn/backends/llvm/simple_jit.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/cinn.h"
 #include "cinn/common/target.h"
 #include "cinn/common/test_helper.h"

--- a/cinn/hlir/pe/pe_transform_test.cc
+++ b/cinn/hlir/pe/pe_transform_test.cc
@@ -18,7 +18,7 @@
 #include "cinn/backends/codegen_cuda_util.h"
 #include "cinn/backends/cuda_util.h"
 #include "cinn/backends/llvm/execution_engine.h"
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/cinn.h"
 #include "cinn/common/target.h"
 #include "cinn/common/test_helper.h"
@@ -137,7 +137,7 @@ TEST(ScatterAssign, ScatterAssign) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
   // cuda_module load ptx
@@ -179,7 +179,7 @@ TEST(SliceAssign, SliceAssign) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 
@@ -218,7 +218,7 @@ TEST(Concat, ConcatCase0) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 #endif
@@ -258,7 +258,7 @@ TEST(Reduce, Reduce_Test_0) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 #endif
@@ -327,7 +327,7 @@ TEST(Reduce, Reduce_Test_1) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -362,7 +362,7 @@ TEST(Reduce, Reduce_Test_2) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -397,7 +397,7 @@ TEST(Reduce, Reduce_Test_2_1) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -432,7 +432,7 @@ TEST(Reduce, Reduce_Test_2_2) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -467,7 +467,7 @@ TEST(Reduce, Reduce_Test_2_3) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -502,7 +502,7 @@ TEST(Reduce, Reduce_Test_3) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -537,7 +537,7 @@ TEST(Reduce, Reduce_Test_3_1) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -573,7 +573,7 @@ TEST(Reduce, Reduce_Test_3_2) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -609,7 +609,7 @@ TEST(Reduce, Reduce_Test_4) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -644,7 +644,7 @@ TEST(Reduce, Reduce_Test_5) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -679,7 +679,7 @@ TEST(Reduce, Reduce_Test_6) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -715,7 +715,7 @@ TEST(Reduce, Reduce_Test_7) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -751,7 +751,7 @@ TEST(Reduce, Reduce_Test_8) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -787,7 +787,7 @@ TEST(Reduce, Reduce_Test_9) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -832,7 +832,7 @@ TEST(Reduce, Reduce_Test_10) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -865,7 +865,7 @@ TEST(Reduce, Reduce_Test_11) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -898,7 +898,7 @@ TEST(Reduce, Reduce_Test_12) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }
@@ -931,7 +931,7 @@ TEST(Reduce, Reduce_Test_13) {
   LOG(INFO) << "compiled code:\n\n\n" << source_code;
 
   // nv jit compile to ptx
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 }

--- a/cinn/runtime/cuda/cuda_module_test.cc
+++ b/cinn/runtime/cuda/cuda_module_test.cc
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include "cinn/backends/nvrtc_util.h"
+#include "cinn/backends/nvrtc/nvrtc_util.h"
 #include "cinn/cinn.h"
 #include "cinn/runtime/cuda/cuda_util.h"
 #include "cinn/runtime/cuda/use_extern_funcs.h"
@@ -26,7 +26,7 @@ namespace runtime {
 namespace cuda {
 
 TEST(CUDAModule, basic) {
-  backends::NVRTC_Compiler compiler;
+  backends::nvrtc::Compiler compiler;
 
   std::string source_code = R"ROC(
 extern "C" __global__

--- a/cmake/external/jitify.cmake
+++ b/cmake/external/jitify.cmake
@@ -1,0 +1,31 @@
+IF(NOT WITH_CUDA)
+  SET(JITIFY_FOUND OFF)
+  RETURN()
+ENDIF()
+
+include(ExternalProject)
+
+set(JITIFY_SOURCE_PATH ${THIRD_PARTY_PATH}/install/jitify)
+set(JITIFY_STL_HEADERS ${THIRD_PARTY_PATH}/install/jitify/stl_headers)
+
+ExternalProject_Add(
+  external_jitify
+  ${EXTERNAL_PROJECT_LOG_ARGS}
+  GIT_REPOSITORY "https://github.com/NVIDIA/jitify.git"
+  GIT_TAG master
+  PREFIX ${THIRD_PARTY_PATH}/jitify
+  SOURCE_DIR ${JITIFY_SOURCE_PATH}
+  CONFIGURE_COMMAND ""
+  PATCH_COMMAND ${CMAKE_COMMAND} -E make_directory ${JITIFY_STL_HEADERS}
+  BUILD_COMMAND ""
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+include_directories(${JITIFY_SOURCE_PATH})
+add_definitions(-DNVRTC_STL_PATH="${JITIFY_STL_HEADERS}")
+message(STATUS "Jitify header files path: ${JITIFY_STL_HEADERS}")
+
+add_library(extern_jitify INTERFACE)
+add_dependencies(extern_jitify external_jitify)
+set(jitify_deps extern_jitify)


### PR DESCRIPTION
1、将 nvidia 编译运行时的头文件生成逻辑及单测进行了整理；
2、添加 nvidia jitify 第三方的 stl 头文件依赖，后续可直接将头文件从 jitify 移植到本仓储源码中；
3、在上述基础上支持 float16.h 编译。