### PR TITLE
upgrade CheckResult on auto_gen_rule/TestAutoGenRuleBase

### DIFF
--- a/cinn/auto_schedule/search_space/auto_gen_rule/mix_rules_test.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/mix_rules_test.cc
@@ -36,7 +36,8 @@ class TestMixRules : public TestAutoGenRuleBase {
 };
 
 TEST_F(TestMixRules, 2DMatmulOnMultiTilingRelated) {
-  ir::IRSchedule ir_schedule       = InitSchedule(MatmulOpBuilder({32, 32}, {32, 32})(), common::DefaultNVGPUTarget());
+  Initialize(common::DefaultNVGPUTarget());
+  ir::IRSchedule ir_schedule       = MakeIRSchedule(MatmulOpBuilder({32, 32}, {32, 32})());
   std::vector<ir::Expr> func_bodys = ir_schedule.GetModule().GetExprs();
   ASSERT_EQ(func_bodys.size(), 1UL);
   VLOG(6) << "Original Expr:\n" << func_bodys[0];
@@ -68,7 +69,8 @@ TEST_F(TestMixRules, 2DMatmulOnMultiTilingRelated) {
   VLOG(6) << "scheduled source code:\n" << source_code;
   // execute and check precision
   CheckResult(GenExecutableKernel(ir_module),
-              expected_func_matmul,
+              GenExecutableKernel(BuildIRModule(
+                  MakeIRSchedule(MatmulOpBuilder({32, 32}, {32, 32})(), /* apply_manual_schedule*/ true))),
               default_input_names,
               default_output_names,
               {{32, 32}, {32, 32}},

--- a/cinn/auto_schedule/search_space/auto_gen_rule/test_helper.cc
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/test_helper.cc
@@ -41,19 +41,26 @@ using ::cinn::hlir::framework::Scope;
 using ::cinn::hlir::framework::Shape;
 using ::cinn::hlir::framework::Tensor;
 
-ir::IRSchedule TestAutoGenRuleBase::InitSchedule(const frontend::Program& test_program, const common::Target& target) {
-  Context::Global().ResetNameId();
+void TestAutoGenRuleBase::Initialize(const common::Target& target) {
   target_          = target;
   backend_compier_ = backends::Compiler::Create(target);
+}
 
-  auto graph = std::make_shared<hlir::framework::Graph>(test_program, target);
+ir::IRSchedule TestAutoGenRuleBase::MakeIRSchedule(const frontend::Program& test_program, bool apply_manual_schedule) {
+  Context::Global().ResetNameId();
+
+  auto graph = std::make_shared<hlir::framework::Graph>(test_program, target_);
   hlir::framework::ApplyPass(graph.get(), "OpFusionPass");
   LOG_IF(WARNING, graph->fusion_groups.size() > 1) << "Test Graph has more than 1 group";
   auto& dtype_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, common::Type>>("inferdtype");
   auto& shape_dict = graph->GetMutableAttrs<absl::flat_hash_map<std::string, hlir::framework::shape_t>>("infershape");
-  hlir::framework::OpLowerer op_lowerer(dtype_dict, shape_dict, target);
+  hlir::framework::OpLowerer op_lowerer(dtype_dict, shape_dict, target_);
 
-  lowered_funcs_ = op_lowerer.LowerWithoutSchedule(graph->fusion_groups.front());
+  if (apply_manual_schedule) {
+    lowered_funcs_ = op_lowerer.Lower(graph->fusion_groups.front());
+  } else {
+    lowered_funcs_ = op_lowerer.LowerWithoutSchedule(graph->fusion_groups.front());
+  }
   CHECK(!lowered_funcs_.empty()) << "lowered_funcs_ is empty";
 
   std::vector<Expr> bodys;
@@ -87,51 +94,18 @@ std::string TestAutoGenRuleBase::GenSourceCode(const ir::Module& ir_module) {
     codegen = std::make_unique<backends::CodeGenCX86>(this->target_, CodeGenCX86::Feature::AVX512);
   }
 #else
-  codegen      = std::make_unique<backends::CodeGenCX86>(this->target_, CodeGenCX86::Feature::AVX512);
+  codegen = std::make_unique<backends::CodeGenCX86>(this->target_, CodeGenCX86::Feature::AVX512);
 #endif
   codegen->SetInlineBuiltinCodes(false);
   return codegen->Compile(ir_module, CodeGenC::OutputKind::CImpl);
 }
 
-test_func_type TestAutoGenRuleBase::GenExecutableKernel(const ir::Module& ir_module) {
+raw_func_type TestAutoGenRuleBase::GenExecutableKernel(const ir::Module& ir_module) {
   auto&& func_name = lowered_funcs_.front()->name;
   // Compile to machine code
   backend_compier_->Build(ir_module);
   auto test_func_ptr = reinterpret_cast<void (*)(void**, int32_t)>(backend_compier_->Lookup(func_name));
   return test_func_ptr;
-}
-
-void naive_matmul(const float* A, const float* B, float* C, int M, int N, int K) {
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
-      for (int k = 0; k < K; ++k) {
-        C[i * N + j] += A[i * K + k] * B[k * N + j];
-      }
-    }
-  }
-}
-
-void expected_func_matmul(const std::vector<float*>& inputs,
-                          const std::vector<float*>& outputs,
-                          const std::vector<std::vector<int>>& input_shapes,
-                          const std::vector<std::vector<int>>& output_shapes) {
-  CHECK_EQ(inputs.size(), 2) << "The number of inputs for matmul must be 2.";
-  CHECK_EQ(input_shapes.size(), 2) << "The number of inputs for matmul must be 2.";
-  CHECK_EQ(outputs.size(), 1) << "The number of outputs for matmul must be 1.";
-  CHECK_EQ(output_shapes.size(), 1) << "The number of outputs for matmul must be 1.";
-  CHECK_EQ(input_shapes[0].size(), 2) << "The dimension of the first input must be 2";
-  CHECK_EQ(input_shapes[1].size(), 2) << "The dimension of the second input must be 2";
-  CHECK_EQ(output_shapes[0].size(), 2) << "The dimension of the output must be 2";
-  CHECK_EQ(input_shapes[0][1], input_shapes[1][0])
-      << "The second dimension of the first matrix and the first dimension of the second matrix must be equal";
-  CHECK_EQ(input_shapes[0][0], output_shapes[0][0])
-      << "The first dimension of the first input matrix and the first dimension of the output matrix must be equal";
-  CHECK_EQ(input_shapes[1][1], output_shapes[0][1])
-      << "The second dimension of the second input matrix and the second dimension of the output matrix must be equal";
-  int M = input_shapes[0][0];
-  int N = input_shapes[1][1];
-  int K = input_shapes[0][1];
-  naive_matmul(inputs[0], inputs[1], outputs[0], M, N, K);
 }
 
 void MemoryCopy(const float* src, float* dst, int numel, std::string type) {
@@ -160,18 +134,13 @@ void AddDataToScope(
   CHECK(shape.size()) << "The size of shape can not be 0.";
   Shape cinn_shape(shape);
   tensor->Resize(cinn_shape);
-  auto* tgt_data_ptr = tensor->mutable_data<float>(target);
-  std::string mem_cpy_type;
-#ifdef CINN_WITH_CUDA
-  mem_cpy_type = "HostToDevice";
-#else
-  mem_cpy_type = "HostToHost";
-#endif
+  auto* tgt_data_ptr       = tensor->mutable_data<float>(target);
+  std::string mem_cpy_type = target == common::DefaultNVGPUTarget() ? "DeviceToHost" : "HostToHost";
   MemoryCopy(data_ptr, tgt_data_ptr, cinn_shape.numel(), mem_cpy_type);
 }
 
-void CheckResult(test_func_type test_func,
-                 expected_func_type expected_func,
+void CheckResult(raw_func_type test_func,
+                 raw_func_type expected_func,
                  const std::vector<std::string>& input_names,
                  const std::vector<std::string>& output_names,
                  const std::vector<std::vector<int>>& input_shapes,
@@ -193,57 +162,54 @@ void CheckResult(test_func_type test_func,
       input_data_ptrs[i][j] = (rand() * 1.f) / RAND_MAX;
     }
   }
-  std::vector<float*> output_data_ptrs(output_names.size());
+  std::vector<float*> test_output_data_ptrs(output_names.size());
   std::vector<float*> expected_output_data_ptrs(output_names.size());
   std::vector<int> output_data_numels(output_shapes.size());
   for (int i = 0; i < output_shapes.size(); ++i) {
     output_data_numels[i] =
         std::accumulate(output_shapes[i].begin(), output_shapes[i].end(), 1, [](int a, int b) { return a * b; });
-    ;
-    output_data_ptrs[i] = reinterpret_cast<float*>(malloc(output_data_numels[i] * sizeof(float)));
-    memset(output_data_ptrs[i], 0, output_data_numels[i] * sizeof(float));
+    test_output_data_ptrs[i] = reinterpret_cast<float*>(malloc(output_data_numels[i] * sizeof(float)));
+    memset(test_output_data_ptrs[i], 0, output_data_numels[i] * sizeof(float));
     expected_output_data_ptrs[i] = reinterpret_cast<float*>(malloc(output_data_numels[i] * sizeof(float)));
     memset(expected_output_data_ptrs[i], 0, output_data_numels[i] * sizeof(float));
   }
 
-  // Initialize scope
-  Scope scope;
-  // Initialize input data in scope.
-  for (int i = 0; i < input_names.size(); ++i) {
-    AddDataToScope(&scope, target, input_data_ptrs[i], input_names[i], input_shapes[i]);
-  }
-  // Initialize output data in scope.
-  for (int i = 0; i < output_names.size(); ++i) {
-    AddDataToScope(&scope, target, output_data_ptrs[i], output_names[i], output_shapes[i]);
-  }
+  auto launch_kernel_fn = [&](raw_func_type& raw_func, std::vector<float*>& output_data_ptrs) {
+    // Initialize scope
+    Scope scope;
+    // Initialize input data in scope.
+    for (int i = 0; i < input_names.size(); ++i) {
+      AddDataToScope(&scope, target, input_data_ptrs[i], input_names[i], input_shapes[i]);
+    }
+    // Initialize output data in scope.
+    for (int i = 0; i < output_names.size(); ++i) {
+      AddDataToScope(&scope, target, output_data_ptrs[i], output_names[i], output_shapes[i]);
+    }
 
-  // Create Instruction and run
-  Instruction instr(target, &scope, input_names, output_names);
-  CHECK(test_func) << "The test_func can not be nullptr.";
-  instr.SetLoweredFunc(reinterpret_cast<void*>(test_func));
-  // should call Finalize explicitly before Run
-  instr.Finalize();
-  instr.Run();
+    // Create Instruction and run
+    Instruction instr(target, &scope, input_names, output_names);
+    CHECK(raw_func) << "The raw_func can not be nullptr.";
+    instr.SetLoweredFunc(reinterpret_cast<void*>(raw_func));
+    // should call Finalize explicitly before Run
+    instr.Finalize();
+    instr.Run();
 
-  // Get data
-  for (int i = 0; i < output_names.size(); ++i) {
-    const float* result_ptr = scope.GetTensor(output_names[i])->data<float>();
-    std::string mem_cpy_type;
-#ifdef CINN_WITH_CUDA
-    mem_cpy_type = "DeviceToHost";
-#else
-    mem_cpy_type = "HostToHost";
-#endif
-    MemoryCopy(result_ptr, output_data_ptrs[i], output_data_numels[i], mem_cpy_type);
-  }
+    // data
+    for (int i = 0; i < output_names.size(); ++i) {
+      const float* result_ptr  = scope.GetTensor(output_names[i])->data<float>();
+      std::string mem_cpy_type = target == common::DefaultNVGPUTarget() ? "DeviceToHost" : "HostToHost";
+      MemoryCopy(result_ptr, output_data_ptrs[i], output_data_numels[i], mem_cpy_type);
+    }
+  };
 
-  // Calculate expected result
-  expected_func(input_data_ptrs, expected_output_data_ptrs, input_shapes, output_shapes);
+  // launch and execute test and expected kernel separately
+  launch_kernel_fn(test_func, test_output_data_ptrs);
+  launch_kernel_fn(expected_func, expected_output_data_ptrs);
 
   // Check result
   for (int i = 0; i < output_shapes.size(); ++i) {
     for (int j = 0; j < output_data_numels[i]; ++j) {
-      ASSERT_NEAR(output_data_ptrs[i][j], expected_output_data_ptrs[i][j], 1e-4);
+      ASSERT_NEAR(test_output_data_ptrs[i][j], expected_output_data_ptrs[i][j], 1e-4);
     }
   }
 
@@ -251,7 +217,7 @@ void CheckResult(test_func_type test_func,
   for (auto ptr : input_data_ptrs) {
     free(ptr);
   }
-  for (auto ptr : output_data_ptrs) {
+  for (auto ptr : test_output_data_ptrs) {
     free(ptr);
   }
   for (auto ptr : expected_output_data_ptrs) {

--- a/cinn/auto_schedule/search_space/auto_gen_rule/test_helper.h
+++ b/cinn/auto_schedule/search_space/auto_gen_rule/test_helper.h
@@ -34,7 +34,7 @@ namespace auto_schedule {
  * @params-2: The number of Arguments.
  * @return: void
  */
-using test_func_type = void (*)(void**, int32_t);
+using raw_func_type = void (*)(void**, int32_t);
 
 // A base utility class for testing AutoGenRule
 class TestAutoGenRuleBase : public ::testing::Test {
@@ -43,9 +43,11 @@ class TestAutoGenRuleBase : public ::testing::Test {
     srand(0);
     Context::Global().ResetNameId();
   }
+  // Initialize context for specified target
+  void Initialize(const common::Target& target);
 
-  // Initialize a ir::IRSchedule by lowering the specified for following AutoGenRule test
-  ir::IRSchedule InitSchedule(const frontend::Program& test_program, const common::Target& target);
+  // construct an ir::IRSchedule by lowering the specified for following AutoGenRule test
+  ir::IRSchedule MakeIRSchedule(const frontend::Program& test_program, bool apply_manual_schedule = false);
 
   // build ir::Module from the original lowered funcs with their bodys updated by the schedule
   ir::Module BuildIRModule(const ir::IRSchedule& schedule);
@@ -54,37 +56,13 @@ class TestAutoGenRuleBase : public ::testing::Test {
   std::string GenSourceCode(const ir::Module& ir_module);
 
   // generate executable kernel function with the built ir module
-  test_func_type GenExecutableKernel(const ir::Module& ir_module);
+  raw_func_type GenExecutableKernel(const ir::Module& ir_module);
 
  protected:
   common::Target target_;
   std::vector<ir::LoweredFunc> lowered_funcs_;
   std::unique_ptr<backends::Compiler> backend_compier_;
 };
-
-/* @brief: Packaging the naive matmul as a unified format required by the CheckResult interface.
- * @params-1: Pointers to the memory of input data, each input corresponds to a pointer.
- * @params-2: Pointers to the memory of output data, each output corresponds to a pointer.
- * @params-3: Shapes of the input data, each input corresponds to a std::vector<int>.
- * @params-4: Shapes of the output data, each output corresponds to a std::vector<int>.
- * @return: void
- */
-void expected_func_matmul(const std::vector<float*>& inputs,
-                          const std::vector<float*>& outputs,
-                          const std::vector<std::vector<int>>& input_shapes,
-                          const std::vector<std::vector<int>>& output_shapes);
-
-/* @brief: Unified signature format as the expected function for comparison.
- * @params-1: Pointers to the memory of input data, each input corresponds to a pointer.
- * @params-2: Pointers to the memory of output data, each output corresponds to a pointer.
- * @params-3: Shapes of the input data, each input corresponds to a std::vector<int>.
- * @params-4: Shapes of the output data, each output corresponds to a std::vector<int>.
- * @return: void
- */
-using expected_func_type = void (*)(const std::vector<float*>&,
-                                    const std::vector<float*>&,
-                                    const std::vector<std::vector<int>>&,
-                                    const std::vector<std::vector<int>>&);
 
 /* @brief: Interface for checking function correctness.
  * @params-1: Function pointer of the function to be tested.
@@ -96,8 +74,8 @@ using expected_func_type = void (*)(const std::vector<float*>&,
  * @params-7: The Target expressing computing platform and architecture of the function to be tested.
  * @return: void
  */
-void CheckResult(test_func_type test_func,
-                 expected_func_type expected_func,
+void CheckResult(raw_func_type test_func,
+                 raw_func_type expected_func,
                  const std::vector<std::string>& input_names,
                  const std::vector<std::string>& output_names,
                  const std::vector<std::vector<int>>& input_shapes,


### PR DESCRIPTION
升级AutoGenRule测试接口，支持CheckResult中基准计算kernel采用默认的手工schedule编译生成，并修改相应的应用case