### PR TITLE
fix pool2d not set deterministic algorithm bug

### DIFF
--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -868,7 +868,7 @@ void cinn_call_cudnn_pool2d_forward(void *v_args,
   cudnnDataType_t data_type         = convert_to_cudnn_dtype(v_args, num_args);
 
   if (GetCinnCudnnDeterministic() && pool_mode == CUDNN_POOLING_MAX) {
-    algo = CUDNN_POOLING_MAX_DETERMINISTIC;
+    pool_mode = CUDNN_POOLING_MAX_DETERMINISTIC;
   }
 
   std::string hash_key =
@@ -938,7 +938,7 @@ void cinn_call_cudnn_pool2d_backward(void *v_args,
   cudnnDataType_t data_type         = convert_to_cudnn_dtype(v_args, num_args);
 
   if (GetCinnCudnnDeterministic() && pool_mode == CUDNN_POOLING_MAX) {
-    algo = CUDNN_POOLING_MAX_DETERMINISTIC;
+    pool_mode = CUDNN_POOLING_MAX_DETERMINISTIC;
   }
 
   std::string hash_key =

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -510,6 +510,8 @@ std::string debug_cudnn_pool_mode(cudnnPoolingMode_t pool_mode) {
   switch (pool_mode) {
     case CUDNN_POOLING_MAX:
       return "max";
+    case CUDNN_POOLING_MAX_DETERMINISTIC:
+      return "max_deterministic";
     case CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING:
       return "avg";
     default:
@@ -865,6 +867,10 @@ void cinn_call_cudnn_pool2d_forward(void *v_args,
   cudnnTensorFormat_t tensor_format = static_cast<cudnnTensorFormat_t>(format);
   cudnnDataType_t data_type         = convert_to_cudnn_dtype(v_args, num_args);
 
+  if (GetCinnCudnnDeterministic() && pool_mode == CUDNN_POOLING_MAX) {
+    algo = CUDNN_POOLING_MAX_DETERMINISTIC;
+  }
+
   std::string hash_key =
       "pool2d forward, layout=" + debug_cudnn_tensor_format(tensor_format) +
       ", pool_type=" + debug_cudnn_pool_mode(pool_mode) + ", dtype=" + debug_cudnn_tensor_dtype(data_type) +
@@ -930,6 +936,10 @@ void cinn_call_cudnn_pool2d_backward(void *v_args,
   cudnnPoolingMode_t pool_mode      = static_cast<cudnnPoolingMode_t>(mode);
   cudnnTensorFormat_t tensor_format = static_cast<cudnnTensorFormat_t>(format);
   cudnnDataType_t data_type         = convert_to_cudnn_dtype(v_args, num_args);
+
+  if (GetCinnCudnnDeterministic() && pool_mode == CUDNN_POOLING_MAX) {
+    algo = CUDNN_POOLING_MAX_DETERMINISTIC;
+  }
 
   std::string hash_key =
       "pool2d backward, layout=" + debug_cudnn_tensor_format(tensor_format) +


### PR DESCRIPTION
As title. 原`pool2d`没有采用`deterministic`算法，导致每次跑的结果不一致，本PR修复了改问题，当`FLAGS_cinn_cudnn_deterministic=1`设置了时，采用`CUDNN_POOLING_MAX_DETERMINISTIC`而非`CUDNN_POOLING_MAX`算法。