### PR TITLE
optimize split schedule

### DIFF
--- a/cinn/common/ir_util.cc
+++ b/cinn/common/ir_util.cc
@@ -137,7 +137,7 @@ Expr IndiceToAbsOffset(const std::vector<Expr> &shape, const std::vector<Expr> &
   VLOG(3) << "Begin IndiceToAbsOffset";
   VLOG(3) << "shape is : " << utils::Join(shape, ",");
   VLOG(3) << "indices is : " << utils::Join(indices, ",");
-  CHECK_EQ(shape.size(), indices.size());
+  CHECK_LE(shape.size(), indices.size());
   Expr res;
   for (int i = 0; i < shape.size(); i++) {
     CHECK_EQ(shape[i].type(), Int(32));

--- a/cinn/common/ir_util.cc
+++ b/cinn/common/ir_util.cc
@@ -137,7 +137,7 @@ Expr IndiceToAbsOffset(const std::vector<Expr> &shape, const std::vector<Expr> &
   VLOG(3) << "Begin IndiceToAbsOffset";
   VLOG(3) << "shape is : " << utils::Join(shape, ",");
   VLOG(3) << "indices is : " << utils::Join(indices, ",");
-  CHECK_LE(shape.size(), indices.size());
+  CHECK_EQ(shape.size(), indices.size());
   Expr res;
   for (int i = 0; i < shape.size(); i++) {
     CHECK_EQ(shape[i].type(), Int(32));

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -54,6 +54,58 @@ void CodeGen(ir::LoweredFunc& func) {
 #endif
 }
 
+TEST(OP_LOWERING, Elementwise_TEST_Split_0) {
+  NetBuilder net_builder("Elementwise_TEST_Split_0");
+  {
+    auto A = net_builder.CreateInput(Float(32), {128, 128}, "A");
+    auto B = net_builder.Split(A, {32, 32, 32}, 1);
+  }
+
+  auto program = net_builder.Build();
+  auto target  = common::DefaultTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    CodeGen(lowered_func[0]);
+  }
+}
+
+TEST(OP_LOWERING, Elementwise_TEST_Split_1) {
+  NetBuilder net_builder("Elementwise_TEST_Split_1");
+  {
+    auto A = net_builder.CreateInput(Float(32), {128, 128}, "A");
+    auto B = net_builder.Split(A, {64, 32, 32}, 1);
+  }
+
+  auto program = net_builder.Build();
+  auto target  = common::DefaultTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    CodeGen(lowered_func[0]);
+  }
+}
+
 TEST(OP_LOWERING, Elementwise_TEST_0) {
   NetBuilder net_builder("Elementwise_TEST_0");
   {

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -57,8 +57,8 @@ void CodeGen(ir::LoweredFunc& func) {
 TEST(OP_LOWERING, Elementwise_TEST_Split_0) {
   NetBuilder net_builder("Elementwise_TEST_Split_0");
   {
-    auto A = net_builder.CreateInput(Float(32), {128, 128}, "A");
-    auto B = net_builder.Split(A, {32, 32, 32}, 1);
+    auto A = net_builder.CreateInput(Float(32), {32, 64}, "A");
+    auto B = net_builder.Split(A, {3, 5, 16, 2, 6}, 0);
   }
 
   auto program = net_builder.Build();
@@ -82,6 +82,32 @@ TEST(OP_LOWERING, Elementwise_TEST_Split_0) {
 
 TEST(OP_LOWERING, Elementwise_TEST_Split_1) {
   NetBuilder net_builder("Elementwise_TEST_Split_1");
+  {
+    auto A = net_builder.CreateInput(Float(32), {128, 128}, "A");
+    auto B = net_builder.Split(A, {32, 32, 32, 32}, 1);
+  }
+
+  auto program = net_builder.Build();
+  auto target  = common::DefaultTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  hlir::framework::ApplyPass(graph.get(), "FusionMergePass");
+
+  auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
+  auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
+
+  OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  for (auto& fusion_op : graph->fusion_groups) {
+    auto lowered_func = op_lowerer.Lower(fusion_op);
+    CHECK_EQ(lowered_func.size(), 1);
+    CodeGen(lowered_func[0]);
+  }
+}
+
+TEST(OP_LOWERING, Elementwise_TEST_Split_2) {
+  NetBuilder net_builder("Elementwise_TEST_Split_2");
   {
     auto A = net_builder.CreateInput(Float(32), {128, 128}, "A");
     auto B = net_builder.Split(A, {64, 32, 32}, 1);

--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -163,63 +163,63 @@ void IRCudaSplitSchedule(ir::IRSchedule &ir_sch,
                          const std::vector<std::vector<int>> &output_shapes,
                          int axis,
                          const common::Target &target) {
-  ir_sch.MergeExprs();
   VLOG(3) << "In IRCudaSplitSchedule, Before schedule expr is : " << ir_sch.GetModule().GetExprs().at(0);
-  int dims = output_shapes[0].size();
-  std::vector<int> reorders;
-  for (int i = 0; i < dims; ++i) {
-    reorders.push_back(i);
-  }
-  reorders.erase(reorders.begin() + axis);
-  reorders.push_back(axis);
-  auto all_blocks = ir_sch.GetAllBlocks();
-  for (auto &block : all_blocks) {
-    ir_sch.Reorder(block, reorders);
-  }
-  std::vector<int> fuse_index;
-  for (int i = 0; i < dims - 1; ++i) fuse_index.push_back(i);
-  all_blocks = ir_sch.GetAllBlocks();
-  for (auto &block : all_blocks) {
-    ir_sch.Fuse(block, fuse_index);
-  }
-  int fused_shape = 1;
-  for (int i = 0; i < dims; ++i) {
-    if (i != axis) fused_shape = fused_shape * output_shapes[0][i];
+  ir_sch.MergeExprs();
+  // if all output are with same shape
+  bool with_same_shape = true;
+  for (int idx = 1; idx < output_shapes.size(); ++idx) {
+    if (output_shapes[0] != output_shapes[idx]) {
+      with_same_shape = false;
+      break;
+    }
   }
 
-  all_blocks           = ir_sch.GetAllBlocks();
-  auto loops           = ir_sch.GetLoops(all_blocks.back());
-  int compute_at_level = 0;
-  if (target.arch == Target::Arch::NVGPU) {
-    if (fused_shape > target.max_num_threads()) {
-      ir_sch.Split(loops[0], {-1, target.max_num_threads()});
-      all_blocks = ir_sch.GetAllBlocks();
-      loops      = ir_sch.GetLoops(all_blocks.back());
-      CHECK_GT(loops.size(), 1);
-      ir_sch.Bind(loops[0], "blockIdx.x");
-      ir_sch.Bind(loops[1], "threadIdx.x");
-      compute_at_level++;
-    } else {
-      ir_sch.Bind(loops[0], "threadIdx.x");
+  // collect block names
+  auto get_block_name = [](ir::Expr expr) {
+    CHECK(expr.As<ir::ScheduleBlockRealize>());
+    CHECK(expr.As<ir::ScheduleBlockRealize>()->schedule_block.As<ir::ScheduleBlock>());
+    return expr.As<ir::ScheduleBlockRealize>()->schedule_block.As<ir::ScheduleBlock>()->name;
+  };
+  std::vector<std::string> block_names;
+  auto blocks = ir_sch.GetAllBlocks();
+  for (auto &block : blocks) {
+    block_names.push_back(get_block_name(block));
+  }
+  // if output with same shape.
+  if (with_same_shape && target == common::DefaultNVGPUTarget()) {
+    // flat loops.
+    {
+      for (auto &block_name : block_names) {
+        ir_sch.FlattenLoops(ir_sch.GetLoops(block_name), false);
+        // split [-1, 256]
+        auto splited = ir_sch.Split(ir_sch.GetLoops(block_name)[0], {-1, target.max_num_threads() / 4});
+        ir_sch.Bind(splited[0], "blockIdx.x");
+        ir_sch.Bind(splited[1], "threadIdx.x");
+      }
     }
-    int all_blocks_num = all_blocks.size();
-    for (int i = 0; i < all_blocks_num - 1; ++i) {
-      all_blocks = ir_sch.GetAllBlocks();
-      loops      = ir_sch.GetLoops(all_blocks[i]);
-      if (fused_shape > target.max_num_threads()) {
-        ir_sch.Split(loops[0], {-1, target.max_num_threads()});
-        all_blocks = ir_sch.GetAllBlocks();
-        loops      = ir_sch.GetLoops(all_blocks.back());
-        CHECK_GT(loops.size(), compute_at_level);
-        ir_sch.SimpleComputeAt(all_blocks[i], loops[compute_at_level]);
+    // do simple compute at.
+    {
+      for (int idx = 1; idx < block_names.size(); ++idx) {
+        auto master_loops = ir_sch.GetLoops(block_names[0]);
+        ir_sch.SimpleComputeAt(ir_sch.GetBlock(block_names[idx]), master_loops[1]);
+      }
+    }
+  } else if (target == common::DefaultNVGPUTarget()) {
+    // flat loops.
+    {
+      for (auto &block_name : block_names) {
+        ir_sch.FlattenLoops(ir_sch.GetLoops(block_name), false);
+        // split [-1, 256]
+        auto splited = ir_sch.Split(ir_sch.GetLoops(block_name)[0], {-1, target.max_num_threads() / 4});
+        ir_sch.Bind(splited[0], "blockIdx.x");
+        ir_sch.Bind(splited[1], "threadIdx.x");
       }
     }
   } else {
-    int all_blocks_num = all_blocks.size();
-    for (int i = 0; i < all_blocks_num - 1; ++i) {
-      all_blocks = ir_sch.GetAllBlocks();
-      loops      = ir_sch.GetLoops(all_blocks.back());
-      ir_sch.SimpleComputeAt(all_blocks[i], loops[0]);
+    {
+      for (auto &block_name : block_names) {
+        ir_sch.FlattenLoops(ir_sch.GetLoops(block_name), false);
+      }
     }
   }
   VLOG(3) << "In IRCudaSplitSchedule, After schedule expr is : " << ir_sch.GetModule().GetExprs().at(0);

--- a/cinn/ir/ir.cc
+++ b/cinn/ir/ir.cc
@@ -366,6 +366,9 @@ Expr Store::index() const {
   auto *tensor_n = tensor.As<ir::_Tensor_>();
   CHECK(tensor_n);
   VLOG(3) << "Begin Store::index IndiceToAbsOffset of tensor: " << this->name();
+  if (indices.size() == 1) {
+    return indices[0];
+  }
   Expr res = common::IndiceToAbsOffset(tensor_n->shape, indices);
   VLOG(3) << "Begin Store::index Simplify";
   optim::Simplify(&res);
@@ -584,6 +587,9 @@ Expr Load::index() const {
     auto *tensor_n = tensor.As<_Tensor_>();
     CHECK(tensor_n);
     VLOG(3) << "Begin Load::index IndiceToAbsOffset of tensor: " << this->name();
+    if (indices.size() == 1) {
+      return indices[0];
+    }
     Expr res = common::IndiceToAbsOffset(tensor_n->shape, indices);
     VLOG(3) << "Begin Load::index Simplify";
     optim::Simplify(&res);

--- a/cinn/ir/ir_schedule.cc
+++ b/cinn/ir/ir_schedule.cc
@@ -1574,7 +1574,7 @@ void ScheduleImpl::FlattenLoops(const std::vector<Expr>& loops, const bool flat_
           auto tsize = std::accumulate(t->shape.begin(), t->shape.end(), 1, [](const int sum, const Expr& expr) {
             return sum * expr.as_int32();
           });
-          if ((!flat_tensor && !can_do_flat(store->indices, schedule_block->iter_vars))) {
+          if ((!flat_tensor && !can_do_flat(store->indices, schedule_block->iter_vars)) || extent != tsize) {
             // just replace indexs
             for (auto& indice : store->indices) {
               if (!indice.is_var()) {
@@ -1597,7 +1597,7 @@ void ScheduleImpl::FlattenLoops(const std::vector<Expr>& loops, const bool flat_
           auto tsize = std::accumulate(t->shape.begin(), t->shape.end(), 1, [](const int sum, const Expr& expr) {
             return sum * expr.as_int32();
           });
-          if ((!flat_tensor && !can_do_flat(load->indices, schedule_block->iter_vars))) {
+          if ((!flat_tensor && !can_do_flat(load->indices, schedule_block->iter_vars)) || extent != tsize) {
             // just replace indexs
             for (auto& indice : load->indices) {
               if (!indice.is_var()) {


### PR DESCRIPTION
使用flat优化split的schedule实现.
如果输出的shape相同，则进行循环融合。
**Before Schedule.**
ScheduleBlock(root){{
      **serial for (i, 0, 128){
        serial for (j, 0, 32){**
          ScheduleBlock(var_7){
            i0, i1 = axis.bind(i, j)
            var_7[i0, i1] = A[i0, (96 + i1)]
          } } }
      **serial for (i, 0, 128){
        serial for (j, 0, 32){**
          ScheduleBlock(var_6) {
            i0, i1 = axis.bind(i, j)
            var_6[i0, i1] = A[i0, (64 + i1)]
       }} }
      **serial for (i, 0, 128){
        serial for (j, 0, 32){**
          ScheduleBlock(var_5) {
            i0, i1 = axis.bind(i, j)
            var_5[i0, i1] = A[i0, (32 + i1)]
          } }}
      **serial for (i, 0, 128) {
        serial for (j, 0, 32) {**
          ScheduleBlock(var_4){
            i0, i1 = axis.bind(i, j)
            var_4[i0, i1] = A[i0, i1]
          } } }
 }
**After Schedule**
  ScheduleBlock(root) {{
      **_thread_bind[blockIdx.x] for (flat_i_0, 0, 16){
        thread_bind[threadIdx.x] for (flat_i_1, 0, 256) {_**
          ScheduleBlock(var_4){
            _flat_i = axis.bind(((256 * flat_i_0) + flat_i_1))
            var_4[_flat_i] = A[(((_flat_i / 32) * 128) + (_flat_i % 32))]
          } {
            ScheduleBlock(var_5) {
              _flat_i = axis.bind(((256 * flat_i_0) + flat_i_1))
              var_5[_flat_i] = A[(32 + (((_flat_i / 32) * 128) + (_flat_i % 32)))]
            }{
              ScheduleBlock(var_6){
                _flat_i = axis.bind(((256 * flat_i_0) + flat_i_1))
                var_6[_flat_i] = A[(64 + (((_flat_i / 32) * 128) + (_flat_i % 32)))]
              }{
                ScheduleBlock(var_7) {
                  _flat_i = axis.bind(((256 * flat_i_0) + flat_i_1))
                  var_7[_flat_i] = A[(96 + (((_flat_i / 32) * 128) + (_flat_i % 32)))]
                } }
}
