### PR TITLE
add the log function for float16

### DIFF
--- a/cinn/common/float16.h
+++ b/cinn/common/float16.h
@@ -569,6 +569,8 @@ __host__ __device__ inline float16(abs)(const float16& a) {
 #endif
 }
 
+__host__ __device__ inline float16(log)(const float16& a) { return float16(std::log(static_cast<float>(a))); }
+
 #ifdef __cplusplus
 }  // namespace common
 }  // namespace cinn


### PR DESCRIPTION
避免重载歧义报错
```
default_program(950): error: more than one instance of overloaded function "log" matches the argument list:
            function "log(double)"
__nv_nvrtc_builtin_header.h(152246): here
            function "log(float)"
__nv_nvrtc_builtin_header.h(153172): here
            argument types are: (cinn::common::float16)

default_program(950): error: more than one instance of overloaded function "log" matches the argument list:
            function "log(double)"
__nv_nvrtc_builtin_header.h(152246): here
            function "log(float)"
__nv_nvrtc_builtin_header.h(153172): here
            argument types are: (cinn::common::float16)

default_program(950): error: ambiguous "?" operation: second operand of type "cinn::common::float16" can be converted to third operand type "<error-type>", and vice versa
```