### PR TITLE
[Tools]Fix Graph Visualize problem

### DIFF
--- a/cinn/common/graph_utils.cc
+++ b/cinn/common/graph_utils.cc
@@ -150,7 +150,7 @@ std::string Graph::Visualize() const {
 
   // 1. create nodes
   for (auto &node : nodes_) {
-    dot.AddNode(node->id(), {});
+    dot.AddNode(node->id(), {}, "", "", true);
   }
 
   // 2. link each other


### PR DESCRIPTION
开启GLOG_v=4下，在融合pass前：
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/9301846/219567036-58d99bb9-fed4-4390-8066-7bfec34c43dd.png">

但融合后，因为Graph中包含了重复的fill_constant_0 node，导致触发了可视化拦截的条件，报错。
<img width="787" alt="image" src="https://user-images.githubusercontent.com/9301846/219567385-f4d1af8d-bed3-4d05-a92e-e331d11d5aac.png">

修复后可以打印出如下日志：
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/9301846/219567290-3f40b88c-2e76-40be-b2ca-1a3a2d19a8b5.png">
