### PR TITLE
Fix lookup table in auto schedule

### DIFF
--- a/cinn/auto_schedule/search_space/search_space.cc
+++ b/cinn/auto_schedule/search_space/search_space.cc
@@ -178,8 +178,8 @@ std::vector<SearchState> SearchSpace::InitSketchWithRandomPrunedStrategy() {
     std::swap(p_states_cur, p_states_next);
   }
   VLOG(5) << JoinStatesDebugString(
-      "SearchSpace::InitSketchWithRandomPrunedStrategy", *p_states_next, /*verbose=*/VLOG_IS_ON(6));
-  return *p_states_next;
+      "SearchSpace::InitSketchWithRandomPrunedStrategy", *p_states_cur, /*verbose=*/VLOG_IS_ON(6));
+  return *p_states_cur;
 }
 
 std::vector<SearchState> SearchSpace::InitiSketchWithRulePrunedStrategy() {
@@ -210,8 +210,8 @@ std::vector<SearchState> SearchSpace::InitiSketchWithRulePrunedStrategy() {
     std::swap(p_states_cur, p_states_next);
   }
   VLOG(5) << JoinStatesDebugString(
-      "SearchSpace::InitiSketchWithRulePrunedStrategy", *p_states_next, /*verbose=*/VLOG_IS_ON(6));
-  return *p_states_next;
+      "SearchSpace::InitiSketchWithRulePrunedStrategy", *p_states_cur, /*verbose=*/VLOG_IS_ON(6));
+  return *p_states_cur;
 }
 
 std::vector<SearchState> SearchSpace::GenerateSketches(int num, const std::string& strategy) {
@@ -283,7 +283,8 @@ std::vector<SearchState> SearchSpace::ApplySketchRule(const SearchState& state,
       new_states.insert(new_states.end(), tmp_states.begin(), tmp_states.end());
       bool need_prune = false;
       if (prune_by_rule) {
-        need_prune = (type == RuleApplyType::kApplyAndSkipAllRules);
+        // At present, we only retain the state after applying the rule and discard the original state
+        need_prune = true;
       } else {
         std::mt19937 rng;
         rng.seed(std::random_device()());

--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -267,6 +267,13 @@ TEST_F(PerformanceTester, Scale) {
   Evaluate(ScaleProgramBuilder(input_shape, scale, bias, bias_after_scale)());
 }
 
+TEST_F(PerformanceTester, LookupTable) {
+  std::vector<int32_t> table_shape{50001, 768};
+  std::vector<int32_t> ids_shape{10, 128, 1};
+
+  Evaluate(LookupTableProgramBuilder(table_shape, ids_shape, -1)());
+}
+
 // paddle model test
 TEST_F(PerformanceTester, ResNet50) {
   std::vector<std::string> input_names       = {"inputs"};

--- a/cinn/auto_schedule/tests/single_op_program_builder.h
+++ b/cinn/auto_schedule/tests/single_op_program_builder.h
@@ -316,5 +316,26 @@ class ScaleProgramBuilder : public TestProgramBuilder {
   bool bias_after_scale_;
 };
 
+class LookupTableProgramBuilder : public TestProgramBuilder {
+ public:
+  LookupTableProgramBuilder(const std::vector<int32_t>& table_shape,
+                            const std::vector<int32_t>& ids_shape,
+                            int64_t padding_idx)
+      : table_shape_(table_shape), ids_shape_(ids_shape), padding_idx_(padding_idx) {}
+
+  frontend::Program operator()() override {
+    frontend::NetBuilder builder("lookup_net_builder");
+    auto t = builder.CreateInput(Float(32), table_shape_, "table");
+    auto i = builder.CreateInput(Int(64), ids_shape_, "ids");
+    auto y = builder.LookupTable(t, i, padding_idx_);
+    return builder.Build();
+  }
+
+ private:
+  std::vector<int32_t> table_shape_;
+  std::vector<int32_t> ids_shape_;
+  int64_t padding_idx_;
+};
+
 }  // namespace auto_schedule
 }  // namespace cinn


### PR DESCRIPTION
This pr has done the following things：
1.Fix the illegal memory bug of LookupTable Op in auto schedule. In the LookupTable Op, dirty data may cause the index to be an arbitrary value, which may be larger than the table size, causing the memory out of bounds. During auto schedule, there is no real data available, so the data used in measure is initialized to 0.
2.When generating a sketch by pruning by rule, temporarily change the pruning policy to: only retain the state after the rule is applied, and the original state and other derived branches must be deleted. This prevents the number of sketches from exploding.
3.Fix a bug in SearchSpace, when generating sketchs, return the last group of states instead of the penultimate group.