### PR TITLE
change OpPatternKind of lookup_table to kInjective

### DIFF
--- a/cinn/hlir/op/contrib/lookup_table.cc
+++ b/cinn/hlir/op/contrib/lookup_table.cc
@@ -143,6 +143,6 @@ CINN_REGISTER_HELPER(lookup_table_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForLookupTable)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForLookupTable))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForLookupTable))
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOutFusible);
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kInjective);
   return true;
 }

--- a/cinn/hlir/op/contrib/lookup_table.cc
+++ b/cinn/hlir/op/contrib/lookup_table.cc
@@ -143,6 +143,6 @@ CINN_REGISTER_HELPER(lookup_table_ops) {
       .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForLookupTable)
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForLookupTable))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForLookupTable))
-      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kNonFusible);
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kOutFusible);
   return true;
 }


### PR DESCRIPTION
The lookuptable can't fused with elemetwise_add because that its OpPatternKind is kNonFusible.
So I change OpPatternKind of lookup_table from kNonFusible to kInjective.
