### PR TITLE
cast output berfore calculating bias and scale in layernorm op mapper while using mixed precision

### DIFF
--- a/cinn/frontend/op_mappers/paddle/layer_norm.cc
+++ b/cinn/frontend/op_mappers/paddle/layer_norm.cc
@@ -111,6 +111,10 @@ void LayerNormOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
   auto x_var_sqrt = builder->Sqrt(x_var_eps);
   auto y_out      = builder->Divide(y_sub, builder->BroadcastTo(x_var_sqrt, shape, {0}));
 
+  if (x_type.is_float(16)) {
+    y_out = builder->Cast(y_out, "float16");
+  }
+
   // multiply scale
   if (scale) {
     auto scale_broadcast = builder->BroadcastTo(*scale, shape, {1});
@@ -125,10 +129,6 @@ void LayerNormOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
 
   // reshape to the original shape
   y_out = builder->Reshape(y_out, x_shape);
-
-  if (x_type.is_float(16)) {
-    y_out = builder->Cast(y_out, "float16");
-  }
 
   // get output names
   auto y_name        = get_output("Y");


### PR DESCRIPTION
在添加执行 auto_mixed_precision_pass 后，执行模型时遇到elementwise 类op 两个操作数类型不一致问题。
经过定位，问题在 layernorm.cc 中，输入经过 cast 转换为 fp32类型，而最后需要进行运算的 scale 和 bias 依然是 fp16，导致了这个问题。
根据经验，layernorm 中 fp16对精度影响较大的为 reduce 操作，故将 y_out 提前转换回 fp16，在 fp16下进行两次 elementwise 操作。

PS.在本地也实现了将 scale 和 bias 均转换为 fp32再在 fp32下进行两次 elementwise 操作，具体代码可见https://github.com/WhatGhost/CINN/pull/2/files
经过测试，与本 pr 的将yout 提前转换的方案相比，精度相比纯 fp32均无较大 diff。