### PR TITLE
Clean up rule unittests and block/rule sampler

### DIFF
--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_read_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_read_test.cc
@@ -87,20 +87,16 @@ TEST_F(TestAddCacheReadWith2DMatmul, BasicApplyOnMatmul) {
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
-
   // Apply AddCacheRead.
   AddCacheRead add_cache_read(target_);
   add_cache_read.Init(&ir_schedule);
   ASSERT_EQ(add_cache_read.NumberApplicable(), 1);
   add_cache_read.ApplyRandomly();
   VLOG(6) << "Matmul Expr after AddCacheRead: " << func_bodys[0];
-
   // build ir::Module and debug source code
   auto build_module = BuildIRModule(func_bodys);
   auto source_code  = GenSourceCode(build_module);
   VLOG(6) << "scheduled source code:\n" << source_code;
-  // execute and check precision
-  CheckPrecision(build_module);
 
   // ApplyOnBlock
   // Apply AddCacheRead.
@@ -110,34 +106,31 @@ TEST_F(TestAddCacheReadWith2DMatmul, BasicApplyOnMatmul) {
   EXPECT_EQ(exprs.size(), 1UL);
   VLOG(6) << "Matmul Expr after AddCacheRead applied on block: " << exprs[0];
   // build ir::Module and debug source code
-  build_module = BuildIRModule(exprs);
-  source_code  = GenSourceCode(build_module);
-  VLOG(6) << "ApplyOnBlock scheduled source code:\n" << source_code;
+  auto build_module_applied_on_block = BuildIRModule(exprs);
+  auto source_code_applied_on_block  = GenSourceCode(build_module_applied_on_block);
+  VLOG(6) << "ApplyOnBlock scheduled source code:\n" << source_code_applied_on_block;
+  EXPECT_EQ(source_code_applied_on_block, source_code);
   // execute and check precision
-  CheckPrecision(build_module);
+  CheckPrecision(build_module_applied_on_block);
 }
 
 TEST_F(TestAddCacheReadWith2DMatmul, ApplyOnMatmulWithTiling) {
-  ir::IRSchedule ir_schedule = Initialize("matmul_apply_add_cache_read", {{32, 32}, {32, 32}}, {{32, 32}});
-  SearchState state(ir_schedule, 0, {});
+  ir::IRSchedule ir_schedule       = Initialize("matmul_apply_add_cache_read", {{32, 32}, {32, 32}}, {{32, 32}});
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
-
   // Apply MultiLevelTiling before AddCacheRead.
   MultiLevelTiling multi_level_tiling(target_);
   multi_level_tiling.Init(&ir_schedule);
   ASSERT_EQ(multi_level_tiling.NumberApplicable(), 1);
   multi_level_tiling.ApplyRandomly();
   VLOG(6) << "Expr after MultiLevelTiling: " << func_bodys[0];
-
   // Apply AddCacheRead.
   AddCacheRead add_cache_read(target_);
   add_cache_read.Init(&ir_schedule);
   ASSERT_EQ(add_cache_read.NumberApplicable(), 1);
   add_cache_read.ApplyRandomly();
   VLOG(6) << "Expr after AddCacheRead: " << func_bodys[0];
-
   // build ir::Module and debug source code
   auto build_module = BuildIRModule(func_bodys);
   auto source_code  = GenSourceCode(build_module);
@@ -146,6 +139,8 @@ TEST_F(TestAddCacheReadWith2DMatmul, ApplyOnMatmulWithTiling) {
   CheckPrecision(build_module);
 
   // ApplyOnBlock
+  ir_schedule = Initialize("matmul_apply_add_cache_read_on_block", {{32, 32}, {32, 32}}, {{32, 32}});
+  SearchState state(ir_schedule, 0, {});
   // Apply MultiLevelTiling before AddCacheRead.
   EXPECT_EQ(multi_level_tiling.AnalyseApplyType(state, "C"), RuleApplyType::kApplyAndSkipThisRule);
   auto states_after_tiling    = multi_level_tiling.ApplyOnBlock(state, "C");

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -92,20 +92,16 @@ TEST_F(TestAddCacheWriteWith2DMatmul, BasicApplyOnMatmul) {
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
-
   // Apply AddCacheWrite
   AddCacheWrite add_cache_write(target_);
   add_cache_write.Init(&ir_schedule);
   ASSERT_EQ(add_cache_write.NumberApplicable(), 1);
   add_cache_write.ApplyRandomly();
   VLOG(6) << "Matmul Expr after AddCacheWrite: " << func_bodys[0];
-
   // build ir::Module and debug source code
   auto build_module = BuildIRModule(func_bodys);
   auto source_code  = GenSourceCode(build_module);
   VLOG(6) << "scheduled source code:\n" << source_code;
-  // execute and check precision
-  CheckPrecision(build_module);
 
   // ApplyOnBlock
   // Apply AddCacheWrite.
@@ -115,34 +111,31 @@ TEST_F(TestAddCacheWriteWith2DMatmul, BasicApplyOnMatmul) {
   EXPECT_EQ(exprs.size(), 1UL);
   VLOG(6) << "Matmul Expr after AddCacheWrite applied on block: " << exprs[0];
   // build ir::Module and debug source code
-  build_module = BuildIRModule(exprs);
-  source_code  = GenSourceCode(build_module);
-  VLOG(6) << "ApplyOnBlock scheduled source code:\n" << source_code;
+  auto build_module_applied_on_block = BuildIRModule(exprs);
+  auto source_code_applied_on_block  = GenSourceCode(build_module_applied_on_block);
+  VLOG(6) << "ApplyOnBlock scheduled source code:\n" << source_code_applied_on_block;
+  EXPECT_EQ(source_code_applied_on_block, source_code);
   // execute and check precision
-  CheckPrecision(build_module);
+  CheckPrecision(build_module_applied_on_block);
 }
 
 TEST_F(TestAddCacheWriteWith2DMatmul, ApplyOnMatmulWithTiling) {
-  ir::IRSchedule ir_schedule = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
-  SearchState state(ir_schedule, 0, {});
+  ir::IRSchedule ir_schedule       = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
-
   // Apply MultiLevelTiling before AddCacheWrite
   MultiLevelTiling multi_level_tiling(target_);
   multi_level_tiling.Init(&ir_schedule);
   ASSERT_EQ(multi_level_tiling.NumberApplicable(), 1);
   multi_level_tiling.ApplyRandomly();
   VLOG(6) << "Expr after MultiLevelTiling: " << func_bodys[0];
-
   // Apply AddCacheWrite
   AddCacheWrite add_cache_write(target_);
   add_cache_write.Init(&ir_schedule);
   ASSERT_EQ(add_cache_write.NumberApplicable(), 1);
   add_cache_write.ApplyRandomly();
   VLOG(6) << "Expr after AddCacheWrite: " << func_bodys[0];
-
   // build ir::Module and debug source code
   auto build_module = BuildIRModule(func_bodys);
   auto source_code  = GenSourceCode(build_module);
@@ -151,6 +144,8 @@ TEST_F(TestAddCacheWriteWith2DMatmul, ApplyOnMatmulWithTiling) {
   CheckPrecision(build_module);
 
   // ApplyOnBlock
+  ir_schedule = Initialize("matmul_apply_add_cache_write_on_block", {{32, 32}, {32, 32}}, {{32, 32}});
+  SearchState state(ir_schedule, 0, {});
   // Apply MultiLevelTiling before AddCacheRead.
   EXPECT_EQ(multi_level_tiling.AnalyseApplyType(state, "C"), RuleApplyType::kApplyAndSkipThisRule);
   auto states_after_tiling    = multi_level_tiling.ApplyOnBlock(state, "C");

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write_test.cc
@@ -87,7 +87,8 @@ TEST_F(TestAddCacheWriteWith2DMatmul, Init) {
 }
 
 TEST_F(TestAddCacheWriteWith2DMatmul, BasicApplyOnMatmul) {
-  ir::IRSchedule ir_schedule       = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
+  ir::IRSchedule ir_schedule = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
+  SearchState state(ir_schedule, 0, {});
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
@@ -105,33 +106,25 @@ TEST_F(TestAddCacheWriteWith2DMatmul, BasicApplyOnMatmul) {
   VLOG(6) << "scheduled source code:\n" << source_code;
   // execute and check precision
   CheckPrecision(build_module);
-}
 
-TEST_F(TestAddCacheWriteWith2DMatmul, ApplyOnBlock) {
-  ir::IRSchedule ir_schedule       = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
-  std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
-  ASSERT_EQ(func_bodys.size(), 1UL);
-  VLOG(6) << "Original Expr:\n" << func_bodys[0];
-  SearchState state(ir_schedule, 0, {});
-
-  // Apply AddCacheWrite
-  AddCacheWrite add_cache_write(target_);
+  // ApplyOnBlock
+  // Apply AddCacheWrite.
   EXPECT_EQ(add_cache_write.AnalyseApplyType(state, "C"), RuleApplyType::kApplyAndSkipAllRules);
   auto new_states             = add_cache_write.ApplyOnBlock(state, "C");
   std::vector<ir::Expr> exprs = new_states[0]->ir_schedule.GetModule().GetExprs();
   EXPECT_EQ(exprs.size(), 1UL);
-  VLOG(6) << "Matmul Expr after AddCacheWrite: " << exprs[0];
-
+  VLOG(6) << "Matmul Expr after AddCacheWrite applied on block: " << exprs[0];
   // build ir::Module and debug source code
-  auto build_module = BuildIRModule(func_bodys);
-  auto source_code  = GenSourceCode(build_module);
-  VLOG(6) << "scheduled source code:\n" << source_code;
+  build_module = BuildIRModule(exprs);
+  source_code  = GenSourceCode(build_module);
+  VLOG(6) << "ApplyOnBlock scheduled source code:\n" << source_code;
   // execute and check precision
   CheckPrecision(build_module);
 }
 
 TEST_F(TestAddCacheWriteWith2DMatmul, ApplyOnMatmulWithTiling) {
-  ir::IRSchedule ir_schedule       = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
+  ir::IRSchedule ir_schedule = Initialize("matmul_apply_add_cache_write", {{32, 32}, {32, 32}}, {{32, 32}});
+  SearchState state(ir_schedule, 0, {});
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
@@ -154,6 +147,26 @@ TEST_F(TestAddCacheWriteWith2DMatmul, ApplyOnMatmulWithTiling) {
   auto build_module = BuildIRModule(func_bodys);
   auto source_code  = GenSourceCode(build_module);
   VLOG(6) << "scheduled source code:\n" << source_code;
+  // execute and check precision
+  CheckPrecision(build_module);
+
+  // ApplyOnBlock
+  // Apply MultiLevelTiling before AddCacheRead.
+  EXPECT_EQ(multi_level_tiling.AnalyseApplyType(state, "C"), RuleApplyType::kApplyAndSkipThisRule);
+  auto states_after_tiling    = multi_level_tiling.ApplyOnBlock(state, "C");
+  std::vector<ir::Expr> exprs = states_after_tiling[0]->ir_schedule.GetModule().GetExprs();
+  EXPECT_EQ(exprs.size(), 1UL);
+  VLOG(6) << "Expr after MultiLevelTiling applied on block: " << exprs[0];
+  // Apply AddCacheRead.
+  EXPECT_EQ(add_cache_write.AnalyseApplyType(state, "C"), RuleApplyType::kApplyAndSkipAllRules);
+  auto states_after_cache_write = add_cache_write.ApplyOnBlock(state, "C");
+  exprs                         = states_after_cache_write[0]->ir_schedule.GetModule().GetExprs();
+  EXPECT_EQ(exprs.size(), 1UL);
+  VLOG(6) << "Matmul Expr after AddCacheWrite applied on block: " << exprs[0];
+  // build ir::Module and debug source code
+  build_module = BuildIRModule(exprs);
+  source_code  = GenSourceCode(build_module);
+  VLOG(6) << "ApplyOnBlock scheduled source code:\n" << source_code;
   // execute and check precision
   CheckPrecision(build_module);
 }

--- a/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/auto_unroll_test.cc
@@ -77,67 +77,30 @@ TEST(AutoUnroll, UnrollableApply) {
 
   AutoUnroll test_rule(target);
   ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
+  SearchState state(ir_schedule, 0, {});
   ASSERT_EQ(test_rule.Init(&ir_schedule), RuleApplyType::kApplyAndSkipThisRule);
   EXPECT_EQ(test_rule.NumberApplicable(), 1);
   test_rule.ApplyRandomly();
 
-  Expr applied_expr            = ir_schedule.GetModule().GetExprs().front();
-  auto* applied_block_realize  = applied_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>();
-  auto* applied_schedule_block = applied_block_realize->schedule_block.As<ir::ScheduleBlock>();
-  ASSERT_FALSE(applied_schedule_block->attrs.empty());
-  EXPECT_EQ(applied_schedule_block->attrs.count(ir::attr::auto_unroll_max_step), 1);
-  const auto& attr_value = applied_schedule_block->attrs.at(ir::attr::auto_unroll_max_step);
-  const int* max_step    = absl::get_if<int>(&attr_value);
-  EXPECT_NE(max_step, nullptr);
-  EXPECT_LE(*max_step, 128);
-  VLOG(6) << "After auto-unroll:max_step=" << *max_step << ", Ast:\n" << ir_schedule.GetModule().GetExprs().front();
-}
-
-TEST(AutoUnroll, ApplyOnBlock) {
-  using namespace ir;
-
-  Expr M(100);
-  Expr N(4);
-  Expr K(32);
-  Placeholder<float> A("A", {M, K});
-  Placeholder<float> B("B", {K, N});
-  Var k(K.as_int32(), "k0");
-  Tensor C = Compute(
-      {M, N}, [&](Var i, Var j) { return ReduceSum(A(i, k) * B(k, j), {k}); }, "C");
-
-#ifdef CINN_WITH_CUDA
-  Target target = common::DefaultNVGPUTarget();
-#else
-  Target target = common::DefaultHostTarget();
-#endif
-  auto stages = CreateStages({C});
-  auto funcs  = cinn::lang::LowerVec("test_unrollable", stages, {A, B, C}, {}, {}, nullptr, target, true);
-
-  auto ast_expr             = funcs[0]->body;
-  auto* init_block_realize  = ast_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>();
-  auto* init_schedule_block = init_block_realize->schedule_block.As<ir::ScheduleBlock>();
-  ASSERT_NE(init_schedule_block, nullptr);
-  ASSERT_TRUE(init_schedule_block->attrs.empty());
-  VLOG(6) << "Before auto-unroll:\n" << ast_expr;
-
-  AutoUnroll test_rule(target);
-  ir::IRSchedule ir_schedule(ir::ModuleExpr({ast_expr}));
-  SearchState state(ir_schedule, 0, {});
-
+  // ApplyOnBlock
   EXPECT_EQ(test_rule.AnalyseApplyType(state, "C"), RuleApplyType::kApplyAndSkipThisRule);
   std::vector<cinn::auto_schedule::SearchState> states = test_rule.ApplyOnBlock(state, "C");
 
-  Expr applied_expr            = states[0]->ir_schedule.GetModule().GetExprs().front();
-  auto* applied_block_realize  = applied_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>();
-  auto* applied_schedule_block = applied_block_realize->schedule_block.As<ir::ScheduleBlock>();
-  ASSERT_FALSE(applied_schedule_block->attrs.empty());
-  EXPECT_EQ(applied_schedule_block->attrs.count(ir::attr::auto_unroll_max_step), 1);
-  const auto& attr_value = applied_schedule_block->attrs.at(ir::attr::auto_unroll_max_step);
-  const int* max_step    = absl::get_if<int>(&attr_value);
-  EXPECT_NE(max_step, nullptr);
-  EXPECT_LE(*max_step, 128);
-  VLOG(6) << "After auto-unroll:max_step=" << *max_step << ", Ast:\n"
-          << states[0]->ir_schedule.GetModule().GetExprs().front();
+  auto test_func = [](IRSchedule* ir_sch) {
+    Expr applied_expr            = ir_sch->GetModule().GetExprs().front();
+    auto* applied_block_realize  = applied_expr.As<ir::Block>()->stmts.front().As<ir::ScheduleBlockRealize>();
+    auto* applied_schedule_block = applied_block_realize->schedule_block.As<ir::ScheduleBlock>();
+    ASSERT_FALSE(applied_schedule_block->attrs.empty());
+    EXPECT_EQ(applied_schedule_block->attrs.count(ir::attr::auto_unroll_max_step), 1);
+    const auto& attr_value = applied_schedule_block->attrs.at(ir::attr::auto_unroll_max_step);
+    const int* max_step    = absl::get_if<int>(&attr_value);
+    EXPECT_NE(max_step, nullptr);
+    EXPECT_LE(*max_step, 128);
+    VLOG(6) << "After auto-unroll:max_step=" << *max_step << ", Ast:\n" << ir_sch->GetModule().GetExprs().front();
+  };
+
+  test_func(&ir_schedule);
+  test_func(&states[0]->ir_schedule);
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/block_sampler.h
+++ b/cinn/auto_schedule/search_space/block_sampler.h
@@ -49,17 +49,17 @@ class BlockSampler {
   // Reset associated states to sample at the beginning
   virtual void Reset() = 0;
 
-  // Select a block to apply rule
-  // The param remove is used to determine whether to delete the next block after selecting it,
-  // If remove == true, it will not be sampled in the future.
-  virtual std::string NextBlock(bool remove) = 0;
-
   // Select a block with default remove policy.
   std::string NextBlock() { return NextBlock(default_remove_policy_); }
 
  protected:
   // A BlockSampler object should be created with the static function Make()
   BlockSampler(const std::vector<ir::Expr>& all_blocks, bool default_remove_policy);
+
+  // Select a block to apply rule
+  // The param remove is used to determine whether to delete the next block after selecting it,
+  // If remove == true, it will not be sampled in the future.
+  virtual std::string NextBlock(bool remove) = 0;
 
   // The names of all blocks
   // Because the Block Expr will be changed in the search process, the name is saved for indexing
@@ -80,6 +80,7 @@ class TraversalBlockSampler : public BlockSampler {
 
   void Reset() override { cur_idx_ = 0; }
 
+ private:
   std::string NextBlock(bool remove) override;
 
  private:
@@ -98,6 +99,7 @@ class ProbabilisticBlockSampler : public BlockSampler {
 
   void Reset() override {}
 
+ private:
   std::string NextBlock(bool remove) override;
 
  private:

--- a/cinn/auto_schedule/search_space/block_sampler_test.cc
+++ b/cinn/auto_schedule/search_space/block_sampler_test.cc
@@ -43,25 +43,30 @@ TEST(TraversalBlockSampler, NextBlock) {
   auto traversal_block_sampler = BlockSampler::Make(blocks, true, "traversal");
   ASSERT_EQ("block_0", traversal_block_sampler->NextBlock());
   ASSERT_EQ("block_1", traversal_block_sampler->NextBlock());
-  ASSERT_EQ("block_2", traversal_block_sampler->NextBlock(false));
   ASSERT_EQ("block_2", traversal_block_sampler->NextBlock());
   ASSERT_EQ("", traversal_block_sampler->NextBlock());
   traversal_block_sampler->Reset();
+  ASSERT_EQ("block_0", traversal_block_sampler->NextBlock());
+
+  traversal_block_sampler = BlockSampler::Make(blocks, false, "traversal");
+  ASSERT_EQ("block_0", traversal_block_sampler->NextBlock());
   ASSERT_EQ("block_0", traversal_block_sampler->NextBlock());
 }
 
 TEST(ProbabilisticBlockSampler, NextBlock) {
   std::vector<ir::Expr> blocks     = CreateTestBlocks();
-  auto probabilistic_block_sampler = BlockSampler::Make(blocks, true, "probabilistic", {4, 2, 1});
+  auto probabilistic_block_sampler = BlockSampler::Make(blocks, false, "probabilistic", {4, 2, 1});
   std::string block_name;
   for (int i = 0; i < 20; ++i) {
-    block_name = probabilistic_block_sampler->NextBlock(false);
+    block_name = probabilistic_block_sampler->NextBlock();
     VLOG(6) << "next block name: " << block_name;
   }
-  probabilistic_block_sampler->NextBlock(true);
-  probabilistic_block_sampler->NextBlock(true);
-  probabilistic_block_sampler->NextBlock(true);
-  ASSERT_EQ("", probabilistic_block_sampler->NextBlock(true));
+
+  probabilistic_block_sampler = BlockSampler::Make(blocks, true, "probabilistic", {4, 2, 1});
+  probabilistic_block_sampler->NextBlock();
+  probabilistic_block_sampler->NextBlock();
+  probabilistic_block_sampler->NextBlock();
+  ASSERT_EQ("", probabilistic_block_sampler->NextBlock());
 }
 
 }  // namespace auto_schedule

--- a/cinn/auto_schedule/search_space/block_sampler_test.cc
+++ b/cinn/auto_schedule/search_space/block_sampler_test.cc
@@ -32,15 +32,15 @@ std::vector<ir::Expr> CreateTestBlocks() {
 
 TEST(BlockSampler, Make) {
   std::vector<ir::Expr> mock_blocks = CreateTestBlocks();
-  auto traversal_block_sampler      = BlockSampler::Make(mock_blocks, "traversal");
+  auto traversal_block_sampler      = BlockSampler::Make(mock_blocks, true, "traversal");
   ASSERT_STREQ(traversal_block_sampler->Name(), "traversal");
-  auto probabilistic_block_sampler = BlockSampler::Make(mock_blocks, "probabilistic");
+  auto probabilistic_block_sampler = BlockSampler::Make(mock_blocks, true, "probabilistic");
   ASSERT_STREQ(probabilistic_block_sampler->Name(), "probabilistic");
 }
 
 TEST(TraversalBlockSampler, NextBlock) {
   std::vector<ir::Expr> blocks = CreateTestBlocks();
-  auto traversal_block_sampler = BlockSampler::Make(blocks, "traversal");
+  auto traversal_block_sampler = BlockSampler::Make(blocks, true, "traversal");
   ASSERT_EQ("block_0", traversal_block_sampler->NextBlock());
   ASSERT_EQ("block_1", traversal_block_sampler->NextBlock());
   ASSERT_EQ("block_2", traversal_block_sampler->NextBlock(false));
@@ -52,7 +52,7 @@ TEST(TraversalBlockSampler, NextBlock) {
 
 TEST(ProbabilisticBlockSampler, NextBlock) {
   std::vector<ir::Expr> blocks     = CreateTestBlocks();
-  auto probabilistic_block_sampler = BlockSampler::Make(blocks, "probabilistic", {4, 2, 1});
+  auto probabilistic_block_sampler = BlockSampler::Make(blocks, true, "probabilistic", {4, 2, 1});
   std::string block_name;
   for (int i = 0; i < 20; ++i) {
     block_name = probabilistic_block_sampler->NextBlock(false);

--- a/cinn/auto_schedule/search_space/rule_sampler.cc
+++ b/cinn/auto_schedule/search_space/rule_sampler.cc
@@ -21,13 +21,14 @@ namespace cinn {
 namespace auto_schedule {
 
 std::unique_ptr<RuleSampler> RuleSampler::Make(const std::vector<AutoGenRule*>& potential_rules,
+                                               bool default_remove_policy,
                                                const std::string& strategy,
                                                const std::vector<int>& weights) {
   CHECK_GT(potential_rules.size(), 0) << "Empty rule list";
   if (strategy == "traversal") {
-    return std::make_unique<TraversalRuleSampler>(potential_rules);
+    return std::make_unique<TraversalRuleSampler>(potential_rules, default_remove_policy);
   } else if (strategy == "probabilistic") {
-    return std::make_unique<ProbabilisticRuleSampler>(potential_rules, weights);
+    return std::make_unique<ProbabilisticRuleSampler>(potential_rules, default_remove_policy, weights);
   }
 
   LOG(FATAL) << "Unimplementd strategy:" << strategy;
@@ -47,8 +48,9 @@ AutoGenRule* TraversalRuleSampler::NextRule(bool remove) {
 }
 
 ProbabilisticRuleSampler::ProbabilisticRuleSampler(const std::vector<AutoGenRule*>& potential_rules,
+                                                   bool default_remove_policy,
                                                    const std::vector<int>& weights)
-    : RuleSampler(potential_rules), weights_(weights), gen_(rd_()) {
+    : RuleSampler(potential_rules, default_remove_policy), weights_(weights), gen_(rd_()) {
   if (weights.empty()) {
     weights_.resize(potential_rules.size(), 1);
   } else {

--- a/cinn/auto_schedule/search_space/rule_sampler.h
+++ b/cinn/auto_schedule/search_space/rule_sampler.h
@@ -25,57 +25,79 @@ namespace auto_schedule {
 
 class SearchState;
 
+// Select the next potential rule for the SearchState during the search process.
 class RuleSampler {
  public:
-  // Create a RuleSampler with the specific strategy name
-  // and necessary construct parameters.
+  /**
+   * @brief Create a RuleSampler with the specific strategy name and necessary construct parameters.
+   * @param potential_rules All possible rules to be sampled.
+   * @param default_remove_policy The default option to determine whether to delete the next block after selecting it.
+   * @param strategy The rule sampling strategy.
+   *                 Currently, the available strategies are "traversal" and "probabilistic",
+   *                 where "traversal" means to select rules one by one until all rules are traversed,
+   *                 and "probabilistic" means randomly picking rules according to the given distribution.
+   * @param weights Used for the probabilistic policy, giving each candidate a weight.
+   */
   static std::unique_ptr<RuleSampler> Make(const std::vector<AutoGenRule*>& potential_rules,
+                                           bool default_remove_policy      = true,
                                            const std::string& strategy     = "traversal",
                                            const std::vector<int>& weights = {});
-  // Return the name of schedule strategy
+  // Return the name of sample strategy
   virtual const char* Name() const = 0;
 
-  // Reset associated states to schedule at the beginning
+  // Reset associated states to sample at the beginning
   virtual void Reset() = 0;
 
-  // Select a rule to apply
-  virtual AutoGenRule* NextRule(bool remove = true) = 0;
+  // Select a rule to apply.
+  // The param remove is used to determine whether to delete the next rule after selecting it,
+  // If remove == true, it will not be sampled in the future.
+  virtual AutoGenRule* NextRule(bool remove) = 0;
+
+  // Select a rule with default remove policy.
+  AutoGenRule* NextRule() { return NextRule(default_remove_policy_); }
 
  protected:
   // A RuleSampler object should be created with the static function Make()
-  RuleSampler(const std::vector<AutoGenRule*>& potential_rules) : potential_rules_(&potential_rules) {}
+  RuleSampler(const std::vector<AutoGenRule*>& potential_rules, bool default_remove_policy)
+      : potential_rules_(&potential_rules), default_remove_policy_(default_remove_policy) {}
 
   // The pointer refers to all potential rules
   const std::vector<AutoGenRule*>* potential_rules_;
+
+  // The default policy to determine whether to delete the next rule after selecting it.
+  bool default_remove_policy_;
 };
 
-// Schedule rules with traversal strategy,
+// Sample rules with traversal strategy,
 // witch means to select rules one by one until all rules are traversed.
 class TraversalRuleSampler : public RuleSampler {
  public:
-  TraversalRuleSampler(const std::vector<AutoGenRule*>& potential_rules) : RuleSampler(potential_rules), cur_idx_(0) {}
+  TraversalRuleSampler(const std::vector<AutoGenRule*>& potential_rules, bool default_remove_policy)
+      : RuleSampler(potential_rules, default_remove_policy), cur_idx_(0) {}
 
   const char* Name() const override { return "traversal"; }
 
   void Reset() override { cur_idx_ = 0; }
 
-  AutoGenRule* NextRule(bool remove = true) override;
+  AutoGenRule* NextRule(bool remove) override;
 
  private:
   int cur_idx_;
 };
 
-// Schedule rules with probabilistic strategy,
+// Sample rules with probabilistic strategy,
 // witch means randomly picking rules according to the given distribution.
 class ProbabilisticRuleSampler : public RuleSampler {
  public:
-  ProbabilisticRuleSampler(const std::vector<AutoGenRule*>& potential_rules, const std::vector<int>& weights = {});
+  ProbabilisticRuleSampler(const std::vector<AutoGenRule*>& potential_rules,
+                           bool default_remove_policy,
+                           const std::vector<int>& weights = {});
 
   const char* Name() const override { return "probabilistic"; }
 
   void Reset() override {}
 
-  AutoGenRule* NextRule(bool remove = true) override;
+  AutoGenRule* NextRule(bool remove) override;
 
  private:
   std::vector<int> weights_;

--- a/cinn/auto_schedule/search_space/rule_sampler.h
+++ b/cinn/auto_schedule/search_space/rule_sampler.h
@@ -48,11 +48,6 @@ class RuleSampler {
   // Reset associated states to sample at the beginning
   virtual void Reset() = 0;
 
-  // Select a rule to apply.
-  // The param remove is used to determine whether to delete the next rule after selecting it,
-  // If remove == true, it will not be sampled in the future.
-  virtual AutoGenRule* NextRule(bool remove) = 0;
-
   // Select a rule with default remove policy.
   AutoGenRule* NextRule() { return NextRule(default_remove_policy_); }
 
@@ -60,6 +55,11 @@ class RuleSampler {
   // A RuleSampler object should be created with the static function Make()
   RuleSampler(const std::vector<AutoGenRule*>& potential_rules, bool default_remove_policy)
       : potential_rules_(&potential_rules), default_remove_policy_(default_remove_policy) {}
+
+  // Select a rule to apply.
+  // The param remove is used to determine whether to delete the next rule after selecting it,
+  // If remove == true, it will not be sampled in the future.
+  virtual AutoGenRule* NextRule(bool remove) = 0;
 
   // The pointer refers to all potential rules
   const std::vector<AutoGenRule*>* potential_rules_;
@@ -79,6 +79,7 @@ class TraversalRuleSampler : public RuleSampler {
 
   void Reset() override { cur_idx_ = 0; }
 
+ private:
   AutoGenRule* NextRule(bool remove) override;
 
  private:
@@ -97,6 +98,7 @@ class ProbabilisticRuleSampler : public RuleSampler {
 
   void Reset() override {}
 
+ private:
   AutoGenRule* NextRule(bool remove) override;
 
  private:

--- a/cinn/auto_schedule/search_space/rule_sampler_test.cc
+++ b/cinn/auto_schedule/search_space/rule_sampler_test.cc
@@ -32,15 +32,15 @@ std::vector<AutoGenRule*> GenerateTestRules() { return {new AutoUnroll(target), 
 
 TEST(RuleSampler, Make) {
   std::vector<AutoGenRule*> rules = GenerateTestRules();
-  auto traversal_block_sampler    = RuleSampler::Make(rules, "traversal");
+  auto traversal_block_sampler    = RuleSampler::Make(rules, true, "traversal");
   ASSERT_STREQ(traversal_block_sampler->Name(), "traversal");
-  auto probabilistic_block_sampler = RuleSampler::Make(rules, "probabilistic");
+  auto probabilistic_block_sampler = RuleSampler::Make(rules, true, "probabilistic");
   ASSERT_STREQ(probabilistic_block_sampler->Name(), "probabilistic");
 }
 
 TEST(TraversalRuleSampler, NextRule) {
   std::vector<AutoGenRule*> rules = GenerateTestRules();
-  auto traversal_rule_sampler     = RuleSampler::Make(rules, "traversal");
+  auto traversal_rule_sampler     = RuleSampler::Make(rules, true, "traversal");
   AutoGenRule* rule               = traversal_rule_sampler->NextRule();
   ASSERT_EQ("AutoUnroll", rule->GetRuleName());
   rule = traversal_rule_sampler->NextRule(false);
@@ -54,7 +54,7 @@ TEST(TraversalRuleSampler, NextRule) {
 
 TEST(ProbabilisticRuleSampler, NextRule) {
   std::vector<AutoGenRule*> rules = GenerateTestRules();
-  auto probabilistic_rule_sampler = RuleSampler::Make(rules, "probabilistic", {4, 1});
+  auto probabilistic_rule_sampler = RuleSampler::Make(rules, true, "probabilistic", {4, 1});
   AutoGenRule* rule;
   for (int i = 0; i < 20; ++i) {
     rule = probabilistic_rule_sampler->NextRule(false);

--- a/cinn/auto_schedule/search_space/rule_sampler_test.cc
+++ b/cinn/auto_schedule/search_space/rule_sampler_test.cc
@@ -43,26 +43,32 @@ TEST(TraversalRuleSampler, NextRule) {
   auto traversal_rule_sampler     = RuleSampler::Make(rules, true, "traversal");
   AutoGenRule* rule               = traversal_rule_sampler->NextRule();
   ASSERT_EQ("AutoUnroll", rule->GetRuleName());
-  rule = traversal_rule_sampler->NextRule(false);
-  ASSERT_EQ("SkipRule", rule->GetRuleName());
   rule = traversal_rule_sampler->NextRule();
   ASSERT_EQ("SkipRule", rule->GetRuleName());
   traversal_rule_sampler->Reset();
+  rule = traversal_rule_sampler->NextRule();
+  ASSERT_EQ("AutoUnroll", rule->GetRuleName());
+
+  traversal_rule_sampler = RuleSampler::Make(rules, false, "traversal");
+  rule                   = traversal_rule_sampler->NextRule();
+  ASSERT_EQ("AutoUnroll", rule->GetRuleName());
   rule = traversal_rule_sampler->NextRule();
   ASSERT_EQ("AutoUnroll", rule->GetRuleName());
 }
 
 TEST(ProbabilisticRuleSampler, NextRule) {
   std::vector<AutoGenRule*> rules = GenerateTestRules();
-  auto probabilistic_rule_sampler = RuleSampler::Make(rules, true, "probabilistic", {4, 1});
+  auto probabilistic_rule_sampler = RuleSampler::Make(rules, false, "probabilistic", {4, 1});
   AutoGenRule* rule;
   for (int i = 0; i < 20; ++i) {
-    rule = probabilistic_rule_sampler->NextRule(false);
+    rule = probabilistic_rule_sampler->NextRule();
     VLOG(6) << "next rule name: " << rule->GetRuleName();
   }
-  probabilistic_rule_sampler->NextRule(true);
-  probabilistic_rule_sampler->NextRule(true);
-  ASSERT_EQ(nullptr, probabilistic_rule_sampler->NextRule(true));
+
+  probabilistic_rule_sampler = RuleSampler::Make(rules, true, "probabilistic", {4, 1});
+  probabilistic_rule_sampler->NextRule();
+  probabilistic_rule_sampler->NextRule();
+  ASSERT_EQ(nullptr, probabilistic_rule_sampler->NextRule());
 }
 
 }  // namespace auto_schedule


### PR DESCRIPTION
1.Clean up the unittests of rules.
2.Move NextRule/Block(bool remove) to private in Rule/BlockSampler, only expose the interface without the remove parameter to the user, which use default_remove_policy_ to determine whether to delete the next rule/block after selecting it. Here is an example to use:
```
auto rule_sampler = RuleSampler::Make(rules, false, "probabilistic", {4, 1});
AutoGenRule* rule;
rule = rule_sampler->NextRule();
rule = rule_sampler->NextRule();
rule = rule_sampler->NextRule();
```