### PR TITLE
[BugFix]Fix reduce_xx infershape bug while aixs < 0

### DIFF
--- a/cinn/hlir/op/reduction.cc
+++ b/cinn/hlir/op/reduction.cc
@@ -14,6 +14,7 @@
 
 #include "cinn/hlir/pe/reduction.h"
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
@@ -382,6 +383,10 @@ std::vector<shape_t> InferShapeForReduction(const std::vector<shape_t> &inputs_s
     for (int i = 0; i < ndim; ++i) {
       dim.emplace_back(i);
     }
+  } else {
+    std::for_each(dim.begin(), dim.end(), [&ndim](int &x) {
+      if (x < 0) x += ndim;
+    });
   }
 
   std::vector<int> out_shapes;

--- a/cinn/hlir/op/reduction.cc
+++ b/cinn/hlir/op/reduction.cc
@@ -55,7 +55,7 @@ std::shared_ptr<OpStrategy> StrategyForReduce(const framework::NodeAttr &attrs,
                                               BlockReduceFunc gpu_reduce_without_last_axis_func,
                                               ReduceFunc cpu_reduce_func) {
   std::vector<int> reduce_axes;
-  auto ndim = inputs_shape[0].size();
+  auto ndim = inputs[0]->shape.size();
   if (attrs.attr_store.count("dim")) {
     reduce_axes = absl::get<std::vector<int>>(attrs.attr_store.at("dim"));
     if (reduce_axes.empty()) {

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -239,7 +239,7 @@ TEST(Operator, Operator_Reduction_Case_6_1) {
   std::vector<int> shape = {32, 32, 32};
   std::vector<int> dim   = {-2, -1, 0};
 
-  GenReduceCode(shape, dim, "reduce_cast_6_1", True);
+  GenReduceCode(shape, dim, "reduce_cast_6_1", true);
 }
 
 struct SumOp {

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -235,11 +235,11 @@ TEST(Operator, Operator_Reduction_Case_6_00) {
   GenReduceCode(shape, dim, "reduce_cast_6_00", false);
 }
 
-TEST(Operator, Operator_Reduction_Case_6_1) {
+TEST(Operator, Operator_Reduction_Case_6_10) {
   std::vector<int> shape = {32, 32, 32};
   std::vector<int> dim   = {-2, -1, 0};
 
-  GenReduceCode(shape, dim, "reduce_cast_6_1", true);
+  GenReduceCode(shape, dim, "reduce_cast_6_10", true);
 }
 
 struct SumOp {

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -179,6 +179,13 @@ TEST(Operator, Operator_Reduction_Case_2) {
   GenReduceCode(shape, dim, "reduce_cast_2", true);
 }
 
+TEST(Operator, Operator_Reduction_Case_2_1) {
+  std::vector<int> shape = {16, 16, 32, 32};
+  std::vector<int> dim   = {-1};
+
+  GenReduceCode(shape, dim, "reduce_cast_2_1", true);
+}
+
 TEST(Operator, Operator_Reduction_Case_3) {
   std::vector<int> shape = {16, 16, 64, 64};
   std::vector<int> dim   = {1};
@@ -226,6 +233,13 @@ TEST(Operator, Operator_Reduction_Case_6_00) {
   std::vector<int> dim   = {0, 1, 2};
 
   GenReduceCode(shape, dim, "reduce_cast_6_00", false);
+}
+
+TEST(Operator, Operator_Reduction_Case_6_1) {
+  std::vector<int> shape = {32, 32, 32};
+  std::vector<int> dim   = {-2, -1, 0};
+
+  GenReduceCode(shape, dim, "reduce_cast_6_1", True);
 }
 
 struct SumOp {


### PR DESCRIPTION
### 一、复现代码
```python
import paddle
import numpy as np
import time

def softmax( x ):
    max1 = paddle.max( x, axis = -1, keepdim=True)  # <<--- axis = 3 精度可以对齐
    t = paddle.exp(x - max1)

    sum1 = paddle.sum( t, axis = -1, keepdim=True)  # <<--- axis = 3 精度可以对齐

    return t/sum1


# baseline result
a = paddle.uniform( [128, 12, 128, 128], dtype="float32")
out1 = paddle.nn.functional.softmax( a )


class Net(paddle.nn.Layer):
    def __init__(self):
        super(Net, self).__init__()

    def forward(self, x):
        return softmax(x)


def apply_to_static(net, build_cinn=False):
    build_strategy = paddle.static.BuildStrategy()
    build_strategy.build_cinn_pass = build_cinn
    print( "cinn pss", build_strategy.build_cinn_pass  )
    return paddle.jit.to_static(net, build_strategy=build_strategy)

net2 = Net()
net2 = apply_to_static(net2, True)
net2.eval()
out3 = net2( a )

print( np.max( out1.numpy() - out3.numpy() ) )
print( np.allclose( out1.numpy(), out3.numpy() ) )  
```
### 二、问题分析
经过日志分析，是因为cinn中的reduce_xx的infershape逻辑的bug，没有考虑axis=-1 负数的情况，导致out.shape推导错误，变成与input.shape一样了，导致触发了RemoveIdentify Pass。
<img width="1396" alt="e0f5b1848e217ee7b6dc2fe5f1f805f2" src="https://user-images.githubusercontent.com/9301846/211490910-f0e282b6-3a8c-4082-ad89-4c19fbef54c8.png">
