### PR TITLE
op_mapper_test add skip check output ability

### DIFF
--- a/cinn/hlir/framework/visualize_helper.cc
+++ b/cinn/hlir/framework/visualize_helper.cc
@@ -235,7 +235,7 @@ std::string DebugString(const Node* node) {
   std::stringstream ss;
   ss << "{";
   bool first = true;
-  for (auto& outlink : node->outlinks()) {
+  for (auto& outlink : node->outlinks_in_order()) {
     auto* outnode = outlink->sink()->safe_as<NodeData>();
     if (outnode) {
       if (!first) {
@@ -249,7 +249,7 @@ std::string DebugString(const Node* node) {
 
   ss << "} = " << node->op()->name << "{";
   first = true;
-  for (auto& inlink : node->inlinks()) {
+  for (auto& inlink : node->inlinks_in_order()) {
     auto* innode = inlink->source()->safe_as<NodeData>();
     if (innode) {
       if (!first) {


### PR DESCRIPTION
为OpMapper python测试添加了跳过对某些输出检查的功能，如对于layer_norm算子：
```
    def set_op_outputs(self):
        return {
            'Y': [str(self.feed_data['x'].dtype)],
            'Mean': [str(self.feed_data['x'].dtype)],
            'Variance': [str(self.feed_data['x'].dtype)]
        }

    def skip_check_outputs(self):
        return ["Mean", "Variance"]
```