### PR TITLE
fix type of lookup_table padding_idx attribute not matched

### DIFF
--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -502,7 +502,7 @@ Variable NetBuilder::Argmin(const Variable& x, const int& axis, const bool& keep
 }
 
 Variable NetBuilder::LookupTable(const Variable& table, const Variable& ids, int64_t padding_idx) {
-  return CustomInstr("lookup_table", {table, ids}, {{"padding_idx", static_cast<int>(padding_idx)}}).front();
+  return CustomInstr("lookup_table", {table, ids}, {{"padding_idx", padding_idx}}).front();
 }
 
 Variable NetBuilder::Conv2d(const Variable& a,

--- a/cinn/hlir/op/contrib/lookup_table.cc
+++ b/cinn/hlir/op/contrib/lookup_table.cc
@@ -81,7 +81,7 @@ std::shared_ptr<framework::OpStrategy> StrategyForLookupTable(const framework::N
   std::string op_name("lookup_table");
   const auto& attr_store = attrs.attr_store;
   CHECK(attr_store.count("padding_idx")) << "find no attr of axis";
-  auto padding_idx = absl::get<int32_t>(attr_store.at("padding_idx"));
+  auto padding_idx = absl::get<int64_t>(attr_store.at("padding_idx"));
 
   framework::CINNCompute lookup_table_compute([=](lang::Args args, lang::RetValue* ret) {
     CHECK(!args.empty()) << "The input arguments of " << op_name << " compute is empty! Please check.\n";


### PR DESCRIPTION
lookup_table算子NetBuilder api中将`padding_idx`属性由int64_t类型cast为int32_t，而算子注册定义中实际使用仍为int64_t，因此将两处统一为int64_t

 