### PR TITLE
Fix reduce_mean bug in ir_schedule loop split

### DIFF
--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -318,10 +318,8 @@ void IRCudaScheduleReduce(ir::IRSchedule &ir_sch,
     auto loops = ir_sch.GetLoops(output->name);
     CHECK_GE(loops.size(), index + 1);
 
-    auto *for_node = loops[index].As<ir::For>();
-    CHECK(for_node->extent.is_constant()) << "The For node's extent must be constant! Please check.";
-    int tot_extent = for_node->extent.get_constant();
-    for (int idx = tot_extent; idx > 0; --idx) {
+    int tot_extent = GetLoopExtent(loops[index]);
+    for (int idx = std::min(max_block_size, tot_extent); idx > 0; --idx) {
       if (parallel_thread_num % idx == 0) {
         auto nloops = ir_sch.Split(loops[index], {-1, idx});
         ir_sch.Bind(nloops.back(), "threadIdx.x");

--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -317,7 +317,11 @@ void IRCudaScheduleReduce(ir::IRSchedule &ir_sch,
   if (parallel_thread_num > max_block_size) {
     auto loops = ir_sch.GetLoops(output->name);
     CHECK_GE(loops.size(), index + 1);
-    for (int idx = 1024; idx > 0; --idx) {
+
+    auto *for_node = loops[index].As<ir::For>();
+    CHECK(for_node->extent.is_constant()) << "The For node's extent must be constant! Please check.";
+    int tot_extent = for_node->extent.get_constant();
+    for (int idx = tot_extent; idx > 0; --idx) {
       if (parallel_thread_num % idx == 0) {
         auto nloops = ir_sch.Split(loops[index], {-1, idx});
         ir_sch.Bind(nloops.back(), "threadIdx.x");

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -101,6 +101,13 @@ class TestReduceSumCase4(TestReduceSumOp):
         self.keep_dim = True
 
 
+class TestReduceSumCase5(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([1, 16, 256], "float32", -1.0, 1.0)}
+        self.dim = [0]
+        self.keep_dim = False
+
+
 class TestReduceProdOp(TestReduceBaseOp):
     def paddle_func(self, x):
         return paddle.prod(x, axis=self.dim, keepdim=self.keep_dim)

--- a/python/tests/test_netbuilder.py
+++ b/python/tests/test_netbuilder.py
@@ -130,9 +130,7 @@ class TestNetBuilderOp1(unittest.TestCase):
         b = builder.reduce_sum(a, [0])
         prog = builder.build()
 
-        tensor_data = [
-            np.random.random([1, 16, 256]).astype("float32")
-        ]
+        tensor_data = [np.random.random([1, 16, 256]).astype("float32")]
         result = prog.build_and_get_output(self.target, [a], tensor_data, [b])
         res = result[0].numpy(self.target)
         print(res)

--- a/python/tests/test_netbuilder.py
+++ b/python/tests/test_netbuilder.py
@@ -115,5 +115,28 @@ class TestNetBuilderOp(unittest.TestCase):
         print(res)
 
 
+class TestNetBuilderOp1(unittest.TestCase):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+        else:
+            self.target = DefaultHostTarget()
+
+    def test_exp(self):
+        np.random.seed(1234)
+        builder = NetBuilder("testreduce")
+
+        a = builder.create_input(Float(32), (1, 16, 256), "A")
+        b = builder.reduce_sum(a, [0])
+        prog = builder.build()
+
+        tensor_data = [
+            np.random.random([1, 16, 256]).astype("float32")
+        ]
+        result = prog.build_and_get_output(self.target, [a], tensor_data, [b])
+        res = result[0].numpy(self.target)
+        print(res)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_netbuilder.py
+++ b/python/tests/test_netbuilder.py
@@ -115,26 +115,5 @@ class TestNetBuilderOp(unittest.TestCase):
         print(res)
 
 
-class TestNetBuilderOp1(unittest.TestCase):
-    def setUp(self):
-        if enable_gpu == "ON":
-            self.target = DefaultNVGPUTarget()
-        else:
-            self.target = DefaultHostTarget()
-
-    def test_exp(self):
-        np.random.seed(1234)
-        builder = NetBuilder("testreduce")
-
-        a = builder.create_input(Float(32), (1, 16, 256), "A")
-        b = builder.reduce_sum(a, [0])
-        prog = builder.build()
-
-        tensor_data = [np.random.random([1, 16, 256]).astype("float32")]
-        result = prog.build_and_get_output(self.target, [a], tensor_data, [b])
-        res = result[0].numpy(self.target)
-        print(res)
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
ir_schedule在拆分reduce_mean算子的循环时，由于算子shape值小于要拆分的idx值，导致循环拆分出现以下错误：
```bash
ir_schedule_util.cc:218] Check failed: product <= total_extent (1024 vs. 16) In Split, when there is -1 in factors, the other factors' product should be <= original loop's extent! Please check.

```