### PR TITLE
import conv2d accuracy by using fp32 compute type

### DIFF
--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -470,6 +470,16 @@ cudnnDataType_t convert_to_cudnn_dtype(void *v_args, int num_args) {
   return data_type;
 }
 
+cudnnDataType_t get_cudnn_compute_dtype(cudnnDataType_t data_type) {
+  switch (data_type) {
+    case CUDNN_DATA_FLOAT:
+    case CUDNN_DATA_HALF:
+      return CUDNN_DATA_FLOAT;
+    default:
+      LOG(FATAL) << "unsupported cudnn data type, only support float16 and float32 now!";
+  }
+}
+
 void cinn_call_cudnn_conv2d_forward(void *v_args,
                                     int num_args,
                                     int format,
@@ -516,8 +526,15 @@ void cinn_call_cudnn_conv2d_forward(void *v_args,
 
   cudnnConvolutionDescriptor_t conv_desc;
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-      conv_desc, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, CUDNN_CROSS_CORRELATION, data_type));
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(conv_desc,
+                                             pad_h,
+                                             pad_w,
+                                             stride_h,
+                                             stride_w,
+                                             dilation_h,
+                                             dilation_w,
+                                             CUDNN_CROSS_CORRELATION,
+                                             get_cudnn_compute_dtype(data_type)));
   CUDNN_CALL(cudnnSetConvolutionGroupCount(conv_desc, groups));
   CUDNN_CALL(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
 
@@ -607,8 +624,15 @@ void cinn_call_cudnn_conv2d_backward_data(void *v_args,
 
   cudnnConvolutionDescriptor_t conv_desc;
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-      conv_desc, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, CUDNN_CROSS_CORRELATION, data_type));
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(conv_desc,
+                                             pad_h,
+                                             pad_w,
+                                             stride_h,
+                                             stride_w,
+                                             dilation_h,
+                                             dilation_w,
+                                             CUDNN_CROSS_CORRELATION,
+                                             get_cudnn_compute_dtype(data_type)));
   CUDNN_CALL(cudnnSetConvolutionGroupCount(conv_desc, groups));
   CUDNN_CALL(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
 
@@ -703,8 +727,15 @@ void cinn_call_cudnn_conv2d_backward_filter(void *v_args,
 
   cudnnConvolutionDescriptor_t conv_desc;
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-      conv_desc, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, CUDNN_CROSS_CORRELATION, data_type));
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(conv_desc,
+                                             pad_h,
+                                             pad_w,
+                                             stride_h,
+                                             stride_w,
+                                             dilation_h,
+                                             dilation_w,
+                                             CUDNN_CROSS_CORRELATION,
+                                             get_cudnn_compute_dtype(data_type)));
   CUDNN_CALL(cudnnSetConvolutionGroupCount(conv_desc, groups));
   CUDNN_CALL(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
 
@@ -1349,8 +1380,15 @@ void cinn_gpu_cudnn_conv2d(const absl::flat_hash_map<std::string, int> &attr,
 
   cudnnConvolutionDescriptor_t conv_desc;
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-      conv_desc, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, CUDNN_CROSS_CORRELATION, data_type));
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(conv_desc,
+                                             pad_h,
+                                             pad_w,
+                                             stride_h,
+                                             stride_w,
+                                             dilation_h,
+                                             dilation_w,
+                                             CUDNN_CROSS_CORRELATION,
+                                             get_cudnn_compute_dtype(data_type)));
   CUDNN_CALL(cudnnSetConvolutionGroupCount(conv_desc, groups));
   CUDNN_CALL(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
 
@@ -1442,8 +1480,15 @@ void cinn_gpu_cudnn_conv2d_backward_data(const absl::flat_hash_map<std::string, 
 
   cudnnConvolutionDescriptor_t conv_desc;
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-      conv_desc, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, CUDNN_CROSS_CORRELATION, data_type));
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(conv_desc,
+                                             pad_h,
+                                             pad_w,
+                                             stride_h,
+                                             stride_w,
+                                             dilation_h,
+                                             dilation_w,
+                                             CUDNN_CROSS_CORRELATION,
+                                             get_cudnn_compute_dtype(data_type)));
   CUDNN_CALL(cudnnSetConvolutionGroupCount(conv_desc, groups));
   CUDNN_CALL(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
 
@@ -1537,8 +1582,15 @@ void cinn_gpu_cudnn_conv2d_backward_filter(const absl::flat_hash_map<std::string
 
   cudnnConvolutionDescriptor_t conv_desc;
   CUDNN_CALL(cudnnCreateConvolutionDescriptor(&conv_desc));
-  CUDNN_CALL(cudnnSetConvolution2dDescriptor(
-      conv_desc, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, CUDNN_CROSS_CORRELATION, data_type));
+  CUDNN_CALL(cudnnSetConvolution2dDescriptor(conv_desc,
+                                             pad_h,
+                                             pad_w,
+                                             stride_h,
+                                             stride_w,
+                                             dilation_h,
+                                             dilation_w,
+                                             CUDNN_CROSS_CORRELATION,
+                                             get_cudnn_compute_dtype(data_type)));
   CUDNN_CALL(cudnnSetConvolutionGroupCount(conv_desc, groups));
   CUDNN_CALL(cudnnSetConvolutionMathType(conv_desc, CUDNN_DEFAULT_MATH));
 


### PR DESCRIPTION
CINN现fp16类型的conv2d误差为1e-2级别，而paddle fp16与fp32类型误差在1e-3级别，分析后发现是现CINN调用cudnn conv2d函数时计算类型与输入类型相同，而paddle侧fp16下计算类型也为fp32类型。对齐后CINN精度也达到了1e-3级别。

paddle测试代码：
```
import paddle
import numpy as np

inputs = {
    "x": np.random.random([3, 16, 32, 32]).astype("float32"),
    "weight": np.random.random([16, 16, 3, 3]).astype("float32")
}

x= paddle.to_tensor(inputs['x'])
weight= paddle.to_tensor(inputs['weight'])

y = paddle.nn.functional.conv2d(x, weight)

x_fp16 =  paddle.to_tensor(inputs['x'].astype("float16"), dtype='float16')
weight_fp16 =  paddle.to_tensor(inputs['weight'].astype("float16"), dtype='float16')

y_fp16 = paddle.nn.functional.conv2d(x_fp16, weight_fp16)

print(np.allclose(y.numpy(), y_fp16.numpy().astype("float16"), rtol=1e-3))
```