### PR TITLE
fix slice empty output shape should reshape to {1} bug

### DIFF
--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -1504,7 +1504,10 @@ std::vector<std::vector<int>> InferShapeForSlice(const std::vector<std::vector<i
         new_shape.emplace_back(output_shape[i]);
       }
     }
-    CHECK(!new_shape.empty()) << "Cannot decrease all dims, the output shape of slice should not empty!";
+    if (new_shape.empty()) {
+      // output shape should not empty
+      new_shape = {1};
+    }
 
     output_shape = new_shape;
   }

--- a/python/tests/ops/test_slice_op.py
+++ b/python/tests/ops/test_slice_op.py
@@ -123,6 +123,8 @@ class TestSliceOpWithDecreaseAxis(OpTest):
             else:
                 out_shape.append(y.shape[i])
 
+        if len(out_shape) == 0:
+            out_shape = [1]
         res = paddle.reshape(y, out_shape)
         self.paddle_outputs = [res]
 
@@ -145,6 +147,16 @@ class TestSliceOpWithDecreaseAxis(OpTest):
 
     def test_check_results(self):
         self.check_outputs_and_grads(all_equal=True)
+
+
+class TestSliceOpWithDecreaseAxisCase1(TestSliceOpWithDecreaseAxis):
+    def init_case(self):
+        self.inputs = {"inputs": np.random.random([10, 12]).astype("float32")}
+        self.axes = [0, 1]
+        self.starts = [2, 2]
+        self.ends = [5, 3]
+        self.strides = [1, 1]
+        self.decrease_axis = [0, 1]
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_slice_op.py
+++ b/python/tests/ops/test_slice_op.py
@@ -154,7 +154,7 @@ class TestSliceOpWithDecreaseAxisCase1(TestSliceOpWithDecreaseAxis):
         self.inputs = {"inputs": np.random.random([10, 12]).astype("float32")}
         self.axes = [0, 1]
         self.starts = [2, 2]
-        self.ends = [5, 3]
+        self.ends = [3, 3]
         self.strides = [1, 1]
         self.decrease_axis = [0, 1]
 


### PR DESCRIPTION
若`decrease`所有维度后所有shape为0，应该保留至少一维