### PR TITLE
try fix reduce axis bind error bug

### DIFF
--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -454,7 +454,9 @@ void IRCudaScheduleBlockReduce(ir::IRSchedule &ir_sch,
     for (auto &tensor : {reduce_tmp_out, tmp_out, out}) {
       auto loops      = ir_sch.GetLoops(tensor->name);
       int reduce_axis = tensor->reduce_axis.size();
-      if (loops.size() >= 2 + reduce_axis) ir_sch.Fuse({loops[0], loops[1]});
+      if (loops.size() >= 2 + reduce_axis) {
+        ir_sch.Fuse({loops[0], loops[1]});
+      }
     }
   }
 
@@ -494,15 +496,23 @@ void IRCudaScheduleBlockReduce(ir::IRSchedule &ir_sch,
     }
   }
 
-  for (auto &tensor : {reduce_tmp_out, tmp_out, out}) {
+  for (auto &tensor : {reduce_tmp_out, tmp_out}) {
     auto loops = ir_sch.GetLoops(tensor->name);
-    if (loops.empty()) {
-      continue;
-    } else if (loops.size() == 1U) {
+    if (loops.size() == 1U) {
       ir_sch.Bind(loops[0], "threadIdx.x");
-    } else {
+    } else if (loops.size() > 1U) {
       ir_sch.Bind(loops[0], "blockIdx.x");
       ir_sch.Bind(loops[1], "threadIdx.x");
+    }
+  }
+
+  {
+    auto loops = ir_sch.GetLoops(out->name);
+    if (!loops.empty()) {
+      ir_sch.Bind(loops[0], "blockIdx.x");
+      if (loops.size() > 1U) {
+        ir_sch.Bind(loops[1], "threadIdx.x");
+      }
     }
   }
 

--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -496,9 +496,12 @@ void IRCudaScheduleBlockReduce(ir::IRSchedule &ir_sch,
 
   for (auto &tensor : {reduce_tmp_out, tmp_out, out}) {
     auto loops = ir_sch.GetLoops(tensor->name);
-    if (loops.empty()) continue;
-    ir_sch.Bind(loops[0], "blockIdx.x");
-    if (loops.size() > 1U) {
+    if (loops.empty()) {
+      continue;
+    } else if (loops.size() == 1U) {
+      ir_sch.Bind(loops[0], "threadIdx.x");
+    } else {
+      ir_sch.Bind(loops[0], "blockIdx.x");
       ir_sch.Bind(loops[1], "threadIdx.x");
     }
   }

--- a/python/tests/ops/test_binary_elementwise_op.py
+++ b/python/tests/ops/test_binary_elementwise_op.py
@@ -107,6 +107,30 @@ class TestAddOpFP64(TestAddOp):
         return self.random([32, 64], 'float64', -10.0, 10.0)
 
 
+class TestAddOpFP16(TestAddOp):
+    def get_x_data(self):
+        return self.random([32, 64], 'float16', -10.0, 10.0)
+
+    def get_y_data(self):
+        return self.random([32, 64], 'float16', -10.0, 10.0)
+
+
+class TestAddOpInt32(TestAddOp):
+    def get_x_data(self):
+        return self.random([32, 64], 'int32', -10.0, 10.0)
+
+    def get_y_data(self):
+        return self.random([32, 64], 'int32', -10.0, 10.0)
+
+
+class TestAddOpInt64(TestAddOp):
+    def get_x_data(self):
+        return self.random([32, 64], 'int64', -10.0, 10.0)
+
+    def get_y_data(self):
+        return self.random([32, 64], 'int64', -10.0, 10.0)
+
+
 class TestSubtractOp(TestBinaryOp):
     def paddle_func(self, x, y):
         return paddle.subtract(x, y)

--- a/python/tests/ops/test_pow_op.py
+++ b/python/tests/ops/test_pow_op.py
@@ -83,5 +83,14 @@ class TestPowCase2(TestPowOp):
         self.axis = -1
 
 
+class TestPowFP64(TestPowOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([8, 16, 32, 32], "float64", 2, 10),
+            "y": self.random([8, 16, 32, 32], "float64", 0, 5)
+        }
+        self.axis = -1
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -22,6 +22,9 @@ import cinn
 from cinn.frontend import *
 from cinn.common import *
 
+paddle.seed(2)
+np.random.seed(2)
+
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
@@ -150,7 +153,7 @@ class TestReduceSumCase10(TestReduceSumOp):
 class TestReduceSumCase11(TestReduceSumOp):
     def init_case(self):
         self.inputs = {
-            "x": self.random([32, 32, 32, 32], "float32", -1.0, 1.0)
+            "x": self.random([32, 32, 32, 32], "float32", -0.1, 0.1)
         }
         self.dim = [0, 2, 3]
         self.keep_dim = False
@@ -183,33 +186,57 @@ class TestReduceSumCase14(TestReduceSumOp):
 
 class TestReduceSumCase15(TestReduceSumOp):
     def init_case(self):
-        # data shape from resnet50 bs=64
+        # data shape from resnet50 bs=32
         self.inputs = {
-            "x": self.random([128, 64, 56, 56], "float32", -1.0, 1.0)
+            "x": self.random([32, 64, 56, 56], "float32", -0.1, 0.1)
         }
         self.dim = [0, 2, 3]
         self.keep_dim = False
 
     def test_check_results(self):
         # the shape of tensor is large, lead to the different of result increase
-        self.check_outputs_and_grads(max_relative_error=1e-3)
+        self.check_outputs_and_grads(max_relative_error=1e-4)
 
 
 class TestReduceSumCase16(TestReduceSumOp):
     def init_case(self):
-        # data shape from resnet50 NHWC bs=64
+        # data shape from resnet50 NHWC bs=32
         self.inputs = {
-            "x": self.random([128, 56, 56, 64], "float32", -1.0, 1.0)
+            "x": self.random([32, 56, 56, 64], "float32", -0.1, 0.1)
         }
         self.dim = [0, 1, 2]
         self.keep_dim = False
 
     def test_check_results(self):
         # the shape of tensor is large, lead to the different of result increase
+        # NHWC's difference are more larger than NCHW
         self.check_outputs_and_grads(max_relative_error=1e-3)
 
 
-'''
+class TestReduceSumCase17(TestReduceSumOp):
+    def init_case(self):
+        # data shape from resnet50 bs=1
+        self.inputs = {"x": self.random([1, 64, 56, 56], "float32", -0.1, 0.1)}
+        self.dim = [0, 2, 3]
+        self.keep_dim = False
+
+    def test_check_results(self):
+        # the shape of tensor is large, lead to the different of result increase
+        self.check_outputs_and_grads(max_relative_error=1e-4)
+
+
+class TestReduceSumCase18(TestReduceSumOp):
+    def init_case(self):
+        # data shape from resnet50 NHWC bs=1
+        self.inputs = {"x": self.random([1, 56, 56, 64], "float32", -0.1, 0.1)}
+        self.dim = [0, 1, 2]
+        self.keep_dim = False
+
+    def test_check_results(self):
+        # the shape of tensor is large, lead to the different of result increase
+        self.check_outputs_and_grads(max_relative_error=1e-4)
+
+
 class TestReduceSumFP64(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float64", -1.0, 1.0)}
@@ -484,7 +511,7 @@ class TestAnyCase5(TestAllOp):
         self.inputs = {"x": np.full([10, 10, 10], False, 'bool')}
         self.dim = []
         self.keep_dim = False
-'''
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -133,6 +133,20 @@ class TestReduceSumCase8(TestReduceSumOp):
         self.keep_dim = False
 
 
+class TestReduceSumCase9(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([1, 1, 10], "float32", -1.0, 1.0)}
+        self.dim = [0, 2]
+        self.keep_dim = False
+
+
+class TestReduceSumCase10(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([1, 1, 10], "float32", -1.0, 1.0)}
+        self.dim = [0, 2]
+        self.keep_dim = True
+
+
 class TestReduceSumFP64(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float64", -1.0, 1.0)}

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -147,6 +147,15 @@ class TestReduceSumCase10(TestReduceSumOp):
         self.keep_dim = True
 
 
+class TestReduceSumCase11(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 32, 32, 32], "float32", -1.0, 1.0)
+        }
+        self.dim = [0, 2, 3]
+        self.keep_dim = True
+
+
 class TestReduceSumFP64(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float64", -1.0, 1.0)}

--- a/python/tests/ops/test_reduce_op.py
+++ b/python/tests/ops/test_reduce_op.py
@@ -76,7 +76,7 @@ class TestReduceSumOp(TestReduceBaseOp):
 class TestReduceSumCase1(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float32", -1.0, 1.0)}
-        self.dim = []
+        self.dim = [1]
         self.keep_dim = False
 
 
@@ -90,7 +90,7 @@ class TestReduceSumCase2(TestReduceSumOp):
 class TestReduceSumCase3(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float32", -1.0, 1.0)}
-        self.dim = [0, 1, 2]
+        self.dim = [0, 2]
         self.keep_dim = False
 
 
@@ -153,9 +153,63 @@ class TestReduceSumCase11(TestReduceSumOp):
             "x": self.random([32, 32, 32, 32], "float32", -1.0, 1.0)
         }
         self.dim = [0, 2, 3]
-        self.keep_dim = True
+        self.keep_dim = False
+
+    def test_check_results(self):
+        # the shape of tensor is large, lead to the different of result increase
+        self.check_outputs_and_grads(max_relative_error=1e-4)
 
 
+class TestReduceSumCase12(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([10, 1024], "float32", -1.0, 1.0)}
+        self.dim = []
+        self.keep_dim = False
+
+
+class TestReduceSumCase13(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([10, 1024], "float32", -1.0, 1.0)}
+        self.dim = [0]
+        self.keep_dim = False
+
+
+class TestReduceSumCase14(TestReduceSumOp):
+    def init_case(self):
+        self.inputs = {"x": self.random([10, 1024], "float32", -1.0, 1.0)}
+        self.dim = [1]
+        self.keep_dim = False
+
+
+class TestReduceSumCase15(TestReduceSumOp):
+    def init_case(self):
+        # data shape from resnet50 bs=64
+        self.inputs = {
+            "x": self.random([128, 64, 56, 56], "float32", -1.0, 1.0)
+        }
+        self.dim = [0, 2, 3]
+        self.keep_dim = False
+
+    def test_check_results(self):
+        # the shape of tensor is large, lead to the different of result increase
+        self.check_outputs_and_grads(max_relative_error=1e-3)
+
+
+class TestReduceSumCase16(TestReduceSumOp):
+    def init_case(self):
+        # data shape from resnet50 NHWC bs=64
+        self.inputs = {
+            "x": self.random([128, 56, 56, 64], "float32", -1.0, 1.0)
+        }
+        self.dim = [0, 1, 2]
+        self.keep_dim = False
+
+    def test_check_results(self):
+        # the shape of tensor is large, lead to the different of result increase
+        self.check_outputs_and_grads(max_relative_error=1e-3)
+
+
+'''
 class TestReduceSumFP64(TestReduceSumOp):
     def init_case(self):
         self.inputs = {"x": self.random([10, 10, 10], "float64", -1.0, 1.0)}
@@ -430,7 +484,7 @@ class TestAnyCase5(TestAllOp):
         self.inputs = {"x": np.full([10, 10, 10], False, 'bool')}
         self.dim = []
         self.keep_dim = False
-
+'''
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
尝试修复`reduce`算子在下列配置下的索引值被错误绑定的bug：
```
a = builder.create_input(Float(32), (1, 1, 10), "A")
b = builder.reduce_sum(a, [0, 2])
```
此处应该绑定`threadIdx.x`但实际绑定的是`blockIdx.x`：
![image](https://user-images.githubusercontent.com/31386411/220876499-baf7af5d-afbf-4a4c-b586-1c37fe847b29.png)
