### PR TITLE
add FLAGS_cinn_self_check_accuracy_num for debug

### DIFF
--- a/cinn/hlir/framework/accuracy_checker.h
+++ b/cinn/hlir/framework/accuracy_checker.h
@@ -21,7 +21,7 @@ namespace cinn {
 namespace hlir {
 namespace framework {
 
-enum CheckResult { kOK = 0, kZero = 1, kNaN = 2, kInf = 3 };
+enum CheckResult { kOK = 0, kZero = 1, kNaN = 2, kInf = 3, kOne = 4 };
 
 class AccuracyChecker {
  public:

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -27,6 +27,7 @@ DEFINE_bool(cinn_cudnn_deterministic,
 
 using ::GFLAGS_NAMESPACE::BoolFromEnv;
 using ::GFLAGS_NAMESPACE::Int32FromEnv;
+using ::GFLAGS_NAMESPACE::Int64FromEnv;
 using ::GFLAGS_NAMESPACE::StringFromEnv;
 
 DEFINE_string(cinn_x86_builtin_code_root, StringFromEnv("FLAGS_cinn_x86_builtin_code_root", ""), "");
@@ -67,6 +68,10 @@ DEFINE_bool(cinn_sync_run,
 DEFINE_bool(cinn_self_check_accuracy,
             BoolFromEnv("FLAGS_cinn_self_check_accuracy", false),
             "Whether self-check accuracy after each instruction run, which is used for debug.");
+
+DEFINE_int64(cinn_self_check_accuracy_num,
+             Int64FromEnv("FLAGS_cinn_self_check_accuracy_num", 0L),
+             "Set self-check accuracy print numel, which is used for debug.");
 
 DEFINE_string(cinn_fusion_groups_graphviz_dir,
               StringFromEnv("FLAGS_cinn_fusion_groups_graphviz_dir", ""),


### PR DESCRIPTION
As title.现在`FLAGS_cinn_self_check_accuracy`默认只打印10个结果，增加`FLAGS_cinn_self_check_accuracy_num`允许自定义打印的值的数目。

```
export FLAGS_cinn_self_check_accuracy_num=-1
```

`FLAGS_cinn_self_check_accuracy_num < 0`时默认打印所有值，`FLAGS_cinn_self_check_accuracy_num = 0`时打印10个值，`FLAGS_cinn_self_check_accuracy_num > 0`时打印`2 * FLAGS_cinn_self_check_accuracy_num`个值。