### PR TITLE
change op_mapper AddVar can_inplace default value true

### DIFF
--- a/cinn/frontend/op_mapper_registry.h
+++ b/cinn/frontend/op_mapper_registry.h
@@ -82,13 +82,13 @@ class OpMapperContext {
   NetBuilder* Builder() const { return builder_; }
 
   // add Variable into local var_map
-  void AddVar(const std::string& name, const Variable& var, bool can_inplace = false) const;
+  void AddVar(const std::string& name, const Variable& var, bool can_inplace = true) const;
 
   // get Variable from local var_map or scope
   Variable GetVar(const std::string& name) const;
 
   // add map from paddle name to cinn name into var_model_to_program_map
-  void AddVarModelToProgram(const std::string& name, const std::string& id, bool can_inplace = false) const;
+  void AddVarModelToProgram(const std::string& name, const std::string& id, bool can_inplace = true) const;
 
   void AddFetchVarName(const std::string& name) const;
 


### PR DESCRIPTION
由于含inplace变量的大算子被拆分成了框架的基础算子，所以现在所有框架基础算子都有可能是inplace的。再在op_mapper中给每个变量单独判断是否inplace已无意义