### PR TITLE
optimize expand_dims to support vector axes

### DIFF
--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -414,8 +414,8 @@ Variable NetBuilder::Squeeze(const Variable& operand, const std::vector<int>& ax
   return CustomInstr("squeeze", {operand}, {{"axes", axes}}).front();
 }
 
-Variable NetBuilder::ExpandDims(const Variable& operand, int axis, int num_newaxis) {
-  return CustomInstr("expand_dims", {operand}, {{"axis", axis}, {"num_newaxis", num_newaxis}}).front();
+Variable NetBuilder::ExpandDims(const Variable& operand, const cinn::utils::ShapeType& axes) {
+  return CustomInstr("expand_dims", {operand}, {{"axes", axes}}).front();
 }
 
 Variable NetBuilder::Conv(const Variable& lhs,

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -575,7 +575,7 @@ class NetBuilder {
    * `axes=axes+rank(input)`.
    * @return Output squeezed variable. Data type is same as input variable.
    */
-  Variable Squeeze(const Variable& x, const cinn::utils::ShapeType& axes);
+  Variable Squeeze(const Variable& x, const cinn::utils::ShapeType& axes = {});
 
   /**
    * @brief Creates an operation to insert new dimensions of length 1.

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -584,7 +584,7 @@ class NetBuilder {
    * @param num_newaxis The number of new dimensions to insert
    * @return A variable whose op member is the dim expandsion operation.
    */
-  Variable ExpandDims(const Variable& operand, int axis, int num_newaxis = 1);
+  Variable ExpandDims(const Variable& operand, const cinn::utils::ShapeType& axes);
 
   /**
    * @brief This operator reverse the input along the axis.

--- a/cinn/frontend/op_mappers/paddle/unsqueeze.cc
+++ b/cinn/frontend/op_mappers/paddle/unsqueeze.cc
@@ -30,10 +30,7 @@ void UnSqueeze2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   VLOG(4) << "x shape: " << cinn::utils::Join(x->shape, ",");
   VLOG(4) << "unsqueeze axes: " << cinn::utils::Join(axes, ",");
 
-  Variable out = x;
-  for (auto axis : axes) {
-    out = ctx.Builder()->ExpandDims(out, axis);
-  }
+  const auto& out = ctx.Builder()->ExpandDims(x, axes);
 
   CHECK_EQ(op_desc.Output("Out").size(), 1UL);
   auto out_name = op_desc.Output("Out").front();

--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -528,8 +528,8 @@ std::shared_ptr<framework::OpStrategy> StrategyForSqueeze(const framework::NodeA
                                                           const std::vector<Type> &out_type,
                                                           const std::vector<std::vector<int>> &output_shapes,
                                                           const Target &target) {
-  CHECK(attrs.attr_store.count("axes")) << "find no attr of axes";
-  std::vector<int> axes = absl::get<std::vector<int>>(attrs.attr_store.at("axes"));
+  const std::vector<int> &axes =
+      attrs.attr_store.count("axes") ? absl::get<std::vector<int>>(attrs.attr_store.at("axes")) : std::vector<int>{};
 
   framework::CINNCompute squeeze_compute([=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input arguments of Squeeze compute is empty! Please check.\n";
@@ -567,31 +567,12 @@ std::shared_ptr<framework::OpStrategy> StrategyForSqueeze(const framework::NodeA
 std::vector<std::vector<int>> InferShapeForSqueeze(const std::vector<std::vector<int>> &inputs_shape,
                                                    const framework::AttrMapType &attrs) {
   CHECK_EQ(inputs_shape.size(), 1U);
-  CHECK(attrs.count("axes"));
-  std::vector<int> axes = absl::get<std::vector<int>>(attrs.at("axes"));
-  for (auto &axis : axes) {
-    if (axis < 0) {
-      axis += inputs_shape[0].size();
-    }
-  }
+  const std::vector<int> &axes =
+      attrs.count("axes") ? absl::get<std::vector<int>>(attrs.at("axes")) : std::vector<int>{};
+  VLOG(4) << "The [axis] value used in Squeeze: " << cinn::utils::Join(axes, ",");
 
-  std::vector<int> output_shape;
-  if (axes.size()) {
-    for (int idx = 0; idx < inputs_shape[0].size(); ++idx) {
-      // if can't find idx in axis
-      if (std::find(axes.begin(), axes.end(), idx) == axes.end()) {
-        output_shape.push_back(inputs_shape[0][idx]);
-      } else {
-        CHECK_EQ(inputs_shape[0][idx], 1);
-      }
-    }
-  } else {
-    for (int idx = 0; idx < inputs_shape[0].size(); ++idx) {
-      if (inputs_shape[0][idx] != 1) {
-        output_shape.push_back(inputs_shape[0][idx]);
-      }
-    }
-  }
+  const auto &output_shape = pe::utils::GetSqueezeShape(inputs_shape[0], axes);
+  VLOG(4) << "The output calculated in Squeeze: " << cinn::utils::Join(output_shape, ", ");
 
   return {output_shape};
 }
@@ -601,30 +582,10 @@ std::shared_ptr<OpStrategy> StrategyForExpandDims(const framework::NodeAttr &att
                                                   const std::vector<Type> &out_type,
                                                   const std::vector<std::vector<int>> &output_shapes,
                                                   const Target &target) {
-  CHECK(!output_shapes.empty() && !output_shapes[0].empty()) << "The shape of output is empty! Please check again.";
-  VLOG(4) << "The output passed in StrategyForExpandDims: " << utils::Join(output_shapes[0], ", ");
-  CHECK(!out_type.empty()) << "The output type of IndexSelect is empty! Please check again.\n";
+  const std::vector<int> &axes =
+      attrs.attr_store.count("axes") ? absl::get<std::vector<int>>(attrs.attr_store.at("axes")) : std::vector<int>{};
 
-  int axis = 0;
-  if (attrs.attr_store.contains("axis")) {
-    axis = absl::get<int>(attrs.attr_store.at("axis"));
-  }
-  int num_newaxis = 1;
-  if (attrs.attr_store.contains("num_newaxis")) {
-    num_newaxis = absl::get<int>(attrs.attr_store.at("num_newaxis"));
-  }
-
-  VLOG(4) << "The axis value used in expand_dims: " << axis;
-  VLOG(4) << "The num_newaxis value used in expand_dims: " << num_newaxis;
-
-  std::vector<Expr> output_shape;
-  output_shape.reserve(output_shapes[0].size());
-  for (int i : output_shapes[0]) {
-    output_shape.emplace_back(i);
-  }
-
-  framework::CINNCompute expand_dims_compute{[axis, num_newaxis](lang::Args args, lang::RetValue *ret) {
-    VLOG(4) << "The axis value used in expand_dims: " << axis;
+  framework::CINNCompute expand_dims_compute{[=](lang::Args args, lang::RetValue *ret) {
     CHECK(!args.empty()) << "The input args are empty! Please check again.";
     CINNValuePack input_args = args[0];
     int input_size           = input_args.size();
@@ -639,7 +600,7 @@ std::shared_ptr<OpStrategy> StrategyForExpandDims(const framework::NodeAttr &att
       tensor_name = input_args[1].operator std::string();
     }
 
-    auto out    = pe::ExpandDims(x.as_tensor_ref(), axis, num_newaxis, tensor_name);
+    auto out    = pe::ExpandDims(x.as_tensor_ref(), axes, tensor_name);
     auto stages = CreateStages({x.as_tensor_ref()});
     stages->InsertLazily(out);
     std::vector<CINNValue> res{CINNValue(out), CINNValue(stages)};
@@ -655,37 +616,15 @@ std::shared_ptr<OpStrategy> StrategyForExpandDims(const framework::NodeAttr &att
 std::vector<std::vector<int>> InferShapeForExpandDims(const std::vector<std::vector<int>> &inputs_shape,
                                                       const framework::AttrMapType &attrs) {
   CHECK(!inputs_shape.empty() && !inputs_shape[0].empty()) << "The input's shape size is 0! Please check again.";
-  int axis  = 0;
-  int ndims = inputs_shape[0].size();
-  if (attrs.contains("axis")) {
-    axis = absl::get<int>(attrs.at("axis"));
-  }
-  if (axis < 0) {
-    axis = axis + 1 + static_cast<int>(inputs_shape[0].size());
-  }
-  CHECK(axis >= -ndims - 1 && axis <= ndims)
-      << "expand_dims only accept `axis` in [-x.ndim - 1, x.ndim], but got axis = " << axis
-      << ", and x.ndims = " << ndims;
-  int num_newaxis = 1;
-  if (attrs.contains("num_newaxis")) {
-    num_newaxis = absl::get<int>(attrs.at("num_newaxis"));
-    CHECK_GE(num_newaxis, 0);
-  }
 
-  std::vector<int> output_shape;
-  output_shape.reserve(ndims + num_newaxis);
-  for (int i = 0; i < axis; ++i) {
-    output_shape.push_back(inputs_shape[0][i]);
-  }
-  for (int i = 0; i < num_newaxis; ++i) {
-    output_shape.push_back(1);
-  }
-  for (int i = axis; i < ndims; ++i) {
-    output_shape.push_back(inputs_shape[0][i]);
-  }
+  CHECK_EQ(inputs_shape.size(), 1U);
+  const std::vector<int> &axes =
+      attrs.count("axes") ? absl::get<std::vector<int>>(attrs.at("axes")) : std::vector<int>{};
+  VLOG(4) << "The [axes] value used in ExpandDims: " << cinn::utils::Join(axes, ",");
 
-  VLOG(4) << "The output calculated in InferShapeForExpandDims: " << utils::Join(output_shape, ", ");
-  return {std::move(output_shape)};
+  const auto &output_shape = pe::utils::GetExpandDimsShape(inputs_shape[0], axes);
+  VLOG(4) << "The output calculated in ExpandDims: " << cinn::utils::Join(output_shape, ", ");
+  return {output_shape};
 }
 
 std::shared_ptr<OpStrategy> StrategyForReshape(const framework::NodeAttr &attrs,

--- a/cinn/hlir/op/op_util.cc
+++ b/cinn/hlir/op/op_util.cc
@@ -13,3 +13,21 @@
 // limitations under the License.
 
 #include "cinn/hlir/op/op_util.h"
+
+namespace cinn {
+namespace hlir {
+
+std::vector<int> GetPositiveAxes(const std::vector<int>& axes, int rank) {
+  std::vector<int> new_axes(axes.size());
+  for (int i = 0; i < axes.size(); ++i) {
+    int axis = axes[i] + (axes[i] < 0 ? rank : 0);
+    CHECK(axis >= 0 && axis < rank) << "The axis should in [0, " << rank << "), but axes[" << i << "]=" << axes[i]
+                                    << " not.";
+    new_axes[i] = axis;
+  }
+  std::sort(new_axes.begin(), new_axes.end());
+  return new_axes;
+}
+
+}  // namespace hlir
+}  // namespace cinn

--- a/cinn/hlir/op/op_util.h
+++ b/cinn/hlir/op/op_util.h
@@ -40,5 +40,7 @@ std::vector<Expr> ToCinnExprs(const std::vector<T>& args) {
   return exprs;
 }
 
+std::vector<int> GetPositiveAxes(const std::vector<int>& axes, int rank);
+
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/elementwise.cc
+++ b/cinn/hlir/pe/elementwise.cc
@@ -14,8 +14,10 @@
 
 #include "cinn/hlir/pe/elementwise.h"
 
+#include <algorithm>
 #include <string>
 
+#include "cinn/hlir/op/op_util.h"
 #include "cinn/ir/ir_operators.h"
 #include "cinn/lang/builtin.h"
 
@@ -26,6 +28,60 @@ namespace pe {
 using ir::Expr;
 using ir::Tensor;
 using lang::Compute;
+
+namespace utils {
+std::vector<int> GetPositiveAxes(const std::vector<int>& axes, int rank) {
+  std::vector<int> new_axes(axes.size());
+  for (int i = 0; i < axes.size(); ++i) {
+    int axis = axes[i] + (axes[i] < 0 ? rank : 0);
+    CHECK(axis >= 0 && axis < rank) << "The axis should in [0, " << rank << "), but axes[" << i << "]=" << axes[i]
+                                    << " not.";
+    new_axes[i] = axis;
+  }
+  std::sort(new_axes.begin(), new_axes.end());
+  return new_axes;
+}
+
+std::vector<int> GetSqueezeShape(const std::vector<int>& shape, const std::vector<int>& axes) {
+  auto posi_axes = utils::GetPositiveAxes(axes, shape.size());
+  if (posi_axes.empty()) {
+    for (int i = 0; i < shape.size(); ++i) {
+      posi_axes.emplace_back(i);
+    }
+  }
+
+  std::vector<int> out_shape;
+  int axes_pos = 0;
+  for (int i = 0; i < shape.size(); ++i) {
+    if (axes_pos < posi_axes.size() && posi_axes[axes_pos] == i) {
+      ++axes_pos;
+
+      if (shape[i] == 1) {
+        continue;
+      }
+    }
+    out_shape.emplace_back(shape[i]);
+  }
+  return out_shape;
+}
+
+std::vector<int> GetExpandDimsShape(const std::vector<int>& shape, const std::vector<int>& axes) {
+  std::vector<int> out_shape(shape.size() + axes.size(), 1);
+  const auto& posi_axes = GetPositiveAxes(axes, out_shape.size());
+
+  int shape_pos = 0, axes_pos = 0;
+  for (int i = 0; i < out_shape.size(); ++i) {
+    if (axes_pos < posi_axes.size() && posi_axes[axes_pos] == i) {
+      out_shape[i] = 1;
+      ++axes_pos;
+    } else if (shape_pos < shape.size()) {
+      out_shape[i] = shape[shape_pos];
+      ++shape_pos;
+    }
+  }
+  return out_shape;
+}
+}  // namespace utils
 
 #define HLIR_IMP_UNARY_PE(name__)                                                                          \
   std::vector<ir::Tensor> name__(const Tensor& A, const std::string& output_name) {                        \
@@ -103,72 +159,67 @@ HLIR_IMP_UNARY_PE(Abs);
 HLIR_IMP_UNARY_PE(Rsqrt);
 
 ir::Tensor Squeeze(const ir::Tensor& A, const std::vector<int>& axes, const std::string& output_name) {
-  std::vector<int> position;
-  std::vector<Expr> output_shape;
-  if (axes.size()) {
-    for (int idx = 0; idx < A->shape.size(); ++idx) {
-      // if can't find idx in axis
-      if (std::find(axes.begin(), axes.end(), idx) == axes.end()) {
-        output_shape.push_back(A->shape[idx]);
-        position.push_back(idx);
-      } else {
-        CHECK_EQ(A->shape[idx], Expr(1));
-      }
-    }
-  } else {
-    for (int idx = 0; idx < A->shape.size(); ++idx) {
-      if (A->shape[idx] != Expr(1)) {
-        output_shape.push_back(A->shape[idx]);
-        position.push_back(idx);
-      }
+  auto posi_axes = utils::GetPositiveAxes(axes, A->shape.size());
+  if (posi_axes.empty()) {
+    for (int i = 0; i < A->shape.size(); ++i) {
+      posi_axes.emplace_back(i);
     }
   }
 
+  std::vector<int> in_shape(A->shape.size());
+  for (int i = 0; i < in_shape.size(); ++i) {
+    in_shape[i] = A->shape[i].as_int32();
+  }
+  const auto& out_shape = utils::GetSqueezeShape(in_shape, posi_axes);
+
   auto res = Compute(
-      output_shape,
+      ToCinnExprs(out_shape),
       [=](const std::vector<Expr>& indices) {
-        std::vector<Expr> indexs(A->shape.size(), Expr(0));
-        for (int idx = 0; idx < indices.size(); ++idx) {
-          indexs[position[idx]] = indices[idx];
+        std::vector<Expr> idx;
+
+        int axes_pos = 0, out_idx = 0;
+        for (int i = 0; i < in_shape.size(); ++i) {
+          if (axes_pos < posi_axes.size() && posi_axes[axes_pos] == i) {
+            ++axes_pos;
+
+            if (in_shape[i] == 1) {
+              idx.emplace_back(0);
+              continue;
+            }
+          }
+          idx.emplace_back(indices[out_idx]);
+          ++out_idx;
         }
-        return A(indexs);
+        CHECK_EQ(idx.size(), A->shape.size()) << "The index size not equal with the input rank.";
+        return A(idx);
       },
       output_name);
   return res;
 }
 
-ir::Tensor ExpandDims(const ir::Tensor& input, int axis, int num_newaxis, const std::string& output_name) {
-  int ndims = input.ndims();
-  CHECK(axis >= -ndims - 1 && axis <= ndims)
-      << "expand_dims only accept `axis` in [-x.ndim - 1, x.ndim], but got axis = " << axis
-      << ", and x.ndims = " << ndims;
-  CHECK_GE(num_newaxis, 0);
+ir::Tensor ExpandDims(const ir::Tensor& A, const std::vector<int>& axes, const std::string& output_name) {
+  std::vector<int> in_shape(A->shape.size());
+  for (int i = 0; i < in_shape.size(); ++i) {
+    in_shape[i] = A->shape[i].as_int32();
+  }
 
-  if (axis < 0) {
-    axis = ndims + axis + 1;
-  }
-  std::vector<Expr> output_shape;
-  for (size_t i = 0; i < static_cast<size_t>(axis); ++i) {
-    output_shape.push_back(input->shape[i]);
-  }
-  for (size_t i = 0; i < static_cast<size_t>(num_newaxis); ++i) {
-    output_shape.push_back(Expr(1));
-  }
-  for (size_t i = axis; i < input->shape.size(); ++i) {
-    output_shape.push_back(input->shape[i]);
-  }
+  const auto& out_shape = utils::GetExpandDimsShape(in_shape, axes);
+  const auto& posi_axes = utils::GetPositiveAxes(axes, out_shape.size());
 
   return Compute(
-      output_shape,
+      ToCinnExprs(out_shape),
       [=](const std::vector<Expr>& indice) {
         std::vector<Expr> idx;
-        for (size_t i = 0; i < static_cast<size_t>(axis); ++i) {
-          idx.push_back(indice[i]);
+        int axes_pos = 0;
+        for (int i = 0; i < indice.size(); ++i) {
+          if (axes_pos < posi_axes.size() && posi_axes[axes_pos] == i) {
+            ++axes_pos;
+          } else {
+            idx.push_back(indice[i]);
+          }
         }
-        for (size_t i = axis + num_newaxis; i < indice.size(); ++i) {
-          idx.push_back(indice[i]);
-        }
-        return input(idx);
+        CHECK_EQ(idx.size(), A->shape.size()) << "The index size not equal with the input rank.";
+        return A(idx);
       },
       UniqName(output_name));
 }

--- a/cinn/hlir/pe/elementwise.h
+++ b/cinn/hlir/pe/elementwise.h
@@ -112,6 +112,7 @@ ir::Tensor Squeeze(const ir::Tensor& A,
 
 ir::Tensor ExpandDims(const ir::Tensor& A,
                       const std::vector<int>& axes,
+                      const std::vector<int>& out_shape,
                       const std::string& output_name = UniqName("T_Elementwise_ExpandDims_out"));
 
 ir::Tensor Reshape(const ir::Tensor& A,

--- a/cinn/hlir/pe/elementwise.h
+++ b/cinn/hlir/pe/elementwise.h
@@ -25,11 +25,6 @@ namespace cinn {
 namespace hlir {
 namespace pe {
 
-namespace utils {
-std::vector<int> GetSqueezeShape(const std::vector<int>& shape, const std::vector<int>& axes);
-std::vector<int> GetExpandDimsShape(const std::vector<int>& shape, const std::vector<int>& axes);
-}  // namespace utils
-
 /**
  * @brief Unary primitive emitters
  *

--- a/cinn/hlir/pe/elementwise.h
+++ b/cinn/hlir/pe/elementwise.h
@@ -24,6 +24,12 @@
 namespace cinn {
 namespace hlir {
 namespace pe {
+
+namespace utils {
+std::vector<int> GetSqueezeShape(const std::vector<int>& shape, const std::vector<int>& axes);
+std::vector<int> GetExpandDimsShape(const std::vector<int>& shape, const std::vector<int>& axes);
+}  // namespace utils
+
 /**
  * @brief Unary primitive emitters
  *
@@ -104,9 +110,8 @@ ir::Tensor Squeeze(const ir::Tensor& A,
                    const std::vector<int>& axes   = {},
                    const std::string& output_name = UniqName("T_Elementwise_Squeeze_out"));
 
-ir::Tensor ExpandDims(const ir::Tensor& input,
-                      int axis,
-                      int num_newaxis                = 1,
+ir::Tensor ExpandDims(const ir::Tensor& A,
+                      const std::vector<int>& axes,
                       const std::string& output_name = UniqName("T_Elementwise_ExpandDims_out"));
 
 ir::Tensor Reshape(const ir::Tensor& A,

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -634,7 +634,7 @@ std::vector<Tensor> Depthwise_Conv2d_NCHW(const Tensor &input,
 
   Var kernel_h = Var(weight->shape[2], "kh");
   Var kernel_w = Var(weight->shape[3], "kw");
-  VLOG(3) << "Output shape is : " << utils::Join(output_shape, ",");
+  VLOG(3) << "Output shape is : " << cinn::utils::Join(output_shape, ",");
   auto res = Compute(
       output_shape,
       [=](Expr nn, Expr ff, Expr yy, Expr xx) {
@@ -1068,7 +1068,7 @@ std::vector<Tensor> PoolImpl(const Tensor &tensor,
     for (int i = 0; i < k_size; i++) {
       out_shape[axis[i]] = Expr(kernel_size[i]);
     }
-    VLOG(4) << "PoolImpl out_shape: " << utils::Join(out_shape, ",");
+    VLOG(4) << "PoolImpl out_shape: " << cinn::utils::Join(out_shape, ",");
     CHECK(!do_pad);
     temp = do_pad ? Pad(tensor, pad_before, pad_after, 0, UniqName("pad_temp")) : tensor;
     std::vector<Var> reduce_axis;

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -515,7 +515,7 @@ void BindFrontend(pybind11::module *m) {
       .def("relu6", &NetBuilder::Relu6, py::arg("a"), py::arg("threshold") = 6.0f)
       .def("gelu", &NetBuilder::Gelu, py::arg("x"))
       .def("squeeze", &NetBuilder::Squeeze, py::arg("a"), py::arg("axes"))
-      .def("expand_dims", &NetBuilder::ExpandDims, py::arg("x"), py::arg("axis"), py::arg("num_newaxis") = 1)
+      .def("expand_dims", &NetBuilder::ExpandDims, py::arg("x"), py::arg("axes"))
       .def("argmax", &NetBuilder::Argmax, py::arg("x"), py::arg("axis"), py::arg("keep_dim") = false)
       .def("argmin", &NetBuilder::Argmin, py::arg("x"), py::arg("axis"), py::arg("keep_dim") = false)
       .def("lookup_table", &NetBuilder::LookupTable, py::arg("table"), py::arg("ids"), py::arg("padding_idx"))

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -514,7 +514,7 @@ void BindFrontend(pybind11::module *m) {
            py::arg("axis") = -1)
       .def("relu6", &NetBuilder::Relu6, py::arg("a"), py::arg("threshold") = 6.0f)
       .def("gelu", &NetBuilder::Gelu, py::arg("x"))
-      .def("squeeze", &NetBuilder::Squeeze, py::arg("a"), py::arg("axes"))
+      .def("squeeze", &NetBuilder::Squeeze, py::arg("a"), py::arg("axes") = std::vector<int>{})
       .def("expand_dims", &NetBuilder::ExpandDims, py::arg("x"), py::arg("axes"))
       .def("argmax", &NetBuilder::Argmax, py::arg("x"), py::arg("axis"), py::arg("keep_dim") = false)
       .def("argmin", &NetBuilder::Argmin, py::arg("x"), py::arg("axis"), py::arg("keep_dim") = false)


### PR DESCRIPTION
As title. 之前`expand_dims`算子并不支持`vector`形式的axes参数，导致在适配`unsqueeze`算子时需要用到一个for循环，此处添加了`vector`形式的axes参数支持。