### PR TITLE
fix op_mapper test cannot accept empty list bug

### DIFF
--- a/python/tests/op_mappers/test_squeeze_op.py
+++ b/python/tests/op_mappers/test_squeeze_op.py
@@ -49,5 +49,10 @@ class TestSqueezeOp(OpMapperTest):
         self.check_outputs_and_grads()
 
 
+class TestSqueezeAxesEmpty(TestSqueezeOp):
+    def set_op_attrs(self):
+        return {"axes": []}
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As title. OpMapper python单测重构后，属性值传入空的list会报错，经排查发现问题在于python端空的list在cpp端实际是`vector<bool>`类型。适配并添加了警告显示。