### PR TITLE
Add mutate tile size rule

### DIFF
--- a/cinn/auto_schedule/search_space/search_space.cc
+++ b/cinn/auto_schedule/search_space/search_space.cc
@@ -164,7 +164,7 @@ std::vector<SearchState> SearchSpace::InitSketchWithRandomPrunedStrategy() {
   int total_steps                         = 0, steps;
   std::string block_name;
   while ("" != (block_name = block_sampler->NextBlock()) && total_steps < init_sketch_random_depth_) {
-    steps = utils::SampleUniformInt(0, init_rules.size(), &rand_seed_);
+    steps = utils::SampleUniformInt(1, init_rules.size() + 1, &rand_seed_);
     if (total_steps + steps > init_sketch_random_depth_) {
       steps = init_sketch_random_depth_ - total_steps;
     }

--- a/cinn/auto_schedule/search_strategy/CMakeLists.txt
+++ b/cinn/auto_schedule/search_strategy/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(mutate_rule)
+
 core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS evolutionary_search.cc)

--- a/cinn/auto_schedule/search_strategy/mutate_rule/CMakeLists.txt
+++ b/cinn/auto_schedule/search_strategy/mutate_rule/CMakeLists.txt
@@ -1,0 +1,7 @@
+core_gather_headers()
+
+gather_srcs(cinnapi_src SRCS
+  mutate_tile_size.cc
+	)
+
+cc_test(test_mutate_tile_size SRCS mutate_tile_size_test.cc DEPS cinncore)

--- a/cinn/auto_schedule/search_strategy/mutate_rule/mutate_rule.h
+++ b/cinn/auto_schedule/search_strategy/mutate_rule/mutate_rule.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/ir/schedule_desc.h"
+#include "cinn/utils/random_engine.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+/**
+ * Base class for rules of mutate,
+ * is used to mutate the trace(ScheduleDesc) to explore the search space.
+ */
+class MutateRule {
+ public:
+  MutateRule() = default;
+
+  /**
+   * \brief Apply the mutate rule to the given trace.
+   * \param trace The given trace for mutation.
+   * \param rand_seed The random seed for mutation.
+   * \return The mutated trace.
+   */
+  virtual ir::ScheduleDesc Apply(const ir::ScheduleDesc& trace, utils::LinearRandomEngine::StateType* rand_seed) = 0;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.cc
+++ b/cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+using ::cinn::ir::ScheduleDesc;
+using ::cinn::utils::LinearRandomEngine;
+
+using SampledTile = std::tuple<ScheduleDesc::Step, std::vector<int>, int>;
+
+static std::vector<int> Factorize(int n) {
+  std::vector<int> res;
+  for (int i = 1; i * i <= n; ++i) {
+    if (n % i == 0) {
+      res.push_back(i);
+      if (i * i != n) {
+        res.push_back(n / i);
+      }
+    }
+  }
+  std::sort(res.begin(), res.end());
+  return res;
+}
+
+std::vector<SampledTile> FindSampledTiles(const ScheduleDesc& trace) {
+  std::vector<SampledTile> tiles;
+  int step_idx = 0;
+  for (auto&& step : trace.Steps()) {
+    if (step.type == "SamplePerfectTile") {
+      std::vector<int> tile_factors = absl::get<std::vector<int>>(step.attrs.at("decision"));
+      CHECK(tile_factors.size() >= 2) << "factors size must be greater equal than 2, which is " << tile_factors.size();
+      tiles.push_back(std::make_tuple(step, tile_factors, step_idx));
+    }
+    ++step_idx;
+  }
+
+  return tiles;
+}
+
+ScheduleDesc DoMutateTileSize(const ScheduleDesc& trace,
+                              const SampledTile& tile,
+                              LinearRandomEngine::StateType* rand_seed) {
+  ScheduleDesc::Step step       = std::get<0>(tile);
+  std::vector<int> tile_factors = std::get<1>(tile);
+  int split_size                = tile_factors.size();
+  // Step 1. Choose 2 loops with index: 'loop_x' and 'loop_y'
+  int loop_x, loop_y;
+
+  while (true) {
+    loop_x = utils::SampleUniformInt(0, split_size, rand_seed);
+    if (tile_factors.at(loop_x) <= 1) {
+      continue;
+    }
+    loop_y = utils::SampleUniformInt(0, split_size - 1, rand_seed);
+    if (loop_y >= loop_x) {
+      ++loop_y;
+    }
+    std::vector<int> optional_factors = Factorize(tile_factors.at(loop_x));
+    // Step 2. Choose the divisor for mutate.
+    int divisor;
+    if (loop_y == split_size - 1) {
+      int max_innermost_factor    = absl::get<int>(step.attrs.at("max_innermost_factor"));
+      int max_optional_factor_idx = optional_factors.size() - 1;
+      for (; max_optional_factor_idx > 0; --max_optional_factor_idx) {
+        if (optional_factors.at(max_optional_factor_idx) * tile_factors.at(loop_y) <= max_innermost_factor) {
+          break;
+        }
+      }
+      if (max_optional_factor_idx == 0) {
+        if (split_size <= 2) {
+          VLOG(6) << "Unable to mutate, return the original trace";
+          return trace;
+        }
+        continue;
+      }
+      divisor = optional_factors.at(utils::SampleUniformInt(1, max_optional_factor_idx + 1, rand_seed));
+    } else {
+      divisor = optional_factors.at(utils::SampleUniformInt(1, optional_factors.size(), rand_seed));
+    }
+    // Step 3. Determine the new tile value
+    VLOG(6) << "DoMutateTileSize: divisor = " << divisor << ", before mutate: \n"
+            << "factors[" << loop_x << "] = " << tile_factors[loop_x] << ", factors[" << loop_y
+            << "] = " << tile_factors[loop_y];
+    tile_factors[loop_x] /= divisor;
+    tile_factors[loop_y] *= divisor;
+    VLOG(6) << "after mutate: \n"
+            << "factors[" << loop_x << "] = " << tile_factors[loop_x] << ", factors[" << loop_y
+            << "] = " << tile_factors[loop_y];
+    // Step 4. Create a new step with new tile values and return the new trace
+    int step_idx                              = std::get<2>(tile);
+    std::vector<ScheduleDesc::Step> new_steps = trace.Steps();
+    new_steps[step_idx].attrs["decision"]     = tile_factors;
+    return ScheduleDesc(std::move(new_steps));
+  }
+}
+
+ScheduleDesc MutateTileSize::Apply(const ScheduleDesc& trace, LinearRandomEngine::StateType* rand_seed) {
+  VLOG(6) << "Start applying MutateTileSize, old trace: \n" << trace.DebugString();
+  std::vector<ScheduleDesc::Step> sample_tile_steps;
+  std::vector<std::vector<int>> sample_tile_data;
+
+  auto sampled_tiles = FindSampledTiles(trace);
+  if (sampled_tiles.size() == 0) {
+    VLOG(6) << "MutateTileSize failed, try other mutate rules.";
+    return ScheduleDesc();
+  }
+  int sample_step_idx = utils::SampleUniformInt(0, sampled_tiles.size(), rand_seed);
+  auto new_trace      = DoMutateTileSize(trace, sampled_tiles.at(sample_step_idx), rand_seed);
+  VLOG(6) << "End applying MutateTileSize, new trace: \n" << new_trace.DebugString();
+  return new_trace;
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.h
+++ b/cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "cinn/auto_schedule/search_strategy/mutate_rule/mutate_rule.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+/**
+ * The rule to mutate tile size, witch will modify the factors of the Split primitive.
+ */
+class MutateTileSize : public MutateRule {
+ public:
+  MutateTileSize() = default;
+
+  ir::ScheduleDesc Apply(const ir::ScheduleDesc& trace, utils::LinearRandomEngine::StateType* rand_seed) override;
+};
+
+}  // namespace auto_schedule
+}  // namespace cinn

--- a/cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size_test.cc
+++ b/cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size_test.cc
@@ -1,0 +1,110 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "cinn/cinn.h"
+#include "cinn/ir/ir_schedule.h"
+
+namespace cinn {
+namespace auto_schedule {
+
+TEST(MutateTileSize, Basic) {
+  srand(0);
+  Context::Global().ResetNameId();
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
+  Target target = common::DefaultHostTarget();
+#endif
+
+  Expr M(32);
+  Expr N(32);
+  Expr K(32);
+
+  Placeholder<float> A("A", {M, K});
+  Placeholder<float> B("B", {K, N});
+
+  Var k(K.as_int32(), "reduce_axis_k");
+  ir::Tensor C = Compute(
+      {M, N}, [&](Var i, Var j) { return ReduceSum(A(i, k) * B(k, j), {k}); }, "C");
+
+  poly::StageMap stages = CreateStages({A, B, C});
+  std::vector<ir::LoweredFunc> funcs =
+      lang::LowerVec("TestMutateTileSize_Basic", stages, {A, B, C}, {}, {}, nullptr, target, true);
+
+  ir::Expr ast_expr = funcs[0]->body;
+  VLOG(6) << "Original Expr: ";
+  VLOG(6) << ast_expr;
+  ir::ModuleExpr module_expr({ast_expr});
+  // We need to fix the seed as a constant to ensure that the result can be repeated.
+  utils::LinearRandomEngine::StateType rand_seed = 123;
+  ir::IRSchedule ir_schedule(module_expr, rand_seed);
+  ir::IRSchedule new_ir_schedule(ir_schedule);
+
+  // apply schedule
+  auto loops   = ir_schedule.GetLoops("C");
+  auto factors = ir_schedule.SamplePerfectTile(loops[0], 2, 32);
+  auto splited = ir_schedule.Split(loops[0], factors);
+
+  // apply mutate
+  MutateTileSize mutator;
+  ir::ScheduleDesc sch_desc = mutator.Apply(ir_schedule.GetTraceDesc(), &rand_seed);
+  sch_desc.Replay(&new_ir_schedule);
+  VLOG(6) << "Expr before mutate tile size: \n" << ir_schedule.GetModule().GetExprs()[0];
+  VLOG(6) << "Expr after mutate tile size: \n" << new_ir_schedule.GetModule().GetExprs()[0];
+
+  std::string target_new_ir = R"ROC({
+  ScheduleBlock(root)
+  {
+    serial for (i_0, 0, 2)
+    {
+      serial for (i_1, 0, 16)
+      {
+        serial for (j, 0, 32)
+        {
+          ScheduleBlock(C__reduce_init)
+          {
+            i0, i1 = axis.bind(((16 * i_0) + i_1), j)
+            C__reduce_init[i0, i1] = 0.00000f
+          }
+          serial for (reduce_axis_k, 0, 32)
+          {
+            ScheduleBlock(C)
+            {
+              i0, i1, i2 = axis.bind(((16 * i_0) + i_1), j, reduce_axis_k)
+              C[i0, i1] = (C[i0, i1] + (A[i0, i2] * B[i2, i1]))
+            }
+          }
+        }
+      }
+    }
+  }
+})ROC";
+
+  auto get_ir_str = [](const ir::IRSchedule* ir_sch) -> std::string {
+    std::vector<ir::Expr> exprs = ir_sch->GetModule().GetExprs();
+    EXPECT_EQ(exprs.size(), 1UL);
+    std::stringstream ss;
+    ss << exprs[0];
+    return ss.str();
+  };
+  CHECK_EQ(get_ir_str(&new_ir_schedule), target_new_ir);
+}
+
+}  // namespace auto_schedule
+}  // namespace cinn


### PR DESCRIPTION
1.Add interface of mutate rules. The Apply() interface receives a ScheduleDesc object and gets a new mutated ScheduleDesc object. Later, it can be replayed through ScheduleDesc::Replay() to restore a ModuleExpr.
2.Implemented a rule named MutateTileSize, which can randomly transform the split factor of For loop.