### PR TITLE
update precompiled llvm with glibc2.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if (WITH_CUDA)
     message(STATUS "Enable CUDNN")
     add_definitions(-DCINN_WITH_CUDNN)
   endif()
+
   enable_language(CUDA)
   find_package(CUDA REQUIRED)
   include_directories(${CUDA_INCLUDE_DIRS})
@@ -61,11 +62,18 @@ if (WITH_CUDA)
   message(STATUS "copy cinn/common/float16.h to $ENV{runtime_include_dir}")
   file(COPY cinn/common/float16.h DESTINATION $ENV{runtime_include_dir})
 
+  # I found libcuda.so is not needed by any target, while libcuda.so.1 is needed.
   find_library(CUDASTUB libcuda.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/ REQUIRED)
   find_library(CUBLAS libcublas.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
   find_library(CUDNN libcudnn.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
   find_library(CURAND libcurand.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
   find_library(CUSOLVER libcusolver.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
+
+  # In manylinux docker, the libcuda.so.1 is located in /usr/local/cuda-11.2/compat, add it to RPATH
+  execute_process(COMMAND bash "-c" "find /usr -name libcuda.so.1 | head -n 1"  OUTPUT_VARIABLE CUDASO_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND bash "-c" "dirname ${CUDASO_PATH}"  OUTPUT_VARIABLE CUDASO_LIB OUTPUT_STRIP_TRAILING_WHITESPACE)
+  # find_library(CUDA_SO libcuda.so.1 HINTS ${CUDASO_LIB} REQUIRED)
+  message(STATUS "Found libcuda.so.1 in ${CUDASO_LIB}")
 endif()
 
 find_package(Threads REQUIRED)
@@ -144,7 +152,7 @@ if (WITH_MKL_CBLAS)
 endif()
 
 if (WITH_CUDA)
-  target_link_libraries(cinnapi ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN} ${CURAND} ${CUSOLVER})
+  target_link_libraries(cinnapi ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN} ${CURAND} ${CUSOLVER} ${CUDASO_PATH})
   if (NVTX_FOUND)
     target_link_libraries(cinnapi ${CUDA_NVTX_LIB})
   endif()
@@ -173,7 +181,7 @@ function(gen_cinncore LINKTYPE)
 
   if (WITH_CUDA)
     target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN}
-      ${CURAND} ${CUSOLVER} ${jitify_deps})
+      ${CURAND} ${CUSOLVER} ${jitify_deps} ${CUDASO_PATH})
     if (NVTX_FOUND)
       target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVTX_LIB})
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ if (WITH_CUDA)
     message(STATUS "Enable CUDNN")
     add_definitions(-DCINN_WITH_CUDNN)
   endif()
-
   enable_language(CUDA)
   find_package(CUDA REQUIRED)
   include_directories(${CUDA_INCLUDE_DIRS})
@@ -62,18 +61,11 @@ if (WITH_CUDA)
   message(STATUS "copy cinn/common/float16.h to $ENV{runtime_include_dir}")
   file(COPY cinn/common/float16.h DESTINATION $ENV{runtime_include_dir})
 
-  # I found libcuda.so is not needed by any target, while libcuda.so.1 is needed.
   find_library(CUDASTUB libcuda.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/ REQUIRED)
   find_library(CUBLAS libcublas.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
   find_library(CUDNN libcudnn.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
   find_library(CURAND libcurand.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
   find_library(CUSOLVER libcusolver.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib REQUIRED)
-
-  # In manylinux docker, the libcuda.so.1 is located in /usr/local/cuda-11.2/compat, add it to RPATH
-  execute_process(COMMAND bash "-c" "find /usr -name libcuda.so.1 | head -n 1"  OUTPUT_VARIABLE CUDASO_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND bash "-c" "dirname ${CUDASO_PATH}"  OUTPUT_VARIABLE CUDASO_LIB OUTPUT_STRIP_TRAILING_WHITESPACE)
-  # find_library(CUDA_SO libcuda.so.1 HINTS ${CUDASO_LIB} REQUIRED)
-  message(STATUS "Found libcuda.so.1 in ${CUDASO_LIB}")
 endif()
 
 find_package(Threads REQUIRED)
@@ -152,7 +144,7 @@ if (WITH_MKL_CBLAS)
 endif()
 
 if (WITH_CUDA)
-  target_link_libraries(cinnapi ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN} ${CURAND} ${CUSOLVER} ${CUDASO_PATH})
+  target_link_libraries(cinnapi ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN} ${CURAND} ${CUSOLVER})
   if (NVTX_FOUND)
     target_link_libraries(cinnapi ${CUDA_NVTX_LIB})
   endif()
@@ -181,7 +173,7 @@ function(gen_cinncore LINKTYPE)
 
   if (WITH_CUDA)
     target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVRTC_LIB} ${CUDA_LIBRARIES} ${CUDASTUB} ${CUBLAS} ${CUDNN}
-      ${CURAND} ${CUSOLVER} ${jitify_deps} ${CUDASO_PATH})
+      ${CURAND} ${CUSOLVER} ${jitify_deps})
     if (NVTX_FOUND)
       target_link_libraries(${CINNCORE_TARGET} ${CUDA_NVTX_LIB})
     endif()

--- a/cmake/external/llvm.cmake
+++ b/cmake/external/llvm.cmake
@@ -67,7 +67,8 @@ cmake -G Ninja ../llvm \
 #]==]
 
 # The matched llvm-project version is f9dc2b7079350d0fed3bb3775f496b90483c9e42 (currently a temporary commit)
-# Update: to beild it in manylinux docker with glibc-2.17, the patch https://gist.github.com/zhiqiu/6e8d969176dce13d98fd15338a16265e is needed.
+# Update: to build llvm in manylinux docker with glibc-2.17, and use it in manylinux and ubuntu docker,
+# the patch https://gist.github.com/zhiqiu/6e8d969176dce13d98fd15338a16265e is needed.
 
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/cmake/external/llvm.cmake
+++ b/cmake/external/llvm.cmake
@@ -1,7 +1,10 @@
 include(FetchContent)
 
-set(LLVM_DOWNLOAD_URL https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11.tar.gz)
-set(LLVM_MD5 39d32b6be466781dddf5869318dcba53)
+# set(LLVM_DOWNLOAD_URL https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11.tar.gz)
+# set(LLVM_MD5 39d32b6be466781dddf5869318dcba53)
+
+set(LLVM_DOWNLOAD_URL https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11-glibc2.17.tar.gz)
+set(LLVM_MD5 e784ddd0f8938e05af613e44357f4992)
 
 set(FETCHCONTENT_BASE_DIR ${THIRD_PARTY_PATH}/llvm)
 set(FETCHCONTENT_QUIET OFF)

--- a/cmake/external/llvm.cmake
+++ b/cmake/external/llvm.cmake
@@ -4,7 +4,7 @@ include(FetchContent)
 # set(LLVM_MD5 39d32b6be466781dddf5869318dcba53)
 
 set(LLVM_DOWNLOAD_URL https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11-glibc2.17.tar.gz)
-set(LLVM_MD5 e784ddd0f8938e05af613e44357f4992)
+set(LLVM_MD5 33c7d3cc6d370585381e8d90bd7c2198)
 
 set(FETCHCONTENT_BASE_DIR ${THIRD_PARTY_PATH}/llvm)
 set(FETCHCONTENT_QUIET OFF)
@@ -62,8 +62,12 @@ cmake -G Ninja ../llvm \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DLLVM_ENABLE_ZLIB=OFF \
   -DLLVM_ENABLE_RTTI=ON \
+  -DLLVM_ENABLE_TERMINFO=OFF \
+  -DCMAKE_INSTALL_PREFIX=./install
 #]==]
+
 # The matched llvm-project version is f9dc2b7079350d0fed3bb3775f496b90483c9e42 (currently a temporary commit)
+# Update: to beild it in manylinux docker with glibc-2.17, the patch https://gist.github.com/zhiqiu/6e8d969176dce13d98fd15338a16265e is needed.
 
 add_definitions(${LLVM_DEFINITIONS})
 


### PR DESCRIPTION
- The original llvm is compiled with glibc2.27, which is not supported in manylinux docker.