### PR TITLE
trick fix reduce 1 bug

### DIFF
--- a/cinn/frontend/pass/remove_identity.cc
+++ b/cinn/frontend/pass/remove_identity.cc
@@ -78,6 +78,35 @@ static std::unordered_map<std::string, std::function<bool(const Instruction&)>> 
 
 #undef SHAPE_SAME_REMOVE
 
+namespace {
+bool check_reduce_to_reshape(const Instruction& instr) {
+  const auto& input_shape = instr->inputs[0]->shape;
+
+  auto dims = instr->attrs.count("dim") ? instr.GetAttrs<std::vector<int>>("dim") : std::vector<int>();
+
+  if (dims.empty()) {
+    for (int i = 0; i < input_shape.size(); ++i) {
+      dims.emplace_back(i);
+    }
+  }
+
+  for (auto aixs : dims) {
+    if (input_shape[aixs] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
+
+static std::unordered_map<std::string, std::function<bool(const Instruction&)>> reshape_ops = {
+    {"reduce_sum", check_reduce_to_reshape},
+    {"reduce_prod", check_reduce_to_reshape},
+    {"reduce_max", check_reduce_to_reshape},
+    {"reduce_min", check_reduce_to_reshape},
+    {"reduce_all", check_reduce_to_reshape},
+    {"reduce_any", check_reduce_to_reshape}};
+
 // RemoveIdentityPass will remove the identity instructions in following patterns:
 //
 // 1. When varB is not in fetch_ids, the identity and varB will be removed.
@@ -107,9 +136,6 @@ class RemoveIdentityPass : public ProgramPass {
 
     VLOG(3) << "Before RemoveIdentityPass: " << *program;
     VLOG(3) << "Total remove " << remove_idxs_.size() << " instructions.";
-    if (remove_idxs_.size() == 0) {
-      return;
-    }
 
     NetBuilder builder("remove_identity_builder");
     for (auto& var : program->GetInputs()) {
@@ -122,8 +148,20 @@ class RemoveIdentityPass : public ProgramPass {
 
       auto& instr = (*program)[i];
       if (replace_identity_idxs_.count(i)) {
+        VLOG(4) << "Replace op " << instr->outputs[0]->id << "[" << cinn::utils::Join(instr->outputs[0]->shape, ", ")
+                << "]=" << instr->op_type << "{" << instr->inputs[0]->id << "["
+                << cinn::utils::Join(instr->inputs[0]->shape, ", ") << "]} to identity";
+
         instr->op_type = "identity";
         instr->attrs.clear();
+      } else if (reshape_ops.count(instr->op_type) && reshape_ops.at(instr->op_type)(instr)) {
+        VLOG(4) << "Replace op " << instr->outputs[0]->id << "[" << cinn::utils::Join(instr->outputs[0]->shape, ", ")
+                << "]=" << instr->op_type << "{" << instr->inputs[0]->id << "["
+                << cinn::utils::Join(instr->inputs[0]->shape, ", ") << "]} to reshape";
+
+        instr->op_type = "reshape";
+        instr->attrs.clear();
+        instr->attrs["shape"] = instr->outputs[0]->shape;
       }
 
       auto& inputs = instr->inputs;

--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -66,7 +66,7 @@ class OpTest(unittest.TestCase):
                         inputs,
                         feed_data,
                         outputs,
-                        passes=["Decomposer"],
+                        passes=[],
                         scope=None):
         fetch_ids = {str(out) for out in outputs}
         result = prog.build_and_get_output(

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -115,6 +115,24 @@ class TestReduceSumCase6(TestReduceSumOp):
         self.keep_dim = False
 
 
+class TestReduceSumCase7(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([1, 1, 10, 10, 10], "float32", -1.0, 1.0)
+        }
+        self.dim = [0]
+        self.keep_dim = False
+
+
+class TestReduceSumCase8(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([1, 10, 1, 10, 10], "float32", -1.0, 1.0)
+        }
+        self.dim = [0, 2]
+        self.keep_dim = False
+
+
 class TestReduceSumFP64(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float64", -1.0, 1.0)}


### PR DESCRIPTION
通过pass绕开reduce维度为1时`IRCudaScheduleReduce`中的bug，具体示例如下：
```
a = builder.create_input(Float(32), (1, 1, 2, 5, 6, 10), "A")
b = builder.reduce_sum(a, [0])
```
报错如下：
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/31386411/218722293-08c924ad-4351-4042-aefb-b16ef975ebfa.png">
