### PR TITLE
[IrSchedule] SamplePerfectTile

### DIFF
--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -351,6 +351,21 @@ class IRSchedule {
   // TODO(sunli): Solve Index Simplify.
   void FlattenLoops(const std::vector<Expr>& loops, const bool force_flat = false);
 
+  /*!
+   * \brief Number of random sampling cycles for the loop to be split
+   * \param loop the loop to be split
+   * \param n the number of loop layers to split
+   * \param max_innermost_factor the maximum factor of the innermost loop
+   * \return the split factors of the loop (The larger the index, the inner the corresponding loop)
+   * For example, return {16,64} means the loop will be like this:
+   * for (i, 0, 16) {
+   *  for (j, 0, 64) {
+   *   ...
+   *  }
+   * }
+   */
+  std::vector<Expr> SamplePerfectTile(const Expr& loop, int n, int max_innermost_factor);
+
  private:
   std::unique_ptr<ScheduleImpl> impl_;
   mutable ScheduleDesc trace_;  // trace the scheduling process

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -352,7 +352,7 @@ class IRSchedule {
   void FlattenLoops(const std::vector<Expr>& loops, const bool force_flat = false);
 
   /*!
-   * \brief Number of random sampling cycles for the loop to be split
+   * \brief Sample the factors to tile a specific loop perfectly
    * \param loop the loop to be split
    * \param n the number of loop layers to split
    * \param max_innermost_factor the maximum factor of the innermost loop

--- a/cinn/ir/ir_schedule_util.cc
+++ b/cinn/ir/ir_schedule_util.cc
@@ -962,5 +962,47 @@ bool ContainVar(const std::vector<Expr>& exprs, const std::string& var_name) {
   return false;
 }
 
+int SampleInt(int min, int max, uint32_t seed) {
+  // TODO(PuQing): If the seed always be a constant, the random number will be the same.
+  std::default_random_engine rng(seed);
+  std::uniform_int_distribution<int> dist(min, max);
+  return dist(rng);
+}
+
+std::unordered_map<int, int> PrimeFactorize(int n) {
+  std::unordered_map<int, int> factors;
+  while (n % 2 == 0) {
+    ++factors[2];
+    n /= 2;
+  }
+  for (int i = 3; i <= sqrt(n); i += 2) {
+    while (n % i == 0) {
+      ++factors[i];
+      n /= i;
+    }
+  }
+  if (n > 2) {
+    factors[n] = 1;
+  }
+  return factors;
+}
+
+std::vector<int> SampleTile(uint32_t seed, int n, int extent) {
+  if (n == 1) {
+    return {extent};
+  }
+  std::vector<int> tile;
+  std::unordered_map<int, int> factors = PrimeFactorize(extent);
+  int product                          = 1;
+  for (auto& factor : factors) {
+    if (factor.second >= 1) {
+      int num = ir::SampleInt(1, factor.second, seed);
+      product *= std::pow(factor.first, num);
+    }
+  }
+  auto result = SampleTile(seed, n - 1, extent / product);
+  result.push_back(product);
+  return result;
+}
 }  // namespace ir
 }  // namespace cinn

--- a/cinn/ir/ir_schedule_util.cc
+++ b/cinn/ir/ir_schedule_util.cc
@@ -988,21 +988,22 @@ std::unordered_map<int, int> PrimeFactorize(int n) {
 }
 
 std::vector<int> SampleTile(uint32_t seed, int n, int extent) {
-  if (n == 1) {
-    return {extent};
-  }
   std::vector<int> tile;
-  std::unordered_map<int, int> factors = PrimeFactorize(extent);
-  int product                          = 1;
-  for (auto& factor : factors) {
-    if (factor.second >= 1) {
-      int num = ir::SampleInt(1, factor.second, seed);
-      product *= std::pow(factor.first, num);
+  while (n > 1) {
+    std::unordered_map<int, int> factors = PrimeFactorize(extent);
+    int product                          = 1;
+    for (auto& factor : factors) {
+      if (factor.second >= 1) {
+        int num = ir::SampleInt(1, factor.second, seed);
+        product *= std::pow(factor.first, num);
+      }
     }
+    tile.push_back(product);
+    extent /= product;
+    --n;
   }
-  auto result = SampleTile(seed, n - 1, extent / product);
-  result.push_back(product);
-  return result;
+  tile.push_back(extent);
+  return tile;
 }
 }  // namespace ir
 }  // namespace cinn

--- a/cinn/ir/ir_schedule_util.h
+++ b/cinn/ir/ir_schedule_util.h
@@ -14,7 +14,9 @@
 
 #pragma once
 #include <map>
+#include <random>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -413,5 +415,39 @@ std::vector<IterRange> CalculateRequiredRegions(const Expr& block,
 
 Expr CheckComputeInlineValidationAndGetStore(const Expr& schedule_block, const Expr& root);
 
+/*!
+ * \brief RandomSeedController is used to control the random seed in the whole program.
+ */
+class RandomSeedController {
+  // TODO(PuQing): This is a temporary solution, maybe change it to a better one.
+ public:
+  static constexpr uint32_t seed = 1;
+};
+
+/*!
+ * \brief sample a int in [min, max].
+ * \param min The min value of the range.
+ * \param max The max value of the range.
+ * \param seed The random number generator to use.
+ */
+int SampleInt(int min, int max, uint32_t seed);
+
+/*!
+ * \brief Get the prime factors of a number.
+ * For example, 12 = 2^2 * 3^1, then the return value is {2: 2, 3: 1}.
+ * \param n The number to be factorized.
+ * \return A map of prime factors and their corresponding exponents.
+ */
+std::unordered_map<int, int> PrimeFactorize(int n);
+
+/*!
+ * \brief Given a number returns the form of the product of its n factors
+ * For example:
+ *  n = 2, dividend = 12, return one of {2, 6}, {6, 2}, {3, 4}, {4, 3}
+ * \param seed The random number generator to use.
+ * \param n The number to be factorized.
+ * \param dividend The dividend of the number.
+ */
+std::vector<int> SampleTile(uint32_t seed, int n, int dividend);
 }  // namespace ir
 }  // namespace cinn

--- a/cinn/ir/schedule_desc.cc
+++ b/cinn/ir/schedule_desc.cc
@@ -462,6 +462,11 @@ CINN_BUILD_STEP_KIND(FlattenLoops)
     .Attrs({"force_flat"})
     .SetApplyFn(APPLY_FUNC_UNIFORM(FREE_FUNCTION_CONVERTER(&IRSchedule::FlattenLoops)));
 
+CINN_BUILD_STEP_KIND(SamplePerfectTile)
+    .Inputs({"loop"})
+    .Attrs({"n","max_innermost_factor"})
+    .SetApplyFn(APPLY_FUNC_UNIFORM(FREE_FUNCTION_CONVERTER(&IRSchedule::SamplePerfectTile)));
+
 // clang-format on
 
 // ------ Following codes are about member function implement of the ScheduleDesc class

--- a/cinn/ir/schedule_desc_test.cc
+++ b/cinn/ir/schedule_desc_test.cc
@@ -676,5 +676,30 @@ TEST_F(TestScheduleDesc, StepKind_Unannotate) {
   CheckReplayResult(ir_sch, trace);
   CheckReplayResult(ir_sch, ir_sch.GetTraceDesc());
 }
+
+TEST_F(TestScheduleDesc, StepKind_SamplePerfectTile) {
+  Expr M(1024);
+  Var n(1, "n");
+
+  Placeholder<int> A("A", {M});
+  auto B = Compute(
+      {M}, [&](Expr i) { return A(i) + n; }, "B");
+  lowered_funcs =
+      cinn::lang::LowerVec("test_sample_perfect_tile", CreateStages({A, B}), {A, B}, {}, {}, nullptr, target, true);
+
+  ir::IRSchedule ir_sch = MakeIRSchedule(lowered_funcs);
+  auto loops            = ir_sch.GetLoops("B");
+  trace.Append(ScheduleDesc::Step("GetLoopsWithName", {}, {{"block_name", std::string("B")}}, loops));
+  auto result = ir_sch.SamplePerfectTile(loops[0], 2, 64);
+  trace.Append(ScheduleDesc::Step("SamplePerfectTile",
+                                  {{"loop", std::vector<Expr>({loops[0]})}},
+                                  {{"n", 2}, {"max_innermost_factor", 64}},
+                                  result));
+  CheckTracingOutputs(result, trace);
+  CheckTracingOutputs(result, ir_sch.GetTraceDesc());
+  CheckReplayResult(ir_sch, trace);
+  CheckReplayResult(ir_sch, ir_sch.GetTraceDesc());
+}
+
 }  // namespace ir
 }  // namespace cinn


### PR DESCRIPTION
该 Pr 新增了 SamplePerfectTile 调度原语，其功能为对需要分裂的循环随机采样循环次数

参数

- `loop` 要进行分裂的Loop
- `n` 要分裂的循环层数
- `max_innermost_factor` 最内层循环的次数限制

返回

- `std::vector<Expr>` 采样到的tile size, 其 index 越大，代表的循环越靠内部，如

```cpp
对于循环

for (i, 0, 1024) {
  ...
}

auto result = ir_schedule.SamplePerfectTile(for_node, 2, 64)
// result: [16, 64]

则对应的循环为

for (i, 0, 16) {
 for (j, 0, 64) {
  ...
 }
}
```

而为了保持该调度可 trace ，临时使用了一个 random seed 控制器，用于控制随机种子，希望建议更好方案
