### PR TITLE
support tile op

### DIFF
--- a/cinn/frontend/op_mappers/paddle/tile.cc
+++ b/cinn/frontend/op_mappers/paddle/tile.cc
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/frontend/op_mapper_registry.h"
+#include "cinn/frontend/op_mappers/common_utils.h"
+#include "cinn/frontend/var_type_utils.h"
+
+namespace cinn {
+namespace frontend {
+namespace paddle_mappers {
+
+void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+  // input
+  CHECK_EQ(op_desc.Input("X").size(), 1UL);
+  auto x_name = op_desc.Input("X").front();
+  // output
+  CHECK_EQ(op_desc.Output("Out").size(), 1UL);
+  auto out_name = op_desc.Output("Out").front();
+
+  // attr repeat_times
+  std::vector<int> repeat_times = op_desc.GetAttr<std::vector<int>>("repeat_times");
+
+  // for loop check repeat_times's element
+  for (auto i : repeat_times) {
+    CHECK_GT(i, 0) << "repeat_times's element must be greater than 0";
+  }
+
+  auto x = ctx.GetVar(x_name);
+
+  // promotion
+  auto vec_x_dims = std::vector<int>(x->shape);
+  if (repeat_times.size() < vec_x_dims.size()) {
+    int diff = vec_x_dims.size() - repeat_times.size();
+    repeat_times.insert(repeat_times.begin(), diff, 1);
+  } else {
+    int diff = repeat_times.size() - vec_x_dims.size();
+    vec_x_dims.insert(vec_x_dims.begin(), diff, 1);
+  }
+
+  // VLOG for loop check repeat_times's element
+  for (auto i : repeat_times) {
+    VLOG(1) << "repeat_times's element: " << i;
+  }
+
+  // VLOG for loop check vec_x_dims's element
+  for (auto i : vec_x_dims) {
+    VLOG(1) << "vec_x_dims's element: " << i;
+  }
+
+  // check vec_x_dims's size and repeat_times's size
+  CHECK_EQ(vec_x_dims.size(), repeat_times.size())
+      << "vec_x_dims's size must be equal to repeat_times's size after promotion";
+
+  // output's shape
+  std::vector<int> output_shape = vec_x_dims;
+
+  // calucate output's shape
+  for (size_t i = 0; i < repeat_times.size(); ++i) {
+    output_shape[i] *= repeat_times[i];
+  }
+  x = ctx.Builder()->Reshape(x, vec_x_dims);
+
+  // VLOG for loop check output_shape's element
+  for (auto i : output_shape) {
+    VLOG(1) << "output_shape's element: " << i;
+  }
+  x        = ctx.Builder()->Reshape(x, {1, 1, 1, 3});
+  auto tmp = ctx.Builder()->BroadcastTo(x, {1, 2, 2, 3});
+  // auto output = ctx.Builder()->BroadcastTo(x, output_shape, repeat_times);
+  auto output = ctx.Builder()->Reshape(tmp, output_shape);
+
+  ctx.AddVar(out_name, output);
+  ctx.AddVarModelToProgram(out_name, output->id);
+}
+
+}  // namespace paddle_mappers
+}  // namespace frontend
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(paddle_tile) {
+  CINN_REGISTER_OP_MAPPER(tile, cinn::frontend::paddle_mappers::TileOpMapper)
+  return true;
+}

--- a/cinn/frontend/op_mappers/paddle/tile.cc
+++ b/cinn/frontend/op_mappers/paddle/tile.cc
@@ -62,7 +62,7 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
 
   // NOTE(wuweilong): Paddle's tile is implemented by Eigen's broadcast directly, but CINN's tile can not be implemented
   // by BroadcastTo directly, because it is different from Eigen's broadcast. The semantics of Eigen's broadcast is same
-  // to tile, but CINN can not use Eigen's broadcast. So we need to Combine Reshape and BroadcastTo to implement tile.
+  // as tile, but CINN can not use Eigen's broadcast. So we need to Combine Reshape and BroadcastTo to implement tile.
 
   // make a copy of vec_x_dims
   std::vector<int> vec_x_dims_copy = vec_x_dims;

--- a/cinn/frontend/op_mappers/paddle/tile.cc
+++ b/cinn/frontend/op_mappers/paddle/tile.cc
@@ -48,16 +48,6 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
     vec_x_dims.insert(vec_x_dims.begin(), diff, 1);
   }
 
-  // VLOG for loop check repeat_times's element
-  for (auto i : repeat_times) {
-    VLOG(1) << "repeat_times's element: " << i;
-  }
-
-  // VLOG for loop check vec_x_dims's element
-  for (auto i : vec_x_dims) {
-    VLOG(1) << "vec_x_dims's element: " << i;
-  }
-
   // check vec_x_dims's size and repeat_times's size
   CHECK_EQ(vec_x_dims.size(), repeat_times.size())
       << "vec_x_dims's size must be equal to repeat_times's size after promotion";
@@ -71,10 +61,7 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   }
   x = ctx.Builder()->Reshape(x, vec_x_dims);
 
-  // VLOG for loop check output_shape's element
-  for (auto i : output_shape) {
-    VLOG(1) << "output_shape's element: " << i;
-  }
+  VLOG(1) << "output_shape: " << cinn::utils::Join(output_shape, ",");
 
   // make a copy of vec_x_dims
   std::vector<int> vec_x_dims_copy = vec_x_dims;
@@ -82,10 +69,6 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   for (size_t i = 0; i < vec_x_dims_copy.size(); ++i) {
     vec_x_dims_copy.insert(vec_x_dims_copy.begin() + i, 1);
     i++;
-  }
-  // VLOG for loop check vec_x_dims_copy's element
-  for (auto i : vec_x_dims_copy) {
-    VLOG(1) << "vec_x_dims_copy's element: " << i;
   }
 
   x = ctx.Builder()->Reshape(x, vec_x_dims_copy);
@@ -95,10 +78,6 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
     if (i % 2 == 0) {
       vec_x_dims_copy[i] = output_shape[i / 2] / vec_x_dims_copy[i + 1];
     }
-  }
-  // VLOG for loop check vec_x_dims_copy's element
-  for (auto i : vec_x_dims_copy) {
-    VLOG(1) << "vec_x_dims_copy's element: " << i;
   }
 
   auto tmp    = ctx.Builder()->BroadcastTo(x, vec_x_dims_copy);

--- a/cinn/frontend/op_mappers/paddle/tile.cc
+++ b/cinn/frontend/op_mappers/paddle/tile.cc
@@ -60,6 +60,10 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
 
   VLOG(4) << "output_shape: " << cinn::utils::Join(output_shape, ",");
 
+  // NOTE(wuweilong): Paddle's tile is implemented by Eigen's broadcast directly, but CINN's tile can not be implemented
+  // by BroadcastTo directly, because it is different from Eigen's broadcast. The semantics of Eigen's broadcast is same
+  // to tile, but CINN can not use Eigen's broadcast. So we need to Combine Reshape and BroadcastTo to implement tile.
+
   // make a copy of vec_x_dims
   std::vector<int> vec_x_dims_copy = vec_x_dims;
   // recontruct vec_x_dims_copy by inserting 1 before every element

--- a/cinn/frontend/op_mappers/paddle/tile.cc
+++ b/cinn/frontend/op_mappers/paddle/tile.cc
@@ -31,7 +31,6 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   // attr repeat_times
   std::vector<int> repeat_times = op_desc.GetAttr<std::vector<int>>("repeat_times");
 
-  // for loop check repeat_times's element
   for (auto i : repeat_times) {
     CHECK_GT(i, 0) << "repeat_times's element must be greater than 0";
   }
@@ -48,7 +47,6 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
     vec_x_dims.insert(vec_x_dims.begin(), diff, 1);
   }
 
-  // check vec_x_dims's size and repeat_times's size
   CHECK_EQ(vec_x_dims.size(), repeat_times.size())
       << "vec_x_dims's size must be equal to repeat_times's size after promotion";
 
@@ -59,9 +57,8 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   for (size_t i = 0; i < repeat_times.size(); ++i) {
     output_shape[i] *= repeat_times[i];
   }
-  x = ctx.Builder()->Reshape(x, vec_x_dims);
 
-  VLOG(1) << "output_shape: " << cinn::utils::Join(output_shape, ",");
+  VLOG(4) << "output_shape: " << cinn::utils::Join(output_shape, ",");
 
   // make a copy of vec_x_dims
   std::vector<int> vec_x_dims_copy = vec_x_dims;
@@ -73,7 +70,7 @@ void TileOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
 
   x = ctx.Builder()->Reshape(x, vec_x_dims_copy);
 
-  // recontruct vec_x_dims_copy, the current even digit is equal to output_shape divided by an odd number
+  // recontruct vec_x_dims_copy for BroadaCast
   for (size_t i = 0; i < vec_x_dims_copy.size(); ++i) {
     if (i % 2 == 0) {
       vec_x_dims_copy[i] = output_shape[i / 2] / vec_x_dims_copy[i + 1];

--- a/cinn/frontend/op_mappers/use_op_mappers.h
+++ b/cinn/frontend/op_mappers/use_op_mappers.h
@@ -53,6 +53,7 @@ CINN_USE_REGISTER(paddle_uniform_random)
 CINN_USE_REGISTER(paddle_one_hot)
 CINN_USE_REGISTER(paddle_cumsum)
 CINN_USE_REGISTER(paddle_norm)
+CINN_USE_REGISTER(paddle_tile)
 
 CINN_USE_REGISTER(science_broadcast)
 CINN_USE_REGISTER(science_transform)

--- a/python/tests/op_mappers/test_tile_op.py
+++ b/python/tests/op_mappers/test_tile_op.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import sys
-from timeit import repeat
 import unittest
 import numpy as np
 from op_mapper_test import OpMapperTest

--- a/python/tests/op_mappers/test_tile_op.py
+++ b/python/tests/op_mappers/test_tile_op.py
@@ -57,13 +57,13 @@ class TestGatherNdOp(OpMapperTest):
         self.check_outputs_and_grads(all_equal=True)
 
 
-# class TestGatherNdCase1(TestGatherNdOp):
-#     def init_input_data(self):
-#         self.feed_data = {
-#             'x': np.array([1, 2, 3], dtype='float32'),
-#         }
-#         self.repeat_times = [2, 2]
-# OUT -> [2, 6]
+class TestGatherNdCase1(TestGatherNdOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([2, 3, 4], 'float32'),
+        }
+        self.repeat_times = [1, 2, 3]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/op_mappers/test_tile_op.py
+++ b/python/tests/op_mappers/test_tile_op.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from timeit import repeat
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+paddle.enable_static()
+
+enable_gpu = sys.argv.pop()
+
+
+class TestGatherNdOp(OpMapperTest):
+    def setUp(self):
+        if enable_gpu == "ON":
+            self.target = DefaultNVGPUTarget()
+            self.place = paddle.CUDAPlace(0)
+        else:
+            self.target = DefaultHostTarget()
+            self.place = paddle.CPUPlace()
+
+    def init_input_data(self):
+        self.feed_data = {
+            'x': np.array([1, 2, 3], dtype='float32'),
+        }
+        self.repeat_times = [2, 2]
+
+    def set_paddle_program(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+
+        out = paddle.tile(x, self.repeat_times)
+
+        return ([x.name], [out])
+
+    def test_check_results(self):
+        self.check_outputs_and_grads(all_equal=True)
+
+
+# class TestGatherNdCase1(TestGatherNdOp):
+#     def init_input_data(self):
+#         self.feed_data = {
+#             'x': np.array([1, 2, 3], dtype='float32'),
+#         }
+#         self.repeat_times = [2, 2]
+# OUT -> [2, 6]
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/op_mappers/test_tile_op.py
+++ b/python/tests/op_mappers/test_tile_op.py
@@ -28,7 +28,7 @@ paddle.enable_static()
 enable_gpu = sys.argv.pop()
 
 
-class TestGatherNdOp(OpMapperTest):
+class TestTileOp(OpMapperTest):
     def setUp(self):
         if enable_gpu == "ON":
             self.target = DefaultNVGPUTarget()
@@ -57,12 +57,44 @@ class TestGatherNdOp(OpMapperTest):
         self.check_outputs_and_grads(all_equal=True)
 
 
-class TestGatherNdCase1(TestGatherNdOp):
+class TestTileCase1(TestTileOp):
     def init_input_data(self):
         self.feed_data = {
             'x': self.random([2, 3, 4], 'float32'),
         }
         self.repeat_times = [1, 2, 3]
+
+
+class TestTileCase2(TestTileOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([2, 10, 5], 'float32'),
+        }
+        self.repeat_times = [2, 2]
+
+
+class TestTileCase3(TestTileOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([2, 4, 15], 'float32'),
+        }
+        self.repeat_times = [2, 1, 4]
+
+
+class TestTileCase4(TestTileOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([12, 14], 'float32'),
+        }
+        self.repeat_times = [2, 3]
+
+
+class TestTileCase5(TestTileOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([120], 'float32'),
+        }
+        self.repeat_times = [2, 2]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Paddle's tile is implemented by Eigen's broadcast directly, but CINN's tile can not be implemented by BroadcastTo directly, because it is different from Eigen's broadcast. 
The semantics of Eigen's broadcast is same as tile, but CINN can not use Eigen's broadcast. So we need to Combine Reshape and BroadcastTo to implement tile.