### PR TITLE
replace MatmulOpBuilder to test::OpBuilder

### DIFF
--- a/cinn/auto_schedule/search_strategy/CMakeLists.txt
+++ b/cinn/auto_schedule/search_strategy/CMakeLists.txt
@@ -4,4 +4,4 @@ core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS evolutionary_search.cc)
 
-cc_test(test_evolutionary_search SRCS evolutionary_search_test.cc DEPS cinncore)
+cc_test(test_evolutionary_search SRCS evolutionary_search_test.cc DEPS cinncore test_program_builder)

--- a/cinn/auto_schedule/search_strategy/evolutionary_search_test.cc
+++ b/cinn/auto_schedule/search_strategy/evolutionary_search_test.cc
@@ -30,6 +30,7 @@
 #include "cinn/auto_schedule/tuning.h"
 #include "cinn/ir/ir_base.h"
 #include "cinn/ir/ir_schedule.h"
+#include "tests/program_builder.h"
 
 namespace cinn {
 namespace auto_schedule {
@@ -142,7 +143,7 @@ TEST(EvolutionarySearch, GetEpsGreedy) {
 
 TEST(EvolutionarySearch, Evolve) {
   auto target = common::DefaultNVGPUTarget();
-  auto tasks  = CreateTasks(MatmulOpBuilder({32, 32}, {32, 32})(), target);
+  auto tasks  = CreateTasks(tests::OpBuilder("matmul").Build({{"X", {32, 32}}, {"Y", {32, 32}}}), target);
   CHECK_EQ(tasks.size(), 1);
   ExprCostModel cost_model;
   std::vector<const ir::ModuleExpr*> cost_model_samples(1);

--- a/cinn/auto_schedule/search_strategy/evolutionary_search_test.cc
+++ b/cinn/auto_schedule/search_strategy/evolutionary_search_test.cc
@@ -26,7 +26,6 @@
 #include "cinn/auto_schedule/task/task_creator.h"
 #include "cinn/auto_schedule/task/task_registry.h"
 #include "cinn/auto_schedule/task/tune_task.h"
-#include "cinn/auto_schedule/tests/test_op_builder.h"
 #include "cinn/auto_schedule/tuning.h"
 #include "cinn/ir/ir_base.h"
 #include "cinn/ir/ir_schedule.h"

--- a/cinn/auto_schedule/search_strategy/mutate_rule/mutate_rule.cc
+++ b/cinn/auto_schedule/search_strategy/mutate_rule/mutate_rule.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
 #include "cinn/auto_schedule/search_strategy/mutate_rule/mutate_rule.h"
 
 #include "cinn/auto_schedule/search_strategy/mutate_rule/mutate_tile_size.h"


### PR DESCRIPTION
修复删除auto_schedule/tests/test_op_builder.h导致的ci编译报错