### PR TITLE
optimize reduce with shuffle

### DIFF
--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -167,8 +167,9 @@ __device__ inline float16 cinn_min_fp16(const float16 left, const float16 right)
 __device__ inline bool cinn_all(const bool left, const bool right) { return left && right; }
 __device__ inline bool cinn_any(const bool left, const bool right) { return left || right; }
 
-#define CINN_SHUFFLE_FUNCTION(offset, op, init) \
-  tmp_val = op((threadIdx.x & 0x1f) + offset < lane ? __shfl_down_sync(mask, tmp_val, offset, 32) : init, tmp_val);
+#define CINN_SHUFFLE_FUNCTION(offset, op, init)           \
+  shfl_res = __shfl_down_sync(mask, tmp_val, offset, 32); \
+  tmp_val  = op((threadIdx.x & 0x1f) + offset < lane ? shfl_res : init, tmp_val);
 
 #define CINN_WARP_SHUFFLE_INTERNAL_IMPL(REDUCE_TYPE, INITIAL_VALUE, DTYPE)                \
   __device__ inline DTYPE cinn_warp_shuffle_##REDUCE_TYPE##_internal(const DTYPE value) { \


### PR DESCRIPTION
优化warp shuffle reduce的使用，只有active thread in warp < 32的时候，才判断使用shuffle的值。