### PR TITLE
fix unary/binary elementwise python test not run bug

### DIFF
--- a/cinn/lang/builtin.cc
+++ b/cinn/lang/builtin.cc
@@ -105,7 +105,7 @@ Expr FloorDivide(Expr a, Expr b) {
 }
 
 Expr Mod(Expr a, Expr b) {
-  CHECK_EQ(a.type(), b.type()) << "FloorDivide's inputs type not equal, where a:" << a.type() << " but b:" << b.type();
+  CHECK_EQ(a.type(), b.type()) << "Mod's inputs type not equal, where a:" << a.type() << " but b:" << b.type();
   auto quotient = lang::FloorDivide(a, b);
   if (a.type().is_int()) {
     auto zero = Zero(a->type());


### PR DESCRIPTION
As title. 之前`test_unary_elementwise_op.py`和`test_binary_elementwise_op.py`实际上并没有跑到，本PR修复了该问题。