### PR TITLE
fixes a bug in reduce scheduler

### DIFF
--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -350,7 +350,8 @@ void IRCudaScheduleBlockReduceInternal(ir::IRSchedule &ir_sch,
                                        ir::Tensor out,
                                        const common::Target &target) {
   VLOG(3) << "Before IRCudaScheduleBlockReduceInternal : " << ir_sch.GetModule().GetExprs().at(0);
-  for (int idx = 0; idx < static_cast<int>(tmp_out->shape.size()) - 2; ++idx) {
+  int fuse_times = ir_sch.GetLoops(tmp_out->name).size() - 2;
+  for (int idx = 0; idx < fuse_times; ++idx) {
     for (auto &tensor : {tmp_out, out}) {
       auto loops = ir_sch.GetLoops(tensor->name);
       CHECK_GE(loops.size(), 2U);

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -108,6 +108,13 @@ class TestReduceSumCase5(TestReduceSumOp):
         self.keep_dim = False
 
 
+class TestReduceSumCase6(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([1, 12, 9, 9], "float32", -1.0, 1.0)}
+        self.dim = [-1]
+        self.keep_dim = False
+
+
 class TestReduceProdOp(TestReduceBaseOp):
     def paddle_func(self, x):
         return paddle.prod(x, axis=self.dim, keepdim=self.keep_dim)


### PR DESCRIPTION
修复在首维为 1，化简轴为 -1 时，reduce sceduler 的报错问题：

```
..I0203 12:30:52.421917  7883 ir_schedule_pe.cc:333] Before IRCudaScheduleBlockReduceInternal : {
  ScheduleBlock(root)
  {
    {
      serial for (j, 0, 12)
      {
        serial for (k, 0, 9)
        {
          serial for (a, 0, 9)
          {
            ScheduleBlock(var_0_tmp)
            {
              i0, i1, i2, i3 = axis.bind(0, j, k, a)
              var_0_tmp[i0, i1, i2, i3] = cinn_block_reduce_sum_fp32_internal(x[i0, i1, i2, i3])
            }
          }
        }
      }
      serial for (j, 0, 12)
      {
        serial for (k, 0, 9)
        {
          ScheduleBlock(var_0)
          {
            i0, i1, i2 = axis.bind(0, j, k)
            var_0[i0, i1, i2] = var_0_tmp[i0, i1, i2, 0]
          }
        }
      }
    }
  }
}
F0203 12:30:52.431483  7883 ir_schedule_pe.cc:337] Check failed: loops.size() >= 2U (1 vs. 2)
*** Check failure stack trace: ***

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   cinn::hlir::framework::GraphCompiler::Build(std::string const&)
1   cinn::hlir::framework::GraphCompiler::Build(cinn::hlir::framework::GraphCompiler::CompileOptions const&, std::unordered_set<std::string, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::string > >&&, void*)
2   cinn::hlir::framework::OpLowerer::Lower(std::shared_ptr<cinn::hlir::framework::Graph::Group>&)
3   cinn::hlir::framework::OpLowerer::IRLowerOp(std::vector<cinn::ir::Expr, std::allocator<cinn::ir::Expr> > (cinn::hlir::framework::OpLowerer::*)(cinn::poly::StageMap&, std::vector<cinn::ir::Tensor, std::allocator<cinn::ir::Tensor> >&, std::unordered_map<std::string, cinn::ir::Tensor, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, cinn::ir::Tensor> > >&, std::shared_ptr<cinn::hlir::framework::Graph::Group> const&, std::shared_ptr<cinn::hlir::framework::Graph::Group> const&, bool), void (cinn::hlir::framework::OpLowerer::*)(cinn::ir::IRSchedule&, std::unordered_map<std::string, cinn::ir::Tensor, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, cinn::ir::Tensor> > >&, std::shared_ptr<cinn::hlir::framework::Graph::Group> const&, std::shared_ptr<cinn::hlir::framework::Graph::Group> const&, cinn::hlir::framework::Node*&, cinn::hlir::framework::Node*&), std::shared_ptr<cinn::hlir::framework::Graph::Group>&)
4   cinn::hlir::framework::OpLowerer::IRReduceCompute(cinn::poly::StageMap&, std::vector<cinn::ir::Tensor, std::allocator<cinn::ir::Tensor> >&, std::unordered_map<std::string, cinn::ir::Tensor, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::pair<std::string const, cinn::ir::Tensor> > >&, std::shared_ptr<cinn::hlir::framework::Graph::Group> const&, std::shared_ptr<cinn::hlir::framework::Graph::Group> const&, bool)
5   cinn::common::CINNValue cinn::lang::PackedFunc::operator()<cinn::common::CINNValuePack>(cinn::common::CINNValuePack&&) const
6   std::function<void (cinn::lang::Args, cinn::common::CINNValue*)>::operator()(cinn::lang::Args, cinn::common::CINNValue*) const
7   cinn::hlir::pe::IRCudaScheduleBlockReduceInternal(cinn::ir::IRSchedule&, cinn::ir::Tensor, cinn::ir::Tensor, cinn::common::Target const&)
8   google::LogMessageFatal::~LogMessageFatal()
9   google::LogMessage::Flush()
10  google::LogMessage::SendToLog()
11  google::LogMessage::SendToSink()
12  google::InstallFailureFunction(void (*)())

----------------------
Error Message Summary:
----------------------
FatalError: `Process abort signal` is detected by the operating system.
  [TimeInfo: *** Aborted at 1675427452 (unix time) try "date -d @1675427452" if you are using GNU date ***]
  [SignalInfo: *** SIGABRT (@0x1ecb) received by PID 7883 (TID 0x7f48ef4b8740) from PID 7883 ***]

Aborted (core dumped)
```