### PR TITLE
fix(op): fix compute and schedule func of argmax and argmin

### DIFF
--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -1196,7 +1196,6 @@ TEST(net_build, program_execute_flip) {
   }
 }
 
-/*
 TEST(net_build, program_argmax_case1) {
   const int N     = 4;
   const int IN_C  = 3;
@@ -1209,7 +1208,11 @@ TEST(net_build, program_argmax_case1) {
   Variable output   = builder.Argmax(input, 1, true);
   auto program      = builder.Build();
 
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
   Target target = common::DefaultHostTarget();
+#endif
   std::unordered_set<std::string> fetch_ids;
   auto graph = Optimize(&program, fetch_ids, target);
 
@@ -1222,7 +1225,7 @@ TEST(net_build, program_argmax_case1) {
 
   auto input_tensor = scope->GetTensor(std::string(input.id()));
   SetRandData<float>(input_tensor, target);
-  float* input_data = input_tensor->mutable_data<float>(target);
+  std::vector<float> input_data = GetTensorData<float>(input_tensor, target);
   VLOG(6) << "Visualize input_data";
   for (int n = 0; n < N; ++n) {
     for (int c = 0; c < IN_C; ++c) {
@@ -1247,7 +1250,7 @@ TEST(net_build, program_argmax_case1) {
   EXPECT_EQ(output_shape[2], H);
   EXPECT_EQ(output_shape[3], W);
 
-  int* output_data = output_tensor->mutable_data<int>(target);
+  std::vector<int> output_data = GetTensorData<int>(output_tensor, target);
   VLOG(6) << "Visualize output_data";
   for (int n = 0; n < N; ++n) {
     for (int c = 0; c < IN_C; ++c) {
@@ -1356,8 +1359,12 @@ TEST(net_build, program_argmin_case1) {
   Placeholder input = builder.CreateInput(Float(32), {N, IN_C, H, W}, "In");
   Variable output   = builder.Argmin(input, 1, true);
   auto program      = builder.Build();
-
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
   Target target = common::DefaultHostTarget();
+#endif
+
   std::unordered_set<std::string> fetch_ids;
   auto graph = Optimize(&program, fetch_ids, target);
 
@@ -1370,7 +1377,7 @@ TEST(net_build, program_argmin_case1) {
 
   auto input_tensor = scope->GetTensor(std::string(input.id()));
   SetRandData<float>(input_tensor, target);
-  float* input_data = input_tensor->mutable_data<float>(target);
+  std::vector<float> input_data = GetTensorData<float>(input_tensor, target);
   VLOG(6) << "Visualize input_data";
   for (int n = 0; n < N; ++n) {
     for (int c = 0; c < IN_C; ++c) {
@@ -1395,7 +1402,7 @@ TEST(net_build, program_argmin_case1) {
   EXPECT_EQ(output_shape[2], H);
   EXPECT_EQ(output_shape[3], W);
 
-  int* output_data = output_tensor->mutable_data<int>(target);
+  std::vector<int> output_data = GetTensorData<int>(output_tensor, target);
   VLOG(6) << "Visualize output_data";
   for (int n = 0; n < N; ++n) {
     for (int c = 0; c < IN_C; ++c) {
@@ -1430,8 +1437,11 @@ TEST(net_build, program_argmin_case2) {
   Placeholder input = builder.CreateInput(Float(32), {N, IN_C, H, W}, "In");
   Variable output   = builder.Argmin(input, 1, false);
   auto program      = builder.Build();
-
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
   Target target = common::DefaultHostTarget();
+#endif
   std::unordered_set<std::string> fetch_ids;
   auto graph = Optimize(&program, fetch_ids, target);
 
@@ -1444,7 +1454,7 @@ TEST(net_build, program_argmin_case2) {
 
   auto input_tensor = scope->GetTensor(std::string(input.id()));
   SetRandData<float>(input_tensor, target);
-  float* input_data = input_tensor->mutable_data<float>(target);
+  std::vector<float> input_data = GetTensorData<float>(input_tensor, target);
   VLOG(6) << "Visualize input_data";
   for (int n = 0; n < N; ++n) {
     for (int c = 0; c < IN_C; ++c) {
@@ -1468,7 +1478,7 @@ TEST(net_build, program_argmin_case2) {
   EXPECT_EQ(output_shape[1], H);
   EXPECT_EQ(output_shape[2], W);
 
-  int* output_data = output_tensor->mutable_data<int>(target);
+  std::vector<int> output_data = GetTensorData<int>(output_tensor, target);
   VLOG(6) << "Visualize output_data";
   for (int n = 0; n < N; ++n) {
     for (int c = 0; c < IN_C; ++c) {
@@ -1492,7 +1502,6 @@ TEST(net_build, program_argmin_case2) {
     }
   }
 }
-*/
 
 TEST(net_build, program_execute_repeat_axis_0) {
   const int M       = 4;

--- a/cinn/hlir/op/contrib/argmax.cc
+++ b/cinn/hlir/op/contrib/argmax.cc
@@ -45,12 +45,12 @@ using common::CINNValue;
 using framework::shape_t;
 using ir::Tensor;
 
-Tensor Argmax(const Tensor &in_tensor,
-              const common::Target &target,
-              poly::StageMap stages,
-              const int &axis,
-              const bool &keep_dims,
-              const std::string &name) {
+std::vector<ir::Tensor> Argmax(const Tensor &in_tensor,
+                               const common::Target &target,
+                               poly::StageMap stages,
+                               const int &axis,
+                               const bool &keep_dims,
+                               const std::string &name) {
   auto shape = in_tensor->shape;
   auto ndim  = shape.size();
   CHECK_GT(ndim, 0) << "tensor's dim must be more than 0";
@@ -77,7 +77,7 @@ Tensor Argmax(const Tensor &in_tensor,
     output_shape.push_back(Expr(1));
   }
 
-  auto sort_index = ArgSort(in_tensor, target, stages, pos_axis, false, name + "_index").at(0);
+  auto sort_index = ArgSort(in_tensor, target, stages, pos_axis, false, name + "_index");
   auto res        = Compute(
       output_shape,
       [=](const std::vector<Expr> &indices) {
@@ -87,11 +87,11 @@ Tensor Argmax(const Tensor &in_tensor,
         } else {
           eval_indices[pos_axis] = Expr(0);
         }
-        return sort_index(eval_indices);
+        return sort_index.at(0)(eval_indices);
       },
       name);
-  stages->InsertLazily(sort_index);
-  return res;
+  stages->InsertLazily(sort_index.at(0));
+  return {res, sort_index.at(0), sort_index.at(1)};
 }
 
 std::shared_ptr<framework::OpStrategy> StrategyForArgmax(const framework::NodeAttr &attrs,
@@ -125,10 +125,11 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmax(const framework::NodeAt
       CHECK(pack_args[1].is_string());
       tensor_name = pack_args[1].operator std::string();
     }
-    auto out_tensor = Argmax(in_tensor, target, stages, axis, keep_dims, tensor_name);
+    std::vector<ir::Tensor> out_tensor = Argmax(in_tensor, target, stages, axis, keep_dims, tensor_name);
 
-    stages->InsertLazily(out_tensor);
-    std::vector<CINNValue> cinn_values{CINNValue(out_tensor), CINNValue(stages)};
+    stages->InsertLazily(out_tensor[0]);
+    std::vector<CINNValue> cinn_values{
+        CINNValue(out_tensor[0]), CINNValue(out_tensor[1]), CINNValue(out_tensor[2]), CINNValue(stages)};
     *ret = common::CINNValuePack{cinn_values};
   });
 
@@ -147,13 +148,15 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmax(const framework::NodeAt
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
       ir_sch.MergeExprs();
+      auto blocks = ir_sch.GetAllBlocks();
+      // TODO: It needs to be rewritten according to the reduction_max operator to improve performance.
+      // Do not use local variables, because the size will exceed the limit.
+      ir_sch.SetBuffer(blocks[0], "local");
+      ir_sch.SetBuffer(blocks[1], "local");
+
       long prod_size = std::accumulate(output_shapes[0].begin(), output_shapes[0].end(), 1, std::multiplies<int>());
-      if (prod_size > 1) {
-        if (target.arch == Target::Arch::NVGPU) {
-          pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
-        } else if (target.arch == Target::Arch::X86) {
-          pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, true);
-        }
+      if (prod_size > 1 && target.arch == Target::Arch::X86) {
+        pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, true);
       }
       std::vector<common::CINNValue> res{common::CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = common::CINNValuePack{res};
@@ -167,7 +170,7 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmax(const framework::NodeAt
   });
 
   auto strategy = std::make_shared<framework::OpStrategy>();
-  strategy->AddImpl(argmax_compute, argmax_schedule, "strategy.argmax.x86", 1);
+  strategy->AddImpl(argmax_compute, argmax_schedule, "strategy.argmax", 1);
 
   return strategy;
 }
@@ -239,6 +242,7 @@ CINN_REGISTER_HELPER(argmax_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForArgmax)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForArgmax))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForArgmax))
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
       .set_support_level(4);
 
   return true;

--- a/cinn/hlir/op/contrib/argmax.h
+++ b/cinn/hlir/op/contrib/argmax.h
@@ -21,12 +21,12 @@
 namespace cinn {
 namespace hlir {
 namespace op {
-ir::Tensor Argmax(const ir::Tensor &in_tensor,
-                  const common::Target &target,
-                  poly::StageMap stages,
-                  const int &axis,
-                  const bool &keep_dims   = false,
-                  const std::string &name = "T_Argmax_out");
+std::vector<ir::Tensor> Argmax(const ir::Tensor &in_tensor,
+                               const common::Target &target,
+                               poly::StageMap stages,
+                               const int &axis,
+                               const bool &keep_dims   = false,
+                               const std::string &name = "T_Argmax_out");
 }  // namespace op
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/op/contrib/argmax_test.cc
+++ b/cinn/hlir/op/contrib/argmax_test.cc
@@ -27,6 +27,7 @@
 #include "cinn/lang/lower.h"
 #include "cinn/lang/placeholder.h"
 #include "cinn/poly/stage.h"
+#include "cinn/utils/string.h"
 
 namespace cinn {
 namespace hlir {
@@ -46,7 +47,7 @@ TEST(GenerateCode_Cpu, Argmax_Keep) {
 
   lang::Placeholder<float> in("in", {n, in_c, h, w});
   poly::StageMap stages = poly::CreateStages({in});
-  ir::Tensor res        = Argmax(in, target, stages, axis, true, "test_argmax_in");
+  ir::Tensor res        = Argmax(in, target, stages, axis, true, "test_argmax_in").at(0);
   stages->InsertLazily(res);
 
   std::vector<ir::LoweredFunc> funcs =

--- a/cinn/hlir/op/contrib/argmin.cc
+++ b/cinn/hlir/op/contrib/argmin.cc
@@ -45,12 +45,12 @@ using common::CINNValue;
 using framework::shape_t;
 using ir::Tensor;
 
-Tensor Argmin(const Tensor &in_tensor,
-              const common::Target &target,
-              poly::StageMap stages,
-              const int &axis,
-              const bool &keep_dims,
-              const std::string &name) {
+std::vector<Tensor> Argmin(const Tensor &in_tensor,
+                           const common::Target &target,
+                           poly::StageMap stages,
+                           const int &axis,
+                           const bool &keep_dims,
+                           const std::string &name) {
   auto shape = in_tensor->shape;
   auto ndim  = shape.size();
   CHECK_GT(ndim, 0) << "tensor's dim must be more than 0";
@@ -76,7 +76,7 @@ Tensor Argmin(const Tensor &in_tensor,
   if (output_shape.empty()) {
     output_shape.push_back(Expr(1));
   }
-  auto sort_index = ArgSort(in_tensor, target, stages, pos_axis, true, name + "_index").at(0);
+  auto sort_index = ArgSort(in_tensor, target, stages, pos_axis, true, name + "_index");
   auto res        = Compute(
       output_shape,
       [=](const std::vector<Expr> &indices) {
@@ -86,11 +86,11 @@ Tensor Argmin(const Tensor &in_tensor,
         } else {
           eval_indices[pos_axis] = Expr(0);
         }
-        return sort_index(eval_indices);
+        return sort_index.at(0)(eval_indices);
       },
       name);
-  stages->InsertLazily(sort_index);
-  return res;
+  stages->InsertLazily(sort_index.at(0));
+  return {res, sort_index.at(0), sort_index.at(1)};
 }
 
 std::shared_ptr<framework::OpStrategy> StrategyForArgmin(const framework::NodeAttr &attrs,
@@ -126,8 +126,9 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmin(const framework::NodeAt
     }
     auto out_tensor = Argmin(in_tensor, target, stages, axis, keep_dims, tensor_name);
 
-    stages->InsertLazily(out_tensor);
-    std::vector<CINNValue> cinn_values{CINNValue(out_tensor), CINNValue(stages)};
+    stages->InsertLazily(out_tensor[0]);
+    std::vector<CINNValue> cinn_values{
+        CINNValue(out_tensor[0]), CINNValue(out_tensor[1]), CINNValue(out_tensor[2]), CINNValue(stages)};
     *ret = common::CINNValuePack{cinn_values};
   });
 
@@ -146,13 +147,14 @@ std::shared_ptr<framework::OpStrategy> StrategyForArgmin(const framework::NodeAt
       ir::ModuleExpr mod_expr(vec_ast);
       ir::IRSchedule ir_sch(mod_expr);
       ir_sch.MergeExprs();
+      auto blocks = ir_sch.GetAllBlocks();
+      // TODO: It needs to be rewritten according to the reduction_min operator to improve performance.
+      // Do not use local variables, because the size will exceed the limit.
+      ir_sch.SetBuffer(blocks[0], "local");
+      ir_sch.SetBuffer(blocks[1], "local");
       long prod_size = std::accumulate(output_shapes[0].begin(), output_shapes[0].end(), 1, std::multiplies<int>());
-      if (prod_size > 1) {
-        if (target.arch == Target::Arch::NVGPU) {
-          pe::IRCudaScheduleInjective(ir_sch, output_shapes.front(), target);
-        } else if (target.arch == Target::Arch::X86) {
-          pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, true);
-        }
+      if (prod_size > 1 && target.arch == Target::Arch::X86) {
+        pe::IRScheduleInjectiveCPU(ir_sch, output_shapes.front(), target, true);
       }
       std::vector<common::CINNValue> res{common::CINNValue(ir_sch.GetModule().GetExprs().at(0))};
       *ret = common::CINNValuePack{res};
@@ -239,6 +241,7 @@ CINN_REGISTER_HELPER(argmin_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForArgmin)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForArgmin))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForArgmin))
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
       .set_support_level(4);
 
   return true;

--- a/cinn/hlir/op/contrib/argmin.h
+++ b/cinn/hlir/op/contrib/argmin.h
@@ -21,12 +21,12 @@
 namespace cinn {
 namespace hlir {
 namespace op {
-ir::Tensor Argmin(const ir::Tensor& in_tensor,
-                  const common::Target& target,
-                  poly::StageMap stages,
-                  const int& axis,
-                  const bool& keep_dims   = false,
-                  const std::string& name = "T_Argmin_out");
+std::vector<ir::Tensor> Argmin(const ir::Tensor& in_tensor,
+                               const common::Target& target,
+                               poly::StageMap stages,
+                               const int& axis,
+                               const bool& keep_dims   = false,
+                               const std::string& name = "T_Argmin_out");
 }  // namespace op
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/op/contrib/argmin_test.cc
+++ b/cinn/hlir/op/contrib/argmin_test.cc
@@ -46,7 +46,7 @@ TEST(GenerateCode_Cpu, Argmin_Keep) {
 
   lang::Placeholder<float> in("in", {n, in_c, h, w});
   poly::StageMap stages = poly::CreateStages({in});
-  ir::Tensor res        = Argmin(in, target, stages, axis, true, "test_argmin_in");
+  ir::Tensor res        = Argmin(in, target, stages, axis, true, "test_argmin_in").at(0);
   stages->InsertLazily(res);
 
   std::vector<ir::LoweredFunc> funcs =


### PR DESCRIPTION
The current compute and schedule of argmax and argmin operators cannot be codegen on the gpu。

The PR reference to  #1198 first. Use local variables to make sure the unit tests run.

The compute and schedule of these operators are rewritten in other PR according to the logic of reduction, because
1. The local variables have capacity limitations
2. The reduction mode will improve the performance.