### PR TITLE
test(net_builder): add gpu side test of net builder

### DIFF
--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -173,7 +173,7 @@ TEST(net_build, program_execute_pool2d) {
                                      data_format,
                                      adaptive,
                                      padding_algorithm);
-  auto program = builder.Build();
+  auto program                  = builder.Build();
 
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
@@ -239,7 +239,7 @@ TEST(net_build, program_execute_clip) {
   NetBuilder builder("net_builder");
   Placeholder input = builder.CreateInput(Float(32), {M, N, K}, "In");
   Variable output   = builder.Clip({input}, max_val, min_val);
-  auto program  = builder.Build();
+  auto program      = builder.Build();
 
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
@@ -320,7 +320,7 @@ TEST(net_build, program_execute_gather) {
 #ifdef CINN_WITH_CUDA
   Target target = common::DefaultNVGPUTarget();
 #else
-  Target target           = common::DefaultHostTarget();
+  Target target = common::DefaultHostTarget();
 #endif
   std::unordered_set<std::string> fetch_ids;
   auto graph = Optimize(&program, fetch_ids, target);
@@ -350,7 +350,7 @@ TEST(net_build, program_execute_gather) {
 
   VLOG(6) << "Visualize output_data";
   std::vector<float> input1_data = GetTensorData<float>(input1_tensor, target);
-  std::vector<int> input2_data = GetTensorData<int>(input2_tensor, target);
+  std::vector<int> input2_data   = GetTensorData<int>(input2_tensor, target);
   std::vector<float> output_data = GetTensorData<float>(output_tensor, target);
 
   VLOG(6) << "Visualize output_data";
@@ -411,7 +411,7 @@ TEST(net_build, program_execute_gather_nd) {
   EXPECT_EQ(output_shape[1], H_IN2);
 
   std::vector<float> input1_data = GetTensorData<float>(input1_tensor, target);
-  std::vector<int> input2_data = GetTensorData<int>(input2_tensor, target);
+  std::vector<int> input2_data   = GetTensorData<int>(input2_tensor, target);
   std::vector<float> output_data = GetTensorData<float>(output_tensor, target);
 
   VLOG(6) << "Visualize output_data";
@@ -419,7 +419,7 @@ TEST(net_build, program_execute_gather_nd) {
     for (int h = 0; h < H_IN2; ++h) {
       std::string line;
       for (int c = 0; c < H_IN1; ++c) {
-        float in_data  = input1_data[input2_data[b*H_IN2 + h] * H_IN1 + c];
+        float in_data  = input1_data[input2_data[b * H_IN2 + h] * H_IN1 + c];
         int out_index  = c + h * H_IN1 + H_IN1 * H_IN2 * b;
         float out_data = output_data[out_index];
         line += (std::to_string(out_data) + ", ");
@@ -662,7 +662,7 @@ TEST(net_build, program_execute_squeeze_case0) {
 
   runtime_program->Execute();
 
-  auto output_tensor = scope->GetTensor(std::string(output->id));
+  auto output_tensor                   = scope->GetTensor(std::string(output->id));
   const std::vector<int>& output_shape = output_tensor->shape().data();
   EXPECT_EQ(output_shape.size(), 3UL);
   EXPECT_EQ(output_shape[0], B);
@@ -1638,16 +1638,16 @@ TEST(net_build, program_execute_one_hot) {
   std::vector<int> input_data = GetTensorData<int>(input_tensor, target);
 
   auto on_value_tensor = scope->GetTensor(std::string(on_value_input.id()));
-  SetRandInt(on_value_tensor, target, -1, on_value, on_value+1);
+  SetRandInt(on_value_tensor, target, -1, on_value, on_value + 1);
 
   auto off_value_tensor = scope->GetTensor(std::string(off_value_input.id()));
-  SetRandInt(off_value_tensor, target, -1, off_value, off_value+1);
+  SetRandInt(off_value_tensor, target, -1, off_value, off_value + 1);
 
   runtime_program->Execute();
 
   auto output_tensor                   = scope->GetTensor(std::string(output->id));
   const std::vector<int>& output_shape = output_tensor->shape().data();
-  std::vector<int> output_data = GetTensorData<int>(output_tensor, target);
+  std::vector<int> output_data         = GetTensorData<int>(output_tensor, target);
 
   EXPECT_EQ(output_tensor->type(), Int(32));
   EXPECT_EQ(output_shape.size(), intput_shape.size() + 1);

--- a/cinn/utils/data_util.cc
+++ b/cinn/utils/data_util.cc
@@ -24,7 +24,7 @@ void SetRandInt(hlir::framework::Tensor tensor, const common::Target& target, in
     seed = rd();
   }
   std::default_random_engine engine(seed);
-  std::uniform_int_distribution<int> dist(low, high-1);
+  std::uniform_int_distribution<int> dist(low, high - 1);
   size_t num_ele = tensor->shape().numel();
   std::vector<int> random_data(num_ele);
   for (size_t i = 0; i < num_ele; i++) {
@@ -122,8 +122,7 @@ std::vector<int> GetTensorData<int>(const hlir::framework::Tensor& tensor, const
   std::vector<int> data(size);
 #ifdef CINN_WITH_CUDA
   if (target == common::DefaultNVGPUTarget()) {
-    cudaMemcpy(
-        data.data(), static_cast<const void*>(tensor->data<int>()), size * sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(data.data(), static_cast<const void*>(tensor->data<int>()), size * sizeof(int), cudaMemcpyDeviceToHost);
   } else if (target == common::DefaultHostTarget()) {
     std::copy(tensor->data<int>(), tensor->data<int>() + size, data.begin());
   } else {

--- a/cinn/utils/data_util.cc
+++ b/cinn/utils/data_util.cc
@@ -96,43 +96,26 @@ void SetRandData<float>(hlir::framework::Tensor tensor, const common::Target& ta
 #endif
 }
 
-template <>
-std::vector<float> GetTensorData<float>(const hlir::framework::Tensor& tensor, const common::Target& target) {
+template <typename T>
+std::vector<T> GetTensorData(const hlir::framework::Tensor& tensor, const common::Target& target) {
   auto size = tensor->shape().numel();
-  std::vector<float> data(size);
+  std::vector<T> data(size);
 #ifdef CINN_WITH_CUDA
   if (target == common::DefaultNVGPUTarget()) {
-    cudaMemcpy(
-        data.data(), static_cast<const void*>(tensor->data<float>()), size * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(data.data(), static_cast<const void*>(tensor->data<T>()), size * sizeof(T), cudaMemcpyDeviceToHost);
   } else if (target == common::DefaultHostTarget()) {
-    std::copy(tensor->data<float>(), tensor->data<float>() + size, data.begin());
+    std::copy(tensor->data<T>(), tensor->data<T>() + size, data.begin());
   } else {
     CINN_NOT_IMPLEMENTED
   }
 #else
   CHECK(target == common::DefaultHostTarget());
-  std::copy(tensor->data<float>(), tensor->data<float>() + size, data.begin());
+  std::copy(tensor->data<T>(), tensor->data<T>() + size, data.begin());
 #endif
   return data;
 }
 
-template <>
-std::vector<int> GetTensorData<int>(const hlir::framework::Tensor& tensor, const common::Target& target) {
-  auto size = tensor->shape().numel();
-  std::vector<int> data(size);
-#ifdef CINN_WITH_CUDA
-  if (target == common::DefaultNVGPUTarget()) {
-    cudaMemcpy(data.data(), static_cast<const void*>(tensor->data<int>()), size * sizeof(int), cudaMemcpyDeviceToHost);
-  } else if (target == common::DefaultHostTarget()) {
-    std::copy(tensor->data<int>(), tensor->data<int>() + size, data.begin());
-  } else {
-    CINN_NOT_IMPLEMENTED
-  }
-#else
-  CHECK(target == common::DefaultHostTarget());
-  std::copy(tensor->data<int>(), tensor->data<int>() + size, data.begin());
-#endif
-  return data;
-}
+template std::vector<float> GetTensorData<float>(const hlir::framework::Tensor& tensor, const common::Target& target);
+template std::vector<int> GetTensorData<int>(const hlir::framework::Tensor& tensor, const common::Target& target);
 
 }  // namespace cinn

--- a/cinn/utils/data_util.h
+++ b/cinn/utils/data_util.h
@@ -23,7 +23,7 @@
 #endif
 
 namespace cinn {
-void SetRandInt(hlir::framework::Tensor tensor, const common::Target& target, int seed = -1);
+void SetRandInt(hlir::framework::Tensor tensor, const common::Target& target, int seed = -1, int low=0, int high=11);
 
 template <typename T>
 void SetRandData(hlir::framework::Tensor tensor, const common::Target& target, int seed = -1);

--- a/cinn/utils/data_util.h
+++ b/cinn/utils/data_util.h
@@ -23,7 +23,8 @@
 #endif
 
 namespace cinn {
-void SetRandInt(hlir::framework::Tensor tensor, const common::Target& target, int seed = -1, int low=0, int high=11);
+void SetRandInt(
+    hlir::framework::Tensor tensor, const common::Target& target, int seed = -1, int low = 0, int high = 11);
 
 template <typename T>
 void SetRandData(hlir::framework::Tensor tensor, const common::Target& target, int seed = -1);

--- a/cinn/utils/data_util.h
+++ b/cinn/utils/data_util.h
@@ -23,6 +23,16 @@
 #endif
 
 namespace cinn {
+
+/**
+ * @brief  Fill an int Tensor with random data, which is going to be [low, high).
+ *
+ * @param tensor  A Tensor that needs to be filled with data has to be of type Int.
+ * @param target  The type of device that tensor need.
+ * @param seed    Random number seed. Default setting is -1.
+ * @param low     Set the lower bound of the data range, which is represented as [low, high).
+ * @param high    Set the upper bound of the data range, which is represented as [low, high).
+ */
 void SetRandInt(
     hlir::framework::Tensor tensor, const common::Target& target, int seed = -1, int low = 0, int high = 11);
 


### PR DESCRIPTION
清理单测过程中发现net_buidler_test中很多单测只测了host端，补充gpu端的测试，也对若干算子的测试进行修复。
另外三个实现有问题的算子将在后续PR进行修复再打开测试。

**补充gpu端的测试** ： 主要改动是使用data_util.h中的SetRandXXX()和GetTensorData()方法针对不同target填充和获取数据。

**另外还有2个算子测例的修改：**

1 clip的修改：
该测例名测试的是net builder的clip方法，故将builder.Clip()行代码反注释，并删除冗余代码。

2 gather和gather nd的修改
开始实现的gather、gather nd算子有问题，姜程在https://github.com/PaddlePaddle/CINN/pull/1136 中修改算子实现时，因为测例被注释掉，当时没有进行同步修改。
按照当前的gather、gather nd算子计算逻辑补充测例。