### PR TITLE
add op_mapper for argsort

### DIFF
--- a/cinn/frontend/decomposer/top_k.cc
+++ b/cinn/frontend/decomposer/top_k.cc
@@ -36,7 +36,7 @@ void top_k(const Instruction& instr, const DecomposerContext& context) {
 
   auto sort_tmp    = builder->Sort(x, axis, false);
   auto sort_out    = builder->Slice(sort_tmp, {axis}, {0}, {k});
-  auto argsort_tmp = builder->ArgSort(x, axis, false);
+  auto argsort_tmp = builder->ArgSort(x, axis, false).at(0);
   auto argsort_out = builder->Cast(builder->Slice(argsort_tmp, {axis}, {0}, {k}), "int64");
 
   // map the the output of decomposed operator to the original.

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -459,13 +459,13 @@ Variable NetBuilder::Conv(const Variable& lhs,
       .front();
 }
 
-Variable NetBuilder::ArgSort(const Variable& operand, const int& axis, const bool& is_ascend) {
+std::vector<Variable> NetBuilder::ArgSort(const Variable& operand, const int& axis, const bool& is_ascend) {
   Instruction instr("argsort", {operand});
   instr.SetAttr("axis", axis);
   instr.SetAttr("is_ascend", is_ascend);
   InferShape(instr);
   AppendInstruction(instr);
-  return instr.GetOutput(0);
+  return instr.GetOutputs();
 }
 
 Variable NetBuilder::Sort(const Variable& operand, const int& axis, const bool& is_ascend) {

--- a/cinn/frontend/net_builder.h
+++ b/cinn/frontend/net_builder.h
@@ -980,7 +980,7 @@ class NetBuilder {
    * Defalut “NCHW”.
    * @return `Sorted variable index`.
    */
-  Variable ArgSort(const Variable& operand, const int& axis, const bool& is_ascend = true);
+  std::vector<Variable> ArgSort(const Variable& operand, const int& axis, const bool& is_ascend = true);
 
   /**
    * @brief Sort Variable x along the given axis and return sorted variable. The original Variable x will not be

--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -930,7 +930,7 @@ TEST(net_build, program_execute_argsort) {
 
   NetBuilder builder("net_builder");
   Placeholder input = builder.CreateInput(Float(32), {B, H}, "In");
-  Variable output   = builder.ArgSort(input, 0, true);
+  Variable output   = builder.ArgSort(input, 0, true).at(0);
   auto program      = builder.Build();
 
 #ifdef CINN_WITH_CUDA

--- a/cinn/frontend/op_mappers/paddle/argsort.cc
+++ b/cinn/frontend/op_mappers/paddle/argsort.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,18 +33,18 @@ void ArgsortOpMapper(const paddle::cpp::OpDesc& op_desc, const cinn::frontend::O
   auto indices_name = op_desc.Output("Indices").front();
 
   auto is_ascend = !(utils::GetAttrOrDefault<bool>(op_desc, "descending", false));
-  auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
+  auto axis      = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
 
-  auto x = ctx.GetVar(x_name);
+  auto x   = ctx.GetVar(x_name);
   auto out = ctx.Builder()->ArgSort(x, axis, is_ascend);
   auto idx = ctx.Builder()->Cast(out[0], "int64");
 
   ctx.AddVar(indices_name, idx);
   ctx.AddVarModelToProgram(indices_name, idx->id);
 
-  //TODO: return the sorted tensor here. Now out[1] is a temporary tensor.
-  //this is because output 'Out' is never uesd in Paddle API, but CINN need to return 2 output vars
-  //to meet the op defination, this should be resolved after sort op restructured.
+  // TODO: return the sorted tensor here. Now out[1] is a temporary tensor.
+  // this is because output 'Out' is never uesd in Paddle API, but CINN need to return 2 output vars
+  // to meet the op defination, this should be resolved after sort op restructured.
   ctx.AddVar(out_name, out[1]);
   ctx.AddVarModelToProgram(out_name, out[1]->id);
 }

--- a/cinn/frontend/op_mappers/paddle/argsort.cc
+++ b/cinn/frontend/op_mappers/paddle/argsort.cc
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <variant>
+
+#include "cinn/frontend/op_mapper_registry.h"
+#include "cinn/frontend/op_mappers/common_utils.h"
+#include "cinn/utils/string.h"
+
+namespace cinn {
+namespace frontend {
+namespace paddle_mappers {
+
+void ArgsortOpMapper(const paddle::cpp::OpDesc& op_desc, const cinn::frontend::OpMapperContext& ctx) {
+  CHECK_EQ(op_desc.Input("X").size(), 1UL);
+  auto x_name = op_desc.Input("X").front();
+
+  CHECK_EQ(op_desc.Output("Out").size(), 1UL);
+  auto out_name = op_desc.Output("Out").front();
+
+  CHECK_EQ(op_desc.Output("Indices").size(), 1UL);
+  auto indices_name = op_desc.Output("Indices").front();
+
+  auto is_ascend = !(utils::GetAttrOrDefault<bool>(op_desc, "descending", false));
+  auto axis = utils::ToDimType(utils::GetAttrOrDefault<int64_t>(op_desc, "axis", 0));
+
+  auto x = ctx.GetVar(x_name);
+  auto out = ctx.Builder()->ArgSort(x, axis, is_ascend);
+  auto idx = ctx.Builder()->Cast(out[0], "int64");
+
+  ctx.AddVar(indices_name, idx);
+  ctx.AddVarModelToProgram(indices_name, idx->id);
+
+  //TODO: return the sorted tensor here. Now out[1] is a temporary tensor.
+  //this is because output 'Out' is never uesd in Paddle API, but CINN need to return 2 output vars
+  //to meet the op defination, this should be resolved after sort op restructured.
+  ctx.AddVar(out_name, out[1]);
+  ctx.AddVarModelToProgram(out_name, out[1]->id);
+}
+
+}  // namespace paddle_mappers
+}  // namespace frontend
+}  // namespace cinn
+
+CINN_REGISTER_HELPER(paddle_argsort) {
+  CINN_REGISTER_OP_MAPPER(argsort, cinn::frontend::paddle_mappers::ArgsortOpMapper)
+  return true;
+}

--- a/cinn/frontend/op_mappers/use_op_mappers.h
+++ b/cinn/frontend/op_mappers/use_op_mappers.h
@@ -16,6 +16,7 @@
 
 #include "cinn/common/macros.h"
 
+CINN_USE_REGISTER(paddle_argsort)
 CINN_USE_REGISTER(paddle_fetch_feed)
 CINN_USE_REGISTER(paddle_mul)
 CINN_USE_REGISTER(paddle_slice)

--- a/cinn/hlir/op/contrib/sort.cc
+++ b/cinn/hlir/op/contrib/sort.cc
@@ -51,7 +51,8 @@ std::vector<ir::Tensor> ArgSort(const ir::Tensor &A,
                                 poly::StageMap stages,
                                 const int &axis,
                                 const bool &is_ascend,
-                                const std::string &name) {
+                                const std::string &name,
+                                const std::string &name2) {
   std::string find_func_name;
   std::string index_func_name;
   if (target.arch == common::Target::Arch::NVGPU) {
@@ -92,7 +93,7 @@ std::vector<ir::Tensor> ArgSort(const ir::Tensor &A,
         auto A_shape_axis = A->shape[pos_axis];
         return lang::CallExtern(index_func_name, {A, A_shape_axis, A(indices), offset, stride});
       },
-      name + "_temp");
+      name2 + "cnt");
   auto res = Compute(
       A->shape,
       [=](const std::vector<Expr> &indices) {
@@ -115,7 +116,7 @@ std::vector<ir::Tensor> ArgSort(const ir::Tensor &A,
         auto idx = lang::CallExtern(find_func_name, {positions, A_shape_axis, indices[pos_axis], offset, stride});
         return idx;
       },
-      name);
+      name + "idx");
   stages->InsertLazily(positions);
   return {res, positions};
 }
@@ -248,16 +249,20 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgSort(const framework::NodeA
     auto stages   = CreateStages({tensor_A});
     VLOG(3) << "A shape: " << utils::Join(tensor_A->shape, ", ")
             << ", output_shapes: " << utils::Join(output_shapes[0], ", ");
-    auto tensor_name = UniqName("ArgSort_out");
+    auto tensor_name  = UniqName("ArgSort_out");
+    auto tensor_name2 = UniqName("ArgSort_out2");
     if (FLAGS_cinn_ir_schedule) {
-      CHECK_EQ(pack_args.size(), 2U);
+      CHECK_EQ(pack_args.size(), 3U);
       CHECK(pack_args[1].is_string());
-      tensor_name = pack_args[1].operator std::string();
+      tensor_name  = pack_args[1].operator std::string();
+      tensor_name2 = pack_args[2].operator std::string();
     }
-    auto out = ArgSort(tensor_A, target, stages, axis, is_ascend, tensor_name);
+    auto out = ArgSort(tensor_A, target, stages, axis, is_ascend, tensor_name, tensor_name2);
     std::vector<CINNValue> res;
     stages->InsertLazily(out.at(0));
+    stages->InsertLazily(out.at(1));
     res.push_back(CINNValue(out.at(0)));
+    res.push_back(CINNValue(out.at(1)));
     CHECK(!out_type.empty()) << "Output type of ArgSort is empty! Please check.\n";
     res.push_back(CINNValue(stages));
     *ret = CINNValuePack{res};
@@ -281,7 +286,8 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgSort(const framework::NodeA
       auto blocks = ir_sch.GetAllBlocks();
       // TODO: remove external calls, do not use local variables, because
       // the size will exceed the limit.
-      ir_sch.SetBuffer(blocks[0], "local");
+      // TODO: There is a bug, setting buffer to "local" here will cause the var declared twice at CodeGen.
+      // ir_sch.SetBuffer(blocks[0], "local");
       long prod_size = std::accumulate(output_shapes[0].begin(), output_shapes[0].end(), 1, std::multiplies<int>());
       if (prod_size > 1 && target.arch == Target::Arch::X86) {
         pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, true);
@@ -323,9 +329,25 @@ std::vector<Type> InferDtypeForSort(const std::vector<Type> &inputs_type, const 
   return res;
 }
 
+std::vector<std::vector<int>> InferShapeForArgSort(const std::vector<std::vector<int>> &inputs_shape,
+                                                   const framework::AttrMapType &attrs) {
+  CHECK_EQ(inputs_shape.size(), 1UL) << "The input's shape size should be 1! Please check again.";
+  int axis = 0;
+  for (auto &iter : attrs) {
+    if (iter.first == "axis") {
+      axis = absl::get<int>(iter.second);
+      break;
+    }
+  }
+  CHECK_GT(inputs_shape[0].size(), axis) << "The input's dim should be greater than axis! ";
+  std::vector<std::vector<int>> res{inputs_shape[0], inputs_shape[0]};
+
+  return res;
+}
+
 std::vector<Type> InferDtypeForArgSort(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
   CHECK_EQ(inputs_type.size(), 1UL) << "The input's type size should be 1! Please check again.";
-  return {Int(32)};
+  return {Int(32), Int(32)};
 }
 
 std::vector<std::vector<int>> InferShapeForTopK(const std::vector<std::vector<int>> &inputs_shape,
@@ -371,9 +393,9 @@ CINN_REGISTER_HELPER(sort_ops) {
   CINN_REGISTER_OP(argsort)
       .describe("Sort a variable x along the given axis and return indices.")
       .set_num_inputs(1)
-      .set_num_outputs(1)
+      .set_num_outputs(2)
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForArgSort)
-      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForSort))
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForArgSort))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForArgSort))
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
       .set_support_level(4);

--- a/cinn/hlir/op/contrib/sort.h
+++ b/cinn/hlir/op/contrib/sort.h
@@ -30,7 +30,8 @@ std::vector<ir::Tensor> ArgSort(const ir::Tensor& A,
                                 poly::StageMap stages,
                                 const int& axis,
                                 const bool& is_ascend,
-                                const std::string& name);
+                                const std::string& name,
+                                const std::string& name2 = "");
 
 std::vector<ir::Tensor> Sort(const ir::Tensor& A,
                              const common::Target& target,

--- a/cinn/hlir/op/contrib/sort.h
+++ b/cinn/hlir/op/contrib/sort.h
@@ -30,8 +30,7 @@ std::vector<ir::Tensor> ArgSort(const ir::Tensor& A,
                                 poly::StageMap stages,
                                 const int& axis,
                                 const bool& is_ascend,
-                                const std::string& name,
-                                const std::string& name2 = "");
+                                const std::string& name);
 
 std::vector<ir::Tensor> Sort(const ir::Tensor& A,
                              const common::Target& target,

--- a/python/tests/op_mappers/test_argsort_op.py
+++ b/python/tests/op_mappers/test_argsort_op.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest, logger
+import paddle
+
+
+class TestArgSortOp(OpMapperTest):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([3, 4], "float32"),
+            #'x': np.array([[5,8,9,5],
+            #               [0,0,1,7],
+            #               [6,9,2,4]]).astype('float32')
+        }
+        print("x = ", self.feed_data)
+        self.axis = 1
+
+
+    def set_op_type(self):
+        return "argsort"
+
+    def set_op_inputs(self):
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        return {'X': [x]}
+
+    def set_op_attrs(self):
+        return {'axis': self.axis}
+
+    def set_op_outputs(self):
+        return {'Out': ['int64'],
+                'Indices': ['int64']}
+
+    def skip_check_outputs(self):
+        #'Out' is never used in Paddle API
+        return {"Out"}
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/op_mappers/test_argsort_op.py
+++ b/python/tests/op_mappers/test_argsort_op.py
@@ -24,13 +24,9 @@ class TestArgSortOp(OpMapperTest):
     def init_input_data(self):
         self.feed_data = {
             'x': self.random([3, 4], "float32"),
-            #'x': np.array([[5,8,9,5],
-            #               [0,0,1,7],
-            #               [6,9,2,4]]).astype('float32')
         }
         print("x = ", self.feed_data)
         self.axis = 1
-
 
     def set_op_type(self):
         return "argsort"
@@ -46,8 +42,7 @@ class TestArgSortOp(OpMapperTest):
         return {'axis': self.axis}
 
     def set_op_outputs(self):
-        return {'Out': ['int64'],
-                'Indices': ['int64']}
+        return {'Out': ['int64'], 'Indices': ['int64']}
 
     def skip_check_outputs(self):
         #'Out' is never used in Paddle API


### PR DESCRIPTION
att, 为已有的argsort op 添加opmapper，本PR主要提供mapper功能，算子本身存在若干bug，需要后续修复：
1. 排序为非稳定排序，因此部分情况下结果可能与paddle op结果不同
2. 存在相同元素时，排序输出结果不正确
3. 输入类型仅能支持float32，其他类型会报错
4. 输出结果在原实现中仅返回indices，未返回排序结果，与Paddle定义不一致，但由于Paddle API中排序结果并未实际使用，目前采用返回临时变量的方式绕过
5. axis为负数时未支持

上述1~4在sort算子重新实现后（已在计划中）可能复用解决，5会在后续pr中解决
