### PR TITLE
Flat loops schedule

### DIFF
--- a/cinn/hlir/pe/ir_schedule_pe.h
+++ b/cinn/hlir/pe/ir_schedule_pe.h
@@ -31,6 +31,10 @@ namespace cinn {
 namespace hlir {
 namespace pe {
 
+void IRElementwiseSchedule(ir::IRSchedule &ir_sch, const std::vector<int> &output_shape, const common::Target &target);
+
+void IRInjectiveSchedule(ir::IRSchedule &ir_sch, const std::vector<int> &output_shape, const common::Target &target);
+
 void IRScheduleInjectiveCPU(ir::IRSchedule &ir_sch,
                             const std::vector<int> &output_shape,
                             const common::Target &target,

--- a/cinn/ir/collect_ir_nodes.cc
+++ b/cinn/ir/collect_ir_nodes.cc
@@ -101,6 +101,14 @@ std::set<Expr> CollectIRNodes(Expr expr, std::function<bool(const Expr*)>&& tell
   return exprs;
 }
 
+std::vector<Expr> CollectIRNodesInOrder(Expr expr, std::function<bool(const Expr*)>&& teller) {
+  std::vector<Expr> exprs;
+  IrNodesWithoutTensorCollector::handler_t handler = [&](const Expr* x) { exprs.push_back(*x); };
+  IrNodesWithoutTensorCollector collector(std::move(teller), std::move(handler), false);
+  collector.Visit(&expr);
+  return exprs;
+}
+
 std::set<Expr> CollectIRNodesWithoutTensor(Expr expr, std::function<bool(const Expr*)>&& teller, bool uniq_target) {
   std::set<Expr> exprs;
   IrNodesWithoutTensorCollector::handler_t handler = [&](const Expr* x) { exprs.insert(*x); };

--- a/cinn/ir/collect_ir_nodes.h
+++ b/cinn/ir/collect_ir_nodes.h
@@ -30,6 +30,11 @@ std::set<Expr> CollectIRNodes(Expr x, std::function<bool(const Expr*)>&& teller,
 std::set<Expr> CollectIRNodesWithoutTensor(Expr x, std::function<bool(const Expr*)>&& teller, bool uniq_target = false);
 
 /**
+ * Collect the IR Nodes from Block.
+ */
+std::vector<Expr> CollectIRNodesInOrder(Expr block, std::function<bool(const Expr*)>&& teller);
+
+/**
  * Collect the tensors in Load nodes.
  */
 std::set<Expr> CollectLoadTensors(Expr x, std::function<bool(const Expr*)>&& teller);

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -330,6 +330,8 @@ class IRSchedule {
    * \param loops  the loops to be flatted.
    * \param force_flat force to flat the right value.
    */
+  // Temporary solution for simplify the elementwise/broadcast/injective index.
+  // TODO(sunli): Solve Index Simplify.
   void FlattenLoops(const std::vector<Expr>& loops, const bool force_flat = false);
 
  private:

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -325,6 +325,13 @@ class IRSchedule {
    */
   void Annotate(const Expr& block, const std::string& key, const attr_t& value);
 
+  /*!
+   * \brief flatten the loops in one dim.
+   * \param loops  the loops to be flatted.
+   * \param force_flat force to flat the right value.
+   */
+  void FlattenLoops(const std::vector<Expr>& loops, const bool force_flat = false);
+
  private:
   std::unique_ptr<ScheduleImpl> impl_;
   mutable ScheduleDesc trace_;  // trace the scheduling process

--- a/cinn/ir/schedule_desc.cc
+++ b/cinn/ir/schedule_desc.cc
@@ -448,6 +448,11 @@ CINN_BUILD_STEP_KIND(AnnotateStringAttr)
     .Attrs({"key", "value"})
     .SetApplyFn(APPLY_FUNC_UNIFORM(AnnotateStringAttr));
 
+CINN_BUILD_STEP_KIND(FlattenLoops)
+    .Inputs({"loops"})
+    .Attrs({"force_flat"})
+    .SetApplyFn(APPLY_FUNC_UNIFORM(FREE_FUNCTION_CONVERTER(&IRSchedule::FlattenLoops)));
+
 // clang-format on
 
 // ------ Following codes are about member function implement of the ScheduleDesc class


### PR DESCRIPTION
新增调度原语 FlattenLoops，作为临时的index化简方案。
FlattenLoop替换原来的Fuse( all_loops )的功能，主要用来简化elementwise/broadcast/injective类型的索引。
使用flattenloops 需要保证loop是由外往内保持和tensor shape一致的顺序，没有经历reorder等变换。

FlattenLoop传入std::vector 会将目标loop 融合为单个loops
实例如下:
for ( i0 in [0, 10] )
for ( i1 in [0, 20])
i,j bind( i0, i1 )
a[i,j] = b[i, j]
c[i,j] = b[j, i]

after flatloops
for( i0 in [0, 200])
i bind ( i0 )
a[i] = b[i]
c[i] = b[i/20 + (i%20) * 10]

在flat的时候 会自动做索引的映射变换 以保证索引的正确性。

Reshape:
before->flat
ScheduleBlock(root)
{
  serial for (i, 0, 512)
  {
    serial for (j, 0, 1024)
    {
      ScheduleBlock(var_0)
      {
        i0, i1 = axis.bind(i, j)
        var_0[i0, i1] = A[((((((-1 * (((1024 * i0) + i1) % 512)) + i1) / 512) + ((-1 * (((((-1 * (((1024 * i0) + i1) % 512)) + i1) / 512) + (2 * i0)) % 32)) + (2 * i0))) / 32) % 32), 0, (((((-1 * (((1024 * i0) + i1) % 512)) + i1) / 512) + (2 * i0)) % 32), (((1024 * i0) + i1) % 512)]
      }
    }
  }
}

after:
ScheduleBlock(root)
{
  thread_bind[blockIdx.x] for (flat_i_0, 0, 2048)
  {
    thread_bind[threadIdx.x] for (flat_i_1, 0, 256)
    {
      ScheduleBlock(var_0)
      {
        _flat_i = axis.bind(((256 * flat_i_0) + flat_i_1))
        var_0[_flat_i] = A[_flat_i]
      }
    }
  }
}

BroacastTo
before flat
ScheduleBlock(root)
{
  serial for (i, 0, 32)
  {
    serial for (j, 0, 512)
    {
      ScheduleBlock(var_0)
      {
        i0, i1 = axis.bind(i, j)
        var_0[i0, i1] = A[(i1 % 512)]
      }
    }
  }
}
after flat
ScheduleBlock(root)
{
  thread_bind[blockIdx.x] for (flat_i_0, 0, 64)
  {
    thread_bind[threadIdx.x] for (flat_i_1, 0, 256)
    {
      ScheduleBlock(var_0)
      {
        _flat_i = axis.bind(((256 * flat_i_0) + flat_i_1))
        var_0[_flat_i] = A[((_flat_i % 512) % 512)]
      }
    }
  }
}

