### PR TITLE
Update AutoBind const variable name and fix feature_extractor null

### DIFF
--- a/cinn/auto_schedule/cost_model/feature_extractor.cc
+++ b/cinn/auto_schedule/cost_model/feature_extractor.cc
@@ -59,7 +59,9 @@ Feature FeatureExtractor::Extract(const ir::ModuleExpr &mod_expr, const common::
   void FeatureExtractor::Visit(const NodeType *x) {         \
     std::vector<const Expr *> sub_exprs = x->expr_fields(); \
     for (const Expr *e : sub_exprs) {                       \
-      Visit(e);                                             \
+      if (e->defined()) {                                   \
+        Visit(e);                                           \
+      }                                                     \
     }                                                       \
   }
 
@@ -92,7 +94,9 @@ NotVisitExprFields(_Tensor_)
     }                                                                                             \
     std::vector<const Expr *> sub_exprs = x->expr_fields();                                       \
     for (const Expr *e : sub_exprs) {                                                             \
-      Visit(e);                                                                                   \
+      if (e->defined()) {                                                                         \
+        Visit(e);                                                                                 \
+      }                                                                                           \
     }                                                                                             \
   }
 
@@ -123,7 +127,9 @@ VisitForDtypePattern(Let, other_call);
     }                                                                                             \
     std::vector<const Expr *> sub_exprs = x->expr_fields();                                       \
     for (const Expr *e : sub_exprs) {                                                             \
-      Visit(e);                                                                                   \
+      if (e->defined()) {                                                                         \
+        Visit(e);                                                                                 \
+      }                                                                                           \
     }                                                                                             \
   }
 
@@ -135,7 +141,9 @@ VisitForMultiOperandsDtypePattern(Product, mul);
     feature_.CurrentLoopBlock().member += 1;                \
     std::vector<const Expr *> sub_exprs = x->expr_fields(); \
     for (const Expr *e : sub_exprs) {                       \
-      Visit(e);                                             \
+      if (e->defined()) {                                   \
+        Visit(e);                                           \
+      }                                                     \
     }                                                       \
   }
 


### PR DESCRIPTION
1. FeatureExtractor visitor中遍历时没有对AST中Expr的未定义fields进行判空处理，导致基类IRVisitorBase访问时`CHECK(expr->defined());`报错，比如`IfThenElse`节点的false_case可能为空。

2. AutoBind规则中将最大blocks和每个block最大thread数的常量名分别修改为`kMaxBlocks `和`kMaxThreadsPerBlock`

**遗留TODO：**
1. 将AutoBind整合到SearchSpace的sketch生成流程中：尝试添加发现会导致MultiLevelTiling规则运行报错，排查发现是因为目前`InitSketchWithRandomPrunedStrategy`生成方式中规则的apply顺序可能与注册顺序不一致，若是先运行AutoBind再MultiLevelTiling，则会导致报错。待后续升级统一sketch流程为`InitSketchWithRulePrunedStrategy`后，保证规则apply顺序与注册顺序一致，再添加AutoBind

2. AutoBind在确定thread factor时需要插入SampleCategorical语句以便后续mutate：该原语尚未实现，外部开发者正在开发中，正在尝试推进合入