### PR TITLE
fix broadcast axis error in op_fusion_pass

### DIFF
--- a/cinn/hlir/pass/op_fusion_pass.cc
+++ b/cinn/hlir/pass/op_fusion_pass.cc
@@ -397,7 +397,7 @@ void InsertBroadcastTo(Graph* graph) {
               axis = absl::get<int>(node->attrs.attr_store["axis"]);
             }
             if (axis == -1) {
-              axis = output_shape.size() - 1;
+              axis = output_shape.size() - input_shape.size();
             }
             node->attrs.attr_store = {};
             CHECK_LE(axis + input_shape.size(), output_shape.size())

--- a/cinn/hlir/pass/op_fusion_pass_test.cc
+++ b/cinn/hlir/pass/op_fusion_pass_test.cc
@@ -114,6 +114,26 @@ TEST(OpFusionPass, Brodcast_Test_1) {
   CHECK_EQ(graph->fusion_groups.size(), 2);
 }
 
+TEST(OpFusionPass, Brodcast_Test_2) {
+  int n = 2, c = 16, h = 32, w = 32;
+  NetBuilder net_builder("Brodcast_Test_2");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {c}, "A");
+    auto B = net_builder.CreateInput(Float(32), {n, c, h, w}, "B");
+    auto C = net_builder.Reshape(A, {c, 1, 1});
+    auto D = net_builder.Multiply(B, C);
+  }
+
+  auto program = net_builder.Build();
+  auto target  = common::DefaultTarget();
+  RunDecomposer(&program, target);
+
+  auto graph = std::make_shared<hlir::framework::Graph>(program, target);
+  hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
+  CHECK_EQ(graph->fusion_groups.size(), 2);
+}
+
 TEST(OpFusionPass, Reduce_Test_0) {
   int h = 32, w = 32;
   NetBuilder net_builder("Reduce_Test_0");


### PR DESCRIPTION
The broadcast axis computing is wrong when axis=-1. For example `reshape+multiply` in the test code.

> F0131 16:21:10.939643 86471 op_fusion_pass.cc:403] Check failed: axis + input_shape.size() <= output_shape.size() (6 vs. 4) The rank of input var_11 + axis 3 should less equal rank of output var_35

This PR fixes that.

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/6888866/215758964-8bd3e3b0-f0c0-45fc-8433-8f4604f6cbcd.png">
