### PR TITLE
fix the dropout infer operator

### DIFF
--- a/cinn/hlir/op/nn.cc
+++ b/cinn/hlir/op/nn.cc
@@ -2422,7 +2422,7 @@ CINN_REGISTER_HELPER(nn_ops) {
 #ifndef CINN_WITH_CUDA
       .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForUnary))
 #endif
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible)
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective)
       .set_support_level(4);
 
   CINN_REGISTER_OP(select)

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -1259,7 +1259,8 @@ Tensor DropoutInfer(const ir::Tensor &tensor,
         [=](const std::vector<Expr> &indice) { return tensor(indice) * (1 - dropout_prob); },
         output_name);
   } else if (dropout_implementation == "upscale_in_train") {
-    return Identity(tensor).front();
+    // The name here must be consistent, otherwise it cannot participate in the fusion schedule.
+    return Identity(tensor, output_name).front();
   } else {
     LOG(FATAL) << "dropout_implementation attr must be 'downgrade_in_infer' or 'upscale_in_train'\n";
   }


### PR DESCRIPTION
modify the naming bug and compute type of `dropout_infer` so that it can be fused automatically