### PR TITLE
fix_issue583_Remove unnecessary null pointer checks

### DIFF
--- a/cinn/runtime/buffer.cc
+++ b/cinn/runtime/buffer.cc
@@ -26,7 +26,6 @@ Shape::Shape(const Shape &other) : data_(new value_type[other.ndims()]), ndims_(
 void Shape::Resize(int ndim) {
   CHECK_GT(ndim, 0);
   ndims_ = ndim;
-  if (data_) delete data_;
   data_ = new value_type[ndim];
 }
 

--- a/cinn/runtime/buffer.cc
+++ b/cinn/runtime/buffer.cc
@@ -26,7 +26,8 @@ Shape::Shape(const Shape &other) : data_(new value_type[other.ndims()]), ndims_(
 void Shape::Resize(int ndim) {
   CHECK_GT(ndim, 0);
   ndims_ = ndim;
-  data_  = new value_type[ndim];
+  delete data_;
+  data_ = new value_type[ndim];
 }
 
 Shape::value_type &Shape::operator[](int i) {

--- a/cinn/runtime/buffer.cc
+++ b/cinn/runtime/buffer.cc
@@ -26,7 +26,7 @@ Shape::Shape(const Shape &other) : data_(new value_type[other.ndims()]), ndims_(
 void Shape::Resize(int ndim) {
   CHECK_GT(ndim, 0);
   ndims_ = ndim;
-  data_ = new value_type[ndim];
+  data_  = new value_type[ndim];
 }
 
 Shape::value_type &Shape::operator[](int i) {

--- a/cinn/runtime/buffer.h
+++ b/cinn/runtime/buffer.h
@@ -73,9 +73,7 @@ class Buffer {
     CHECK(data_) << "alloc buffer failed";
   }
   //! Deallocate the memory in host device.
-  void DeallocHost() {
-    data_ = nullptr;
-  }
+  void DeallocHost() { data_ = nullptr; }
 
   T& operator()(int i0) {
     CHECK_EQ(shape_.ndims(), 1);

--- a/cinn/runtime/buffer.h
+++ b/cinn/runtime/buffer.h
@@ -74,7 +74,6 @@ class Buffer {
   }
   //! Deallocate the memory in host device.
   void DeallocHost() {
-    if (data_) delete data_;
     data_ = nullptr;
   }
 


### PR DESCRIPTION
fix_issue583_remove_nullpoint: https://github.com/PaddlePaddle/CINN/issues/583
del:
[An extra null pointer check is not needed in functions](https://isocpp.org/wiki/faq/freestore-mgmt#delete-handles-null) like the following.

[Buffer::DeallocHost](https://github.com/PaddlePaddle/CINN/blob/85ab4981a38926dc5c1dbf672762cec335d2b857/cinn/runtime/buffer.h#L77)
[Shape::Resize](https://github.com/PaddlePaddle/CINN/blob/85ab4981a38926dc5c1dbf672762cec335d2b857/cinn/runtime/buffer.cc#L29)