### PR TITLE
register grad_add mapper

### DIFF
--- a/cinn/frontend/op_mappers/paddle/elementwise.cc
+++ b/cinn/frontend/op_mappers/paddle/elementwise.cc
@@ -229,5 +229,7 @@ CINN_REGISTER_HELPER(paddle_elementwise) {
   CINN_REGISTER_OP_MAPPER(sum, SumOpMapper)
   CINN_REGISTER_OP_MAPPER(cast, CastOpMapper)
   CINN_REGISTER_OP_MAPPER(pow, PowOpMapper)
+  CINN_REGISTER_OP_MAPPER(grad_add,
+                          ElementwiseOpMapper<EltwiseType::kAdd>)  // special elementwise_add for gradient accumulation
   return true;
 }


### PR DESCRIPTION
ATT

grad_add is an alias of elementwise_add op, register it so cinn can fuse it with others

<img width="835" alt="n pa SD copen So pan Mic 0ml" src="https://user-images.githubusercontent.com/6888866/224309830-e44aefe6-3946-4f6e-9cbe-fc566d4a5a5a.png">
