### PR TITLE
fix XShape Cannot found in paddle decomposer version bug

### DIFF
--- a/cinn/frontend/op_mappers/paddle/reshape.cc
+++ b/cinn/frontend/op_mappers/paddle/reshape.cc
@@ -80,18 +80,20 @@ void Reshape2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext&
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
 
-  // Reshape2 adds an intermediate output(XShape) based on
-  // Reshape, the XShape is used to carry the shape and lod of X which
-  // will be used in Reshape_grad, in this way, the framework can reuse
-  // the memory of X immediately the Reshape2_op is finished.
-  // Considering compatibility issues, we could not fix Reshape2_op
-  CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
-  auto xshape_name = op_desc.Output("XShape").front();
+  if (op_desc.HasOutput("XShape")) {
+    // Reshape2 adds an intermediate output(XShape) based on
+    // Reshape, the XShape is used to carry the shape and lod of X which
+    // will be used in Reshape_grad, in this way, the framework can reuse
+    // the memory of X immediately the Reshape2_op is finished.
+    // Considering compatibility issues, we could not fix Reshape2_op
+    CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
+    auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->Identity(x);
+    auto xshape = ctx.Builder()->Identity(x);
 
-  ctx.AddVar(xshape_name, xshape);
-  ctx.AddVarModelToProgram(xshape_name, xshape->id);
+    ctx.AddVar(xshape_name, xshape);
+    ctx.AddVarModelToProgram(xshape_name, xshape->id);
+  }
 }
 
 void Reshape2GradOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {

--- a/cinn/frontend/op_mappers/paddle/squeeze.cc
+++ b/cinn/frontend/op_mappers/paddle/squeeze.cc
@@ -36,18 +36,20 @@ void Squeeze2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext&
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
 
-  // squeeze2 adds an intermediate output(XShape) based on squeeze,
-  // the XShape is used to carry the shape and lod of X which will be used in
-  // squeeze_grad, in this way, the framework can reuse the memory of X
-  // immediately the squeeze2_op is finished.
-  // Considering compatibility issues, we could not fix squeeze2_op
-  CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
-  auto xshape_name = op_desc.Output("XShape").front();
+  if (op_desc.HasOutput("XShape")) {
+    // squeeze2 adds an intermediate output(XShape) based on squeeze,
+    // the XShape is used to carry the shape and lod of X which will be used in
+    // squeeze_grad, in this way, the framework can reuse the memory of X
+    // immediately the squeeze2_op is finished.
+    // Considering compatibility issues, we could not fix squeeze2_op
+    CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
+    auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->Identity(x);
+    auto xshape = ctx.Builder()->Identity(x);
 
-  ctx.AddVar(xshape_name, xshape);
-  ctx.AddVarModelToProgram(xshape_name, xshape->id);
+    ctx.AddVar(xshape_name, xshape);
+    ctx.AddVarModelToProgram(xshape_name, xshape->id);
+  }
 }
 
 }  // namespace paddle_mappers

--- a/cinn/frontend/op_mappers/paddle/transpose.cc
+++ b/cinn/frontend/op_mappers/paddle/transpose.cc
@@ -55,18 +55,20 @@ void Transpose2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
 
-  // transpose2 adds an intermediate output(XShape) based on
-  // transpose, the XShape is used to carry the shape and lod of X which
-  // will be used in transpose_grad, in this way, the framework can reuse
-  // the memory of X immediately the transpose2_op is finished.
-  // Considering compatibility issues, we could not fix transpose2_op
-  CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
-  auto xshape_name = op_desc.Output("XShape").front();
+  if (op_desc.HasOutput("XShape")) {
+    // transpose2 adds an intermediate output(XShape) based on
+    // transpose, the XShape is used to carry the shape and lod of X which
+    // will be used in transpose_grad, in this way, the framework can reuse
+    // the memory of X immediately the transpose2_op is finished.
+    // Considering compatibility issues, we could not fix transpose2_op
+    CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
+    auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->Identity(x);
+    auto xshape = ctx.Builder()->Identity(x);
 
-  ctx.AddVar(xshape_name, xshape);
-  ctx.AddVarModelToProgram(xshape_name, xshape->id);
+    ctx.AddVar(xshape_name, xshape);
+    ctx.AddVarModelToProgram(xshape_name, xshape->id);
+  }
 }
 
 }  // namespace paddle_mappers

--- a/cinn/frontend/op_mappers/paddle/unsqueeze.cc
+++ b/cinn/frontend/op_mappers/paddle/unsqueeze.cc
@@ -37,18 +37,20 @@ void UnSqueeze2OpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContex
   ctx.AddVar(out_name, out);
   ctx.AddVarModelToProgram(out_name, out->id);
 
-  // squeeze2 adds an intermediate output(XShape) based on squeeze,
-  // the XShape is used to carry the shape and lod of X which will be used in
-  // squeeze_grad, in this way, the framework can reuse the memory of X
-  // immediately the squeeze2_op is finished.
-  // Considering compatibility issues, we could not fix squeeze2_op
-  CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
-  auto xshape_name = op_desc.Output("XShape").front();
+  if (op_desc.HasOutput("XShape")) {
+    // squeeze2 adds an intermediate output(XShape) based on squeeze,
+    // the XShape is used to carry the shape and lod of X which will be used in
+    // squeeze_grad, in this way, the framework can reuse the memory of X
+    // immediately the squeeze2_op is finished.
+    // Considering compatibility issues, we could not fix squeeze2_op
+    CHECK_EQ(op_desc.Output("XShape").size(), 1UL);
+    auto xshape_name = op_desc.Output("XShape").front();
 
-  auto xshape = ctx.Builder()->Identity(x);
+    auto xshape = ctx.Builder()->Identity(x);
 
-  ctx.AddVar(xshape_name, xshape);
-  ctx.AddVarModelToProgram(xshape_name, xshape->id);
+    ctx.AddVar(xshape_name, xshape);
+    ctx.AddVarModelToProgram(xshape_name, xshape->id);
+  }
 }
 
 }  // namespace paddle_mappers


### PR DESCRIPTION
`XShape`输出在组合算子拆分中被移除了，因此不能强制要求算子必须得有`XShape`输出