### PR TITLE
remove with_data_parallel in tutorials/train_resnet50_with_cinn.py

### DIFF
--- a/tutorials/train_resnet50_with_cinn.py
+++ b/tutorials/train_resnet50_with_cinn.py
@@ -74,17 +74,14 @@ paddle.enable_static()
 # ``batch_norm,batch_norm_grad,conv2d,conv2d_grad, elementwise_add,elementwise_add_grad,relu,relu_grad,sum``
 #
 allow_ops = "batch_norm;batch_norm_grad;conv2d;conv2d_grad;elementwise_add;elementwise_add_grad;relu;relu_grad;sum"
-# allow_ops = ""
 try:
     paddle.set_flags({
         'FLAGS_use_cinn': True,
         'FLAGS_allow_cinn_ops': allow_ops
     })
-except ValueError as e:
-    print(e)
+except ValueError:
     # If the used PaddlePaddle is not compiled with CINN, just skip and
     # the following steps will not train with CINN.
-    print('[wrong]')
     pass
 
 ##################################################################

--- a/tutorials/train_resnet50_with_cinn.py
+++ b/tutorials/train_resnet50_with_cinn.py
@@ -74,14 +74,17 @@ paddle.enable_static()
 # ``batch_norm,batch_norm_grad,conv2d,conv2d_grad, elementwise_add,elementwise_add_grad,relu,relu_grad,sum``
 #
 allow_ops = "batch_norm;batch_norm_grad;conv2d;conv2d_grad;elementwise_add;elementwise_add_grad;relu;relu_grad;sum"
+# allow_ops = ""
 try:
     paddle.set_flags({
         'FLAGS_use_cinn': True,
         'FLAGS_allow_cinn_ops': allow_ops
     })
-except ValueError:
+except ValueError as e:
+    print(e)
     # If the used PaddlePaddle is not compiled with CINN, just skip and
     # the following steps will not train with CINN.
+    print('[wrong]')
     pass
 
 ##################################################################
@@ -147,8 +150,7 @@ for _ in range(loop_num):
 #
 exe = paddle.static.Executor(place)
 
-compiled_prog = paddle.static.CompiledProgram(main_program).with_data_parallel(
-    loss_name=loss.name)
+compiled_prog = paddle.static.CompiledProgram(main_program)
 scope = paddle.static.Scope()
 
 with paddle.static.scope_guard(scope):
@@ -159,4 +161,4 @@ with paddle.static.scope_guard(scope):
             feed=feed[step],
             fetch_list=[loss],
             return_numpy=True)
-        print("Train step: {} loss: {}".format(step, loss_v[0][0]))
+        print("Train step: {} loss: {}".format(step, loss_v), flush=True)


### PR DESCRIPTION
`with_data_parallel`预计于paddle2.5版本移除。此处是为了开启`build_cinn_pass`，paddle develop分支现在已经支持不使用`with_data_parallel`就打开`build_cinn_pass`，因此直接移除了这里对`with_data_parallel`的使用。


The api `with_data_parallel` will be deprecated in paddle2.5. The purpose of `with_data_parallel` here is to `build_cinn_pass`. howerver, such operation doesn't need to use `with_data_parallel` with current `paddle`(develop). So just delete it.