### PR TITLE
Add op mapper floordiv and fix remainder

### DIFF
--- a/cinn/frontend/op_mappers/paddle/elementwise.cc
+++ b/cinn/frontend/op_mappers/paddle/elementwise.cc
@@ -211,6 +211,27 @@ void PowOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx)
   ctx.AddVarModelToProgram(out_name, out->id);
 }
 
+void FloorDivideOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx) {
+  CHECK_EQ(op_desc.Input("X").size(), 1UL);
+  auto x_name = op_desc.Input("X").front();
+  CHECK_EQ(op_desc.Input("Y").size(), 1UL);
+  auto y_name = op_desc.Input("Y").front();
+  CHECK_EQ(op_desc.Output("Out").size(), 1UL);
+  auto out_name = op_desc.Output("Out").front();
+
+  auto x = ctx.GetVar(x_name);
+  auto y = ctx.GetVar(y_name);
+
+  VLOG(4) << out_name << " = ⌊ " << x_name << " / " << y_name << " ⌋";
+  CHECK_EQ(x->type, y->type) << "Type of input x and y must be the same.";
+  CHECK(x->type.is_int()) << "Type of inputs must be int32 or int64.";
+
+  auto out = ctx.Builder()->FloorDivide(x, y);
+
+  ctx.AddVar(out_name, out);
+  ctx.AddVarModelToProgram(out_name, out->id);
+}
+
 }  // namespace paddle_mappers
 }  // namespace frontend
 }  // namespace cinn
@@ -232,5 +253,6 @@ CINN_REGISTER_HELPER(paddle_elementwise) {
   CINN_REGISTER_OP_MAPPER(pow, PowOpMapper)
   CINN_REGISTER_OP_MAPPER(grad_add,
                           ElementwiseOpMapper<EltwiseType::kAdd>)  // special elementwise_add for gradient accumulation
+  CINN_REGISTER_OP_MAPPER(elementwise_floordiv, FloorDivideOpMapper)
   return true;
 }

--- a/cinn/lang/builtin.cc
+++ b/cinn/lang/builtin.cc
@@ -93,7 +93,7 @@ EXTERN_CALL_IMP(Popc, popc);
     return ir::Call::Make(a->type(), #target__, {a, b}, {}, ir::CallType::Extern);              \
   }
 
-EXTERN_BINARY_CALL_IMP(Remainder, remainder)
+EXTERN_BINARY_CALL_IMP(Remainder, mod)
 EXTERN_BINARY_CALL_IMP(LogicalRightShift, logical_right_shift)
 EXTERN_BINARY_CALL_IMP(Pow, pow)
 EXTERN_BINARY_CALL_IMP(Mod, mod)

--- a/cinn/runtime/cpu/host_intrinsics.cc
+++ b/cinn/runtime/cpu/host_intrinsics.cc
@@ -180,7 +180,6 @@ CINN_REGISTER_HELPER(host_intrinsics) {
 #define REGISTER_EXTERN_FUNC_2_IN_1_F(func__) REGISTER_EXTERN_FUNC_2_IN_1_OUT(func__, host_target, float, float, float);
 
   REGISTER_EXTERN_FUNC_2_IN_1_F(powf)
-  REGISTER_EXTERN_FUNC_2_IN_1_F(remainderf)
 
 #undef REGISTER_EXTERN_FUNC_2_IN_1_F
 

--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -41,7 +41,6 @@ __device__ inline bool FN_FP32(isnan)(float x) { return isnan(x); }
 
 __device__ inline float FN_FP32(pow)(float a, float b) { return powf(a, b); }
 
-__device__ inline float FN_FP32(remainder)(float a, float b) { return remainderf(a, b); }
 __device__ inline float FN_FP32(mod)(float a, float b) {
   float res = fmodf(a, b);
   if ((res != 0.0f) && ((res < 0.0f) != (b < 0.0f))) res += b;
@@ -86,7 +85,6 @@ __device__ inline bool FN_FP64(isinf)(double x) { return isinf(x); }
 __device__ inline bool FN_FP64(isnan)(double x) { return isnan(x); }
 
 __device__ inline double FN_FP64(pow)(double a, double b) { return pow(a, b); }
-__device__ inline double FN_FP64(remainder)(double a, double b) { return remainder(a, b); }
 __device__ inline double FN_FP64(mod)(double a, double b) {
   double res = fmod(a, b);
   if ((res != 0.0) && ((res < 0.0) != (b < 0.0))) res += b;
@@ -187,9 +185,6 @@ __device__ inline float16 FN_FP16(atanh)(float16 x) { return float16(FN_FP32(ata
 
 __device__ inline float16 FN_FP16(sigmoid)(float16 x) { return float16(FN_FP32(sigmoid)(static_cast<float>(x))); }
 
-__device__ inline float16 FN_FP16(remainder)(float16 a, float16 b) {
-  return float16(FN_FP32(remainder)(static_cast<float>(a), static_cast<float>(b)));
-}
 __device__ inline float16 FN_FP16(mod)(float16 a, float16 b) {
   return float16(FN_FP32(mod)(static_cast<float>(a), static_cast<float>(b)));
 }

--- a/cinn/runtime/cuda/cuda_instrinsics_float16.cc
+++ b/cinn/runtime/cuda/cuda_instrinsics_float16.cc
@@ -31,7 +31,6 @@ CINN_REGISTER_HELPER(cuda_intrinsics_float16) {
   REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(cinn_nvgpu_##func__##_fp16, target, float16, float16, float16);
 
   REGISTER_EXTERN_FUNC_2_IN_1_FP16(pow)
-  REGISTER_EXTERN_FUNC_2_IN_1_FP16(remainder)
   REGISTER_EXTERN_FUNC_2_IN_1_FP16(mod)
 
 #undef REGISTER_EXTERN_FUNC_2_IN_1_FP16

--- a/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -72,7 +72,6 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
   REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(cinn_nvgpu_##func__##_fp32, target, float, float, float);
 
   REGISTER_EXTERN_FUNC_2_IN_1_FLOAT(pow)
-  REGISTER_EXTERN_FUNC_2_IN_1_FLOAT(remainder)
   REGISTER_EXTERN_FUNC_2_IN_1_FLOAT(mod)
 
 #undef REGISTER_EXTERN_FUNC_2_IN_1_FLOAT
@@ -124,7 +123,6 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
   REGISTER_EXTERN_SOURCE_FUNC_2_IN_1_OUT(cinn_nvgpu_##func__##_fp64, target, double, double, double);
 
   REGISTER_EXTERN_FUNC_2_IN_1_FP64(pow)
-  REGISTER_EXTERN_FUNC_2_IN_1_FP64(remainder)
   REGISTER_EXTERN_FUNC_2_IN_1_FP64(mod)
 
 #undef REGISTER_EXTERN_FUNC_2_IN_1_FP64

--- a/python/tests/op_mappers/test_elementwise_op.py
+++ b/python/tests/op_mappers/test_elementwise_op.py
@@ -91,5 +91,27 @@ class TestMinOp(TestElementwiseOp):
         return "elementwise_min"
 
 
+class TestFloorDivOpCase1(TestElementwiseOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32, 64], low=1, high=10, dtype='int32'),
+            'y': self.random([32, 64], low=1, high=10, dtype='int32')
+        }
+
+    def set_op_type(self):
+        return "elementwise_floordiv"
+
+
+class TestFloorDivOpCase2(TestElementwiseOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([32], low=1, high=10, dtype='int64'),
+            'y': self.random([32], low=1, high=10, dtype='int64')
+        }
+
+    def set_op_type(self):
+        return "elementwise_floordiv"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. 添加了`floor_divide`算子映射，该算子在paddle中的接口为`elementwise_floordiv`
2. CINN中的`remainder`算子实际功能与`mod`算子相同，但`remainder`的extern call函数未与paddle对齐，因此将此算子原extern call函数删除，改用`mod`算子的extern call函数即可

- `remainder`算子未对齐paddle复现代码（在`python/tests/op_mappers/test_elementwise_op.py`中）：
```python
class TestRemainderOpCase(TestElementwiseOp):
    def init_input_data(self):
        self.feed_data = {
            'x': np.array([0.0277172, 0.0285426, 0.9621329, 0.45386854, 0.99988127], dtype='float32'),
            'y': np.array([0.5357615, 0.26740074, 0.87235093, 0.7783255, 0.6893745], dtype='float32')
        }

    def set_op_type(self):
        return "elementwise_mod"
```