### PR TITLE
Fix cache memory exceeding limit

### DIFF
--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.cc
@@ -136,7 +136,7 @@ void AddCacheWrite::Apply(ir::IRSchedule* ir_schedule, ir::Expr& block_expr) {
   VLOG(6) << "cache block: " << cache_block;
   ir::Expr target_loop = GetFirstSpatialLoopOutofOutermostReduce(ir_schedule, cache_block);
   VLOG(6) << "target_loop: " << target_loop;
-  const std::string original_block_name =
+  const std::string& original_block_name =
       block_expr.As<ir::ScheduleBlockRealize>()->schedule_block.As<ir::ScheduleBlock>()->name;
   ir_schedule->ReverseComputeAt(ir_schedule->GetBlock(original_block_name), target_loop);
 

--- a/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/add_cache_write.cc
@@ -136,9 +136,15 @@ void AddCacheWrite::Apply(ir::IRSchedule* ir_schedule, ir::Expr& block_expr) {
   VLOG(6) << "cache block: " << cache_block;
   ir::Expr target_loop = GetFirstSpatialLoopOutofOutermostReduce(ir_schedule, cache_block);
   VLOG(6) << "target_loop: " << target_loop;
-  const std::string block_name =
+  const std::string original_block_name =
       block_expr.As<ir::ScheduleBlockRealize>()->schedule_block.As<ir::ScheduleBlock>()->name;
-  ir_schedule->ReverseComputeAt(ir_schedule->GetBlock(block_name), target_loop);
+  ir_schedule->ReverseComputeAt(ir_schedule->GetBlock(original_block_name), target_loop);
+
+  target_loop                              = GetFirstSpatialLoopOutofOutermostReduce(ir_schedule, cache_block);
+  const std::string reduce_init_block_name = original_block_name + "__reduce_init";
+  if (ir_schedule->HasBlock(reduce_init_block_name)) {
+    ir_schedule->SimpleComputeAt(ir_schedule->GetBlock(reduce_init_block_name), target_loop);
+  }
 }
 
 const std::unordered_map<common::Target::Arch, std::string> AddCacheWrite::kMemoryTypes{

--- a/cinn/backends/ir_schedule_test.cc
+++ b/cinn/backends/ir_schedule_test.cc
@@ -2912,6 +2912,7 @@ TEST(IrSchedule, GetChildBlocks) {
   std::string expected_expr = R"ROC(ScheduleBlock(B)
 {
   i0, i1, i2 = axis.bind(i, j, (0 + ax0))
+  attrs(compute_at_extra_var:ax0)
   B[i0, i1, i2] = A[i0, i1, i2]
 }, ScheduleBlock(C)
 {

--- a/cinn/ir/ir.h
+++ b/cinn/ir/ir.h
@@ -979,6 +979,10 @@ namespace attr {
 
 // max permitted steps for auto_unroll, used in unroll_loop pass
 constexpr const char* auto_unroll_max_step = "auto_unroll_max_step";
+// record the extra loop built during ComputeAt, used for calculate the size of temp buffer in post-processing
+constexpr const char* compute_at_extra_var = "compute_at_extra_var";
+// record the extra loop built during ReverseComputeAt, used for calculate the size of temp buffer in post-processing
+constexpr const char* reverse_compute_at_extra_var = "reverse_compute_at_extra_var";
 
 }  // namespace attr
 

--- a/cinn/ir/ir_schedule.cc
+++ b/cinn/ir/ir_schedule.cc
@@ -980,7 +980,7 @@ struct LoopReconstructor : public ir::IRMutator<> {
    *        - `index = -1` means inserted into the tail
    *        - otherwise, it should be a index between [0, stmts size)
    */
-  void MakeNewLoop(const std::vector<IterRange>& iter_ranges, int inserted_pos = -1) {
+  std::string MakeNewLoop(const std::vector<IterRange>& iter_ranges, int inserted_pos = -1) {
     int n_iters = iter_ranges.size();
     std::vector<Var> loop_vars;
     std::vector<Expr> loop_extents;
@@ -988,10 +988,13 @@ struct LoopReconstructor : public ir::IRMutator<> {
     loop_vars.reserve(n_iters);
     loop_extents.reserve(n_iters);
     iter_values.reserve(n_iters);
+    std::vector<std::string> new_var_names;
     for (int i = 0; i < n_iters; ++i) {
       const auto& range = iter_ranges[i];
       if (range.extent != Expr(1)) {
-        Var var(common::UniqName("ax" + std::to_string(loop_vars.size())), Int(32));
+        std::string var_name = common::UniqName("ax" + std::to_string(loop_vars.size()));
+        new_var_names.push_back(var_name);
+        Var var(var_name, Int(32));
         loop_vars.push_back(var);
         loop_extents.push_back(range.extent);
         iter_values.push_back(common::AutoSimplify(range.min) + var);
@@ -1010,8 +1013,28 @@ struct LoopReconstructor : public ir::IRMutator<> {
           loop_var, Expr(0), loop_extent, ForType::Serial, loop_.As<ir::For>()->device_api, std::move(loop_body));
     }
     new_loop_ = optim::IRCopy(loop_);
+
+    // Replace the copied Tensor object with the original Tensor object,
+    // to ensure that the same Tensor in a AST is the same object.
+    std::unordered_map<std::string, ir::Expr> tensors_map;
+    ir::CollectIRNodesWithoutTensor(loop_, [&tensors_map](const Expr* x) {
+      if (x->as_tensor()) {
+        tensors_map.insert({x->as_tensor()->name, *x});
+        return true;
+      }
+      return false;
+    });
+    auto find_store = ir::CollectIRNodesWithoutTensor(new_loop_, [](const Expr* x) { return x->As<ir::Store>(); });
+    for (auto store : find_store) {
+      store.As<ir::Store>()->tensor = tensors_map.at(store.As<ir::Store>()->tensor.as_tensor()->name);
+    }
+    auto find_load = ir::CollectIRNodesWithoutTensor(new_loop_, [](const Expr* x) { return x->As<ir::Load>(); });
+    for (auto load : find_load) {
+      load.As<ir::Load>()->tensor = tensors_map.at(load.As<ir::Load>()->tensor.as_tensor()->name);
+    }
+
     InsertBlock(new_loop_, loop_body, inserted_pos);
-    return;
+    return utils::Join(new_var_names, ",");
   }
 
  private:
@@ -1132,8 +1155,10 @@ void ScheduleImpl::ComputeAt(const Expr& block, const Expr& loop) {
   LoopReconstructor reconstructor(root, block, loop);
   LeafBlockRemovalPlan remove_plan(block, &reconstructor.source_expr, &reconstructor.target_expr);
   remove_plan(&root);
-  auto iter_ranges = CalculateRequiredRegions(block, loop, root, consumers);
-  reconstructor.MakeNewLoop(iter_ranges, 0);
+  auto iter_ranges          = CalculateRequiredRegions(block, loop, root, consumers);
+  std::string new_var_names = reconstructor.MakeNewLoop(iter_ranges, 0);
+  auto sch_block_expr       = block.As<ir::ScheduleBlockRealize>()->schedule_block;
+  sch_block_expr.As<ir::ScheduleBlock>()->attrs.emplace(ir::attr::compute_at_extra_var, new_var_names);
   this->Replace(reconstructor.source_expr, reconstructor.target_expr);
   this->Replace(reconstructor.loop_, reconstructor.new_loop_);
   return;
@@ -1233,8 +1258,10 @@ void ScheduleImpl::ReverseComputeAt(const Expr& block, const Expr& loop) {
   LoopReconstructor reconstructor(root, block, loop);
   LeafBlockRemovalPlan remove_plan(block, &reconstructor.source_expr, &reconstructor.target_expr);
   remove_plan(&root);
-  auto iter_ranges = CalculateRequiredRegions(block, loop, root, producers, false);
-  reconstructor.MakeNewLoop(iter_ranges);
+  auto iter_ranges          = CalculateRequiredRegions(block, loop, root, producers, false);
+  std::string new_var_names = reconstructor.MakeNewLoop(iter_ranges);
+  auto sch_block_expr       = block.As<ir::ScheduleBlockRealize>()->schedule_block;
+  sch_block_expr.As<ir::ScheduleBlock>()->attrs.emplace(ir::attr::reverse_compute_at_extra_var, new_var_names);
   this->Replace(reconstructor.source_expr, reconstructor.target_expr);
   this->Replace(reconstructor.loop_, reconstructor.new_loop_);
   return;

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -451,7 +451,7 @@ void OptimizeExprGPU(Expr *expr) {
   auto find_bind_forloops = ir::CollectIRNodesWithoutTensor(
       *expr, [&](const Expr *x) { return x->As<ir::For>() && x->As<ir::For>()->bind_info().valid(); });
   for (auto &for_loop : find_bind_forloops) {
-    VLOG(3) << "format loop:\n" << for_loop;
+    VLOG(3) << "format bind loop:\n" << for_loop;
     std::string for_iter = for_loop.As<ir::For>()->loop_var->name;
     poly::StageForloopInfo for_loop_info;
     for_loop_info.for_type = for_loop.As<ir::For>()->bind_info().for_type;
@@ -465,6 +465,96 @@ void OptimizeExprGPU(Expr *expr) {
       return x->As<ir::Store>();
     });
   }
+
+  auto find_no_bind_forloops = ir::CollectIRNodesWithoutTensor(
+      *expr, [&](const Expr *x) { return x->As<ir::For>() && !x->As<ir::For>()->bind_info().valid(); });
+  for (auto &for_loop : find_no_bind_forloops) {
+    VLOG(3) << "format no bind loop:\n" << for_loop;
+  }
+
+  auto find_schedule_block_realize =
+      ir::CollectIRNodesWithoutTensor(*expr, [&](const Expr *x) { return x->As<ir::ScheduleBlockRealize>(); });
+  for (auto &schedule_block_expr : find_schedule_block_realize) {
+    auto schedule_block_realize            = schedule_block_expr.As<ir::ScheduleBlockRealize>();
+    auto schedule_block                    = schedule_block_realize->schedule_block.As<ir::ScheduleBlock>();
+    auto iter_vars                         = schedule_block->iter_vars;
+    auto iter_values                       = schedule_block_realize->iter_values;
+    auto compute_at_extra_var_iter         = schedule_block->attrs.find("compute_at_extra_var");
+    auto reverse_compute_at_extra_var_iter = schedule_block->attrs.find("reverse_compute_at_extra_var");
+    if (compute_at_extra_var_iter == schedule_block->attrs.end() &&
+        reverse_compute_at_extra_var_iter == schedule_block->attrs.end())
+      continue;
+    std::vector<std::string> compute_at_extra_var, reverse_compute_at_extra_var;
+    if (compute_at_extra_var_iter != schedule_block->attrs.end()) {
+      compute_at_extra_var =
+          utils::Split(absl::get<std::string>(schedule_block->attrs.at("compute_at_extra_var")), ",");
+    }
+    if (reverse_compute_at_extra_var_iter != schedule_block->attrs.end()) {
+      reverse_compute_at_extra_var =
+          utils::Split(absl::get<std::string>(schedule_block->attrs.at("reverse_compute_at_extra_var")), ",");
+    }
+
+    auto temp_buffer_store = ir::CollectIRNodesWithoutTensor(schedule_block_expr, [&](const Expr *x) {
+      return (x->As<ir::Store>() &&
+              utils::Endswith(x->As<ir::Store>()->tensor.as_tensor()->buffer->name, "temp_buffer"));
+    });
+    auto temp_buffer_load  = ir::CollectIRNodesWithoutTensor(schedule_block_expr, [&](const Expr *x) {
+      return (x->As<ir::Load>() && utils::Endswith(x->As<ir::Load>()->tensor.as_tensor()->buffer->name, "temp_buffer"));
+    });
+
+    auto find_for_loop_info_func =
+        [&](const std::set<ir::Expr> &temp_buffer_ops, const std::vector<std::string> &extra_var, bool is_load) {
+          for (auto &buf_op : temp_buffer_ops) {
+            std::vector<cinn::ir::Expr> indices;
+            if (is_load) {
+              CHECK(buf_op.As<ir::Load>());
+              indices = buf_op.As<ir::Load>()->indices;
+            } else {
+              CHECK(buf_op.As<ir::Store>());
+              indices = buf_op.As<ir::Store>()->indices;
+            }
+
+            for (int i = 0; i < iter_vars.size(); ++i) {
+              for (auto &ind : indices) {
+                if (ind.as_var_ref()->name == iter_vars[i]->name) {
+                  auto iter_value     = iter_values.at(i);
+                  auto vars_in_indice = ir::CollectIRNodes(iter_value, [&](const Expr *x) { return x->as_var(); });
+                  for (auto &var_in_indice : vars_in_indice) {
+                    std::string var_name = var_in_indice.as_var_ref()->name;
+
+                    bool is_in_extra_var = false;
+                    for (const auto &ev : extra_var) {
+                      if (var_name.find(ev) != std::string::npos) {
+                        is_in_extra_var = true;
+                        break;
+                      }
+                    }
+                    auto find_loop_with_var_name = std::find_if(
+                        find_no_bind_forloops.begin(), find_no_bind_forloops.end(), [&var_name](const ir::Expr &e) {
+                          return e.As<ir::For>()->loop_var->name == var_name;
+                        });
+                    if (!is_in_extra_var && find_loop_with_var_name != find_no_bind_forloops.end()) {
+                      poly::StageForloopInfo for_loop_info;
+                      for_loop_info.for_type = find_loop_with_var_name->As<ir::For>()->bind_info().for_type;
+                      for_loop_info.offset   = find_loop_with_var_name->As<ir::For>()->bind_info().offset;
+                      for_loop_info.device   = find_loop_with_var_name->As<ir::For>()->bind_info().device;
+                      if (is_load) {
+                        forloop_infos[buf_op.As<ir::Load>()->tensor.as_tensor_ref()->name][var_name] = for_loop_info;
+                      } else {
+                        forloop_infos[buf_op.As<ir::Store>()->tensor.as_tensor_ref()->name][var_name] = for_loop_info;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+    find_for_loop_info_func(temp_buffer_store, compute_at_extra_var, false);
+    find_for_loop_info_func(temp_buffer_load, reverse_compute_at_extra_var, true);
+  }
+
   std::unordered_map<std::string, std::vector<Expr>> resized_buffer_cache;
   TransformGpuForloops(forloop_infos, tensor_traverse_order, &global_tensor_map, resized_buffer_cache, expr);
   VLOG(3) << "After TransformGpuForloops Expr: \n" << *expr;


### PR DESCRIPTION
问题：在Cache Read/Write后，增加的Cache Block再[Reverse]ComputeAt到某个循环下的情况，实际需要用到的memory会变小。如下图，temp_matmul_out_local_temp_buffer需要的size仅与ax0和ax1有关，可将i2和j2置0；X/Y_reshape_shared_temp_buffer同理。
![1678791927](https://user-images.githubusercontent.com/62832681/224982430-e12d88e8-86fd-4ab5-b5c3-09ab1ca17f97.png)
修改后IR如下：
![1678792089](https://user-images.githubusercontent.com/62832681/224983016-1aef6401-473e-4203-bb03-849b48b134db.png)

具体修改如下：
1.在后处理Optim中添加优化逻辑，按照对cache tensor进行Store或Load时用到的下标筛选出外层循环，这些外层循环对应的Var在cache buffer的大小计算时按0计算，仅计算出内层循环需要的buffer大小。
2.修复在使用ComputeAt和ReverseComputeAt原语后，AST中对同一个Tensor的Store/Load节点指向不同Tensor对象的问题。
3.对于有reduce_init操作的算子，由于申请的cache buffer变小，需要将reduce_init操作放到与cache block同级的循环下进行，以保证计算的正确性。