### PR TITLE
[Profiler] Expose Python Interface by Pybind and Add RecordEvent in Framework

### DIFF
--- a/cinn/backends/llvm/execution_engine.cc
+++ b/cinn/backends/llvm/execution_engine.cc
@@ -63,6 +63,7 @@
 #include "cinn/backends/llvm/runtime_symbol_registry.h"
 #include "cinn/ir/ir_printer.h"
 #include "cinn/runtime/intrinsic.h"
+#include "cinn/utils/profiler.h"
 
 namespace cinn::backends {
 namespace {
@@ -155,6 +156,7 @@ std::unique_ptr<llvm::MemoryBuffer> NaiveObjectCache::getObject(const llvm::Modu
 
 template <typename CodeGenT>
 void ExecutionEngine::Link(const ir::Module &module) {
+  utils::RecordEvent("ExecutionEngine Link", utils::EventType::kOrdinary);
   llvm::SMDiagnostic error;
   auto ctx        = std::make_unique<llvm::LLVMContext>();
   auto m          = llvm::parseAssemblyString(AsStringRef(backends::kRuntimeLlvmIr), error, *ctx);
@@ -193,6 +195,7 @@ void ExecutionEngine::Link(const ir::Module &module) {
 }
 
 bool ExecutionEngine::AddModule(std::unique_ptr<llvm::Module> module, std::unique_ptr<llvm::LLVMContext> context) {
+  utils::RecordEvent("ExecutionEngine AddModule", utils::EventType::kOrdinary);
   module->setDataLayout(jit_->getDataLayout());
   if (false) {
     VLOG(3) << "======= dump jit lib ==========";
@@ -216,6 +219,7 @@ void ExecutionEngine::ExportObject(const std::string &path) {
 }
 
 void *ExecutionEngine::Lookup(absl::string_view name) {
+  utils::RecordEvent("ExecutionEngine Lookup", utils::EventType::kOrdinary);
   std::lock_guard<std::mutex> lock(mu_);
   if (auto symbol = jit_->lookup(AsStringRef(name))) {
     return reinterpret_cast<void *>(symbol->getAddress());
@@ -226,6 +230,7 @@ void *ExecutionEngine::Lookup(absl::string_view name) {
 }
 
 void ExecutionEngine::RegisterRuntimeSymbols() {
+  utils::RecordEvent("ExecutionEngine RegisterRuntimeSymbols", utils::EventType::kOrdinary);
   const auto &registry = GlobalSymbolRegistry::Global();
   auto *session        = &jit_->getExecutionSession();
   for (const auto &sym : registry.All()) {

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -21,6 +21,7 @@
 #include "cinn/frontend/syntax.h"
 #include "cinn/hlir/pe/broadcast.h"
 #include "cinn/utils/functional.h"
+#include "cinn/utils/profiler.h"
 
 namespace cinn {
 namespace frontend {
@@ -34,6 +35,7 @@ using utils::ShapeType;
 NetBuilder::NetBuilder(const std::string& name) : name_(name) {}
 
 Program NetBuilder::Build(bool in_reverse) {
+  utils::RecordEvent("NetBuilder::Build", utils::EventType::kProgram);
   std::vector<Instruction> instrs;
   if (in_reverse) {
     instrs.reserve(instrs_.size());
@@ -85,7 +87,7 @@ const std::vector<Variable>& NetBuilder::CustomInstr(const std::string& type,
   for (auto& kv : attrs) {
     instr.SetAttr(kv.first, kv.second);
   }
-
+  utils::RecordEvent("NetBuilder." + type, utils::EventType::kProgram);
   InferShape(instr);
   AppendInstruction(instr);
   return instr.GetOutputs();

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -28,6 +28,7 @@
 #include "cinn/lang/lower.h"
 #include "cinn/optim/transform_gpu_forloop.h"
 #include "cinn/poly/stage.h"
+#include "cinn/utils/profiler.h"
 
 DECLARE_bool(cinn_ir_schedule);
 DECLARE_int32(cinn_parallel_compile_size);
@@ -719,6 +720,7 @@ void GraphCompiler::ProcessFunction(const std::vector<ir::LoweredFunc>& lowered_
 }
 
 std::unique_ptr<Program> GraphCompiler::Build(const std::string& code) {
+  utils::RecordEvent("GraphCompiler::Build", utils::EventType::kGraph);
   GraphCompiler::CompileOptions options;
   options.attached_code              = code;
   options.with_instantiate_variables = true;
@@ -739,6 +741,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
   if (FLAGS_cinn_parallel_compile_size) {
     if (options.with_instantiate_variables) {
       VLOG(3) << "Initantiate all variables on compile-time";
+      utils::RecordEvent("GraphCompiler MutableData", utils::EventType::kOrdinary);
       // All variables reside in scope_, so traverse it to instantiate each one
       for (auto& name : scope_->var_names()) {
         auto* var    = scope_->Var<Tensor>(std::string({name.data(), name.size()}));
@@ -755,6 +758,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
     }
 
     VLOG(2) << "Compile With Parallel Compiler!";
+    utils::RecordEvent("GraphCompiler CompileResult", utils::EventType::kOrdinary);
     ParallelCompiler::CompileOptions option;
     option.lowered_funcs = options.lowered_funcs;
 
@@ -809,6 +813,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
   // if the input lowered_funcs is empty, we will use the defalut lowering process to generate
   std::vector<std::vector<ir::LoweredFunc>> local_lowered_funcs;
   if (options.lowered_funcs.empty()) {
+    utils::RecordEvent("GraphCompiler LoweredFuncs", utils::EventType::kOrdinary);
     // lowering of new fusion pass is not compatible with the groups from the input options,
     // thus process it seperately
     if (!graph_->fusion_groups.empty()) {
@@ -850,8 +855,11 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
   // use the input lowered_funcs in options firstly if exists
   const auto& lowered_funcs = options.lowered_funcs.empty() ? local_lowered_funcs : options.lowered_funcs;
   CHECK_EQ(groups.size(), lowered_funcs.size()) << "The size of groups and lowered_funcs shoule be equal";
-  for (auto&& lowered_func : lowered_funcs) {
-    this->ProcessFunction(lowered_func);
+  {
+    utils::RecordEvent("GraphCompiler ProcessFunction", utils::EventType::kOrdinary);
+    for (auto&& lowered_func : lowered_funcs) {
+      this->ProcessFunction(lowered_func);
+    }
   }
   graph_->VisualizeGroupedGraph(groups, fetch_var_ids_);
 
@@ -863,16 +871,20 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
   auto build_module = m_builder_.Build();
   VLOG(3) << "End of m_builder_.Build()";
   if (this->target_.arch == Target::Arch::X86) {
+    utils::RecordEvent("GraphCompiler CodeGenCX86", utils::EventType::kOrdinary);
     CodeGenCX86 codegen(this->target_, CodeGenCX86::Feature::AVX512);
     codegen.SetInlineBuiltinCodes(false);
     auto out = codegen.Compile(build_module, CodeGenC::OutputKind::CImpl);
     VLOG(3) << "[X86] C Code is:\n" << out;
   }
 
-  compiler_->Build(build_module, options.attached_code);
-  VLOG(3) << "End of compiler_->Build";
-  auto instructions = BuildInstructions(groups, options.groups.empty() ? graph_->fusion_groups : options.groups);
+  {
+    utils::RecordEvent("GraphCompiler BackendsBuild", utils::EventType::kOrdinary);
+    compiler_->Build(build_module, options.attached_code);
+    VLOG(3) << "End of compiler_->Build";
+  }
 
+  auto instructions = BuildInstructions(groups, options.groups.empty() ? graph_->fusion_groups : options.groups);
   VLOG(3) << "End of BuildInstructions";
   if (options.remove_unused_variables) {
     RemoveInvalidVariables(instructions);
@@ -884,6 +896,7 @@ GraphCompiler::CompilationResult GraphCompiler::Build(const GraphCompiler::Compi
 
   if (options.with_instantiate_variables) {
     VLOG(3) << "Initantiate all variables on compile-time";
+    utils::RecordEvent("GraphCompiler MutableData", utils::EventType::kOrdinary);
     // All variables reside in scope_, so traverse it to instantiate each one
     for (auto& name : scope_->var_names()) {
       auto* var    = scope_->Var<Tensor>(std::string({name.data(), name.size()}));
@@ -971,6 +984,7 @@ void GraphCompiler::BuildCublasInstr(const Node& node, Instruction* instr) const
 
 std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
     const std::vector<std::vector<Node*>>& groups, const std::vector<std::shared_ptr<Graph::Group>>& fusion_groups) {
+  utils::RecordEvent("GraphCompiler BuildInstructions", utils::EventType::kOrdinary);
   std::vector<std::unique_ptr<Instruction>> instructions;
   auto topo_order = graph_->topological_order();
   auto& nodes     = std::get<0>(topo_order);
@@ -1236,6 +1250,7 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
 
 void GraphCompiler::RemoveInvalidVariables(const std::vector<std::unique_ptr<Instruction>>& instructions) {
   // mark all variables are invalid initially
+  utils::RecordEvent("GraphCompiler RemoveInvalidVariables", utils::EventType::kOrdinary);
   std::unordered_set<std::string> invalid_variables;
   auto var_names = scope_->var_names();
   invalid_variables.reserve(var_names.size());
@@ -1295,6 +1310,7 @@ static void BufferFreeWithCallback(void* args, int num_args) {
 void GraphCompiler::AnalyzeVariableLifeTime(const std::vector<std::unique_ptr<Instruction>>& instructions,
                                             std::unordered_map<int, std::vector<std::string>>* step2malloc,
                                             std::unordered_map<int, std::vector<std::string>>* step2free) {
+  utils::RecordEvent("GraphCompiler AnalyzeVariableLifeTime", utils::EventType::kOrdinary);
   absl::flat_hash_map<std::string, int> variable_last_used, variable_first_used;
   for (auto step = 0; step < instructions.size(); ++step) {
     const auto& instr = instructions.at(step);
@@ -1324,6 +1340,7 @@ void GraphCompiler::AnalyzeVariableLifeTime(const std::vector<std::unique_ptr<In
 }
 
 void GraphCompiler::InsertBufferHandlers(std::vector<std::unique_ptr<Instruction>>* instructions) {
+  utils::RecordEvent("GraphCompiler InsertBufferHandlers", utils::EventType::kOrdinary);
   std::unordered_map<int, std::vector<std::string>> step2malloc, step2free;
   AnalyzeVariableLifeTime(*instructions, &step2malloc, &step2free);
 
@@ -1398,6 +1415,7 @@ std::vector<std::string> GraphCompiler::OpGetOutputNames(const Node* node) const
 }
 
 std::shared_ptr<Scope> BuildScope(Target target, const std::shared_ptr<Graph>& graph, std::shared_ptr<Scope> scope) {
+  utils::RecordEvent("GraphCompiler BuildScope", utils::EventType::kOrdinary);
   auto& shape_dict = graph->GetAttrs<absl::flat_hash_map<std::string, shape_t>>("infershape");
   auto& dtype_dict = graph->GetAttrs<absl::flat_hash_map<std::string, Type>>("inferdtype");
   if (!scope) scope = std::make_shared<Scope>();
@@ -1425,6 +1443,7 @@ std::vector<ir::LoweredFunc> GetFuncFromImpl(const std::shared_ptr<OpImpl>& impl
                                              const std::vector<std::string>& input_output_nodes,
                                              const std::string& node_id,
                                              const Target& target) {
+  utils::RecordEvent("GraphCompiler GetFuncFromImpl", utils::EventType::kOrdinary);
   // 1.Call Op's Compute function, using the default stages and LowerVec to get IR tree.
   common::CINNValuePack C = impl->fcompute(cinn_inputs);
 

--- a/cinn/pybind/CMakeLists.txt
+++ b/cinn/pybind/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(srcs runtime.cc common.cc lang.cc ir.cc poly.cc backends.cc bind.cc optim.cc pe.cc frontend.cc framework.cc)
+set(srcs runtime.cc common.cc lang.cc ir.cc poly.cc backends.cc bind.cc optim.cc pe.cc frontend.cc framework.cc utils.cc)
 
 if (WITH_CUDA)
   message(STATUS "Compile core_api with CUDA support")

--- a/cinn/pybind/bind.cc
+++ b/cinn/pybind/bind.cc
@@ -34,6 +34,7 @@ PYBIND11_MODULE(core_api, m) {
   py::module pe        = m.def_submodule("pe", "namespace cinn::hlir::pe, CINN Primitive Emitters");
   py::module frontend  = m.def_submodule("frontend", "namespace cinn::frontend, CINN frontend");
   py::module framework = m.def_submodule("framework", "namespace cinn::hlir::framework, CINN framework");
+  py::module utils     = m.def_submodule("utils", "namespace cinn::utils, CINN framework");
 
   BindRuntime(&runtime);
   BindCommon(&common);
@@ -45,6 +46,7 @@ PYBIND11_MODULE(core_api, m) {
   BindPE(&pe);
   BindFrontend(&frontend);
   BindFramework(&framework);
+  BindUtils(&utils);
 }
 
 }  // namespace cinn::pybind

--- a/cinn/pybind/bind.h
+++ b/cinn/pybind/bind.h
@@ -47,5 +47,6 @@ void BindOptim(pybind11::module *m);
 void BindPE(pybind11::module *m);
 void BindFrontend(pybind11::module *m);
 void BindFramework(pybind11::module *m);
+void BindUtils(pybind11::module *m);
 
 }  // namespace cinn::pybind

--- a/cinn/pybind/utils.cc
+++ b/cinn/pybind/utils.cc
@@ -64,10 +64,6 @@ void BindUtils(py::module *m) {
           "type",
           [](HostEvent &self) -> const EventType & { return self.type_; },
           [](HostEvent &self, const EventType &v) { self.type_ = v; });
-
-  m->def("is_profiler_enable", &is_profiler_enable)
-      .def("is_cpu_enable", &is_cpu_enable)
-      .def("is_cuda_enable", &is_cuda_enable);
 }
 
 }  // namespace pybind

--- a/cinn/pybind/utils.cc
+++ b/cinn/pybind/utils.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/pybind/bind.h"
+#include "cinn/utils/profiler.h"
+
+namespace py = pybind11;
+
+namespace cinn {
+namespace pybind {
+
+using namespace cinn::utils;
+
+void BindUtils(py::module *m) {
+  py::enum_<EventType>(*m, "EventType")
+      .value("kOrdinary", EventType::kOrdinary)
+      .value("kGraph", EventType::kGraph)
+      .value("kProgram", EventType::kProgram)
+      .value("kFusePass", EventType::kFusePass)
+      .value("kCompute", EventType::kCompute)
+      .value("kSchedule", EventType::kSchedule)
+      .value("kOptimize", EventType::kOptimize)
+      .value("kCodeGen", EventType::kCodeGen)
+      .value("kCompile", EventType::kCompile)
+      .value("kInstruction", EventType::kInstruction)
+      .export_values();
+
+  py::class_<ProfilerHelper>(*m, "ProfilerHelper")
+      .def_static("enable_all", &ProfilerHelper::EnableAll)
+      .def_static("enable_cpu", &ProfilerHelper::EnableCPU)
+      .def_static("enable_cuda", &ProfilerHelper::EnableCUDA)
+      .def_static("is_enable", &ProfilerHelper::IsEnable)
+      .def_static("is_enable_cpu", &ProfilerHelper::IsEnableCPU)
+      .def_static("is_enable_cuda", &ProfilerHelper::IsEnableCUDA);
+
+  py::class_<HostEventRecorder>(*m, "HostEventRecorder")
+      .def_static("instance", &HostEventRecorder::GetInstance)
+      .def_static("table", &HostEventRecorder::Table)
+      .def("events", &HostEventRecorder::Events)
+      .def("clear", &HostEventRecorder::Clear);
+
+  py::class_<HostEvent>(*m, "HostEvent")
+      .def(py::init<const std::string &, double, EventType>())
+      .def_property(
+          "annotation",
+          [](HostEvent &self) -> const std::string & { return self.annotation_; },
+          [](HostEvent &self, const std::string &v) { self.annotation_ = v; })
+      .def_property(
+          "duration",
+          [](HostEvent &self) -> const double { return self.duration_; },
+          [](HostEvent &self, double v) { self.duration_ = v; })
+      .def_property(
+          "type",
+          [](HostEvent &self) -> const EventType & { return self.type_; },
+          [](HostEvent &self, const EventType &v) { self.type_ = v; });
+
+  m->def("is_profiler_enable", &is_profiler_enable)
+      .def("is_cpu_enable", &is_cpu_enable)
+      .def("is_cuda_enable", &is_cuda_enable);
+}
+
+}  // namespace pybind
+}  // namespace cinn

--- a/cinn/utils/event.cc
+++ b/cinn/utils/event.cc
@@ -16,6 +16,8 @@
 
 #include <glog/logging.h>  // for GLog
 
+#include <unordered_map>
+
 namespace cinn {
 namespace utils {
 inline std::string EventTypeToString(const EventType &type) {
@@ -52,20 +54,30 @@ std::ostream &operator<<(std::ostream &os, const EventType &type) {
 
 std::string Summary::Format(const std::vector<HostEvent> &events) {
   std::vector<Item> items;
+  // TODO(Aurelius84): Consider EventType for more hash key info.
+  std::unordered_map<std::string, Item *> unique_items;
   std::unordered_map<EventType, double> category_cost;
 
   double total_cost     = 0.0;
   size_t max_annot_size = 20;
   for (auto &e : events) {
-    items.emplace_back(e);
+    if (unique_items.count(e.annotation_) == 0U) {
+      items.emplace_back(e);
+      unique_items[e.annotation_]                    = &items.back();
+      unique_items.at(e.annotation_)->info.duration_ = 0.0;
+    }
+    // Sum cost for categorey
     category_cost[e.type_] += e.duration_;
     total_cost += e.duration_;
     max_annot_size = std::max(max_annot_size, e.annotation_.size());
+
+    // Sum cost for same name
+    unique_items.at(e.annotation_)->info.duration_ += e.duration_;
   }
   // Calculate Ratio
   for (auto &item : items) {
-    item.sub_raito   = item.event->duration_ / category_cost[item.event->type_] * 100.0;
-    item.total_raito = item.event->duration_ / total_cost * 100.0;
+    item.sub_raito   = item.info.duration_ / category_cost[item.info.type_] * 100.0;
+    item.total_raito = item.info.duration_ / total_cost * 100.0;
   }
 
   std::sort(items.begin(), items.end());
@@ -79,24 +91,29 @@ std::string Summary::AsStr(const std::vector<Item> &items, int data_width) {
   os << "\n\n------------------------->     Profiling Report     <-------------------------\n\n";
 
   std::vector<std::string> titles = {"Category", "Name", "CostTime(ms)", "Ratio in Category(%)", "Ratio in Total(%)"};
+  std::vector<int> widths         = {20, data_width, 20, 20, 20};
 
   size_t pad_size = 0;
+  int idx         = 0;
   for (auto &t : titles) {
-    pad_size = data_width > t.size() ? data_width - t.size() : 1;
+    pad_size = widths[idx] >= t.size() ? widths[idx] - t.size() : 1;
     os << ' ' << t << std::string(pad_size, ' ');
+    ++idx;
   }
 
   os << "\n\n";
 
   for (auto &item : items) {
-    std::vector<std::string> infos = {EventTypeToString(item.event->type_),
-                                      item.event->annotation_,
-                                      std::to_string(item.event->duration_),
+    std::vector<std::string> infos = {EventTypeToString(item.info.type_),
+                                      item.info.annotation_,
+                                      std::to_string(item.info.duration_),
                                       item.sub_raito.ToStr(),
                                       item.total_raito.ToStr()};
+    idx                            = 0;
     for (auto &info : infos) {
-      pad_size = data_width > info.size() ? data_width - info.size() : 1;
+      pad_size = widths[idx] > info.size() ? widths[idx] - info.size() : 1;
       os << ' ' << info << std::string(pad_size, ' ');
+      ++idx;
     }
     os << "\n";
   }

--- a/cinn/utils/event.h
+++ b/cinn/utils/event.h
@@ -74,11 +74,11 @@ class Summary {
   };
 
   struct Item {
-    const HostEvent* event;
+    HostEvent info;
     Raito sub_raito{0.0};    // percentage of EventType
     Raito total_raito{0.0};  // precentage of total process
 
-    Item(const HostEvent& e) : event(&e) {}
+    Item(const HostEvent& e) : info(e) {}
     bool operator<(const Item& other) const { return total_raito.value > other.total_raito.value; }
   };
 

--- a/cinn/utils/profiler.cc
+++ b/cinn/utils/profiler.cc
@@ -32,9 +32,9 @@ namespace utils {
 ProfilerState ProfilerHelper::g_state = ProfilerState::kDisabled;
 
 RecordEvent::RecordEvent(const std::string& name, EventType type) {
-  if (!is_profiler_enable()) return;
+  if (!ProfilerHelper::IsEnable()) return;
 
-  if (is_cpu_enable()) {
+  if (ProfilerHelper::IsEnableCPU()) {
     call_back_ = [this, tik = std::chrono::steady_clock::now(), annotation = std::move(name), type]() {
       auto tok                               = std::chrono::steady_clock::now();
       std::chrono::duration<double> duration = (tok - tik) * 1e3;  // ms
@@ -42,19 +42,19 @@ RecordEvent::RecordEvent(const std::string& name, EventType type) {
     };
   }
 
-  if (is_cuda_enable()) {
+  if (ProfilerHelper::IsEnableCUDA()) {
     ProfilerRangePush(name);
   }
 }
 
 void RecordEvent::End() {
-  if (!is_profiler_enable()) return;
+  if (!ProfilerHelper::IsEnable()) return;
 
-  if (is_cpu_enable() && call_back_ != nullptr) {
+  if (ProfilerHelper::IsEnableCPU() && call_back_ != nullptr) {
     call_back_();
   }
 
-  if (is_cuda_enable()) {
+  if (ProfilerHelper::IsEnableCUDA()) {
     ProfilerRangePop();
   }
 }

--- a/cinn/utils/profiler.h
+++ b/cinn/utils/profiler.h
@@ -37,9 +37,19 @@ class ProfilerHelper {
  public:
   static ProfilerState g_state;
 
-  static void Enable() { g_state = ProfilerState::kAll; }
-  static void Enable_CPU() { g_state = ProfilerState::kCPU; }
-  static void Enable_CUDA() { g_state = ProfilerState::kCUDA; }
+  static void EnableAll() { g_state = ProfilerState::kAll; }
+  static void EnableCPU() { g_state = ProfilerState::kCPU; }
+  static void EnableCUDA() { g_state = ProfilerState::kCUDA; }
+
+  static bool IsEnable() { return ProfilerHelper::g_state != ProfilerState::kDisabled; }
+
+  static bool IsEnableCPU() {
+    return ProfilerHelper::g_state == ProfilerState::kAll || ProfilerHelper::g_state == ProfilerState::kCPU;
+  }
+
+  static bool IsEnableCUDA() {
+    return ProfilerHelper::g_state == ProfilerState::kAll || ProfilerHelper::g_state == ProfilerState::kCUDA;
+  }
 };
 
 class RecordEvent {
@@ -65,16 +75,6 @@ void ProfilerStop();
 void ProfilerRangePush(const std::string& name);
 
 void ProfilerRangePop();
-
-inline bool is_profiler_enable() { return ProfilerHelper::g_state != ProfilerState::kDisabled; }
-
-inline bool is_cpu_enable() {
-  return ProfilerHelper::g_state == ProfilerState::kAll || ProfilerHelper::g_state == ProfilerState::kCPU;
-}
-
-inline bool is_cuda_enable() {
-  return ProfilerHelper::g_state == ProfilerState::kAll || ProfilerHelper::g_state == ProfilerState::kCUDA;
-}
 
 }  // namespace utils
 }  // namespace cinn

--- a/cinn/utils/profiler_test.cc
+++ b/cinn/utils/profiler_test.cc
@@ -23,7 +23,7 @@ TEST(RecordEvent, HOST) {
   using cinn::utils::ProfilerHelper;
   using cinn::utils::RecordEvent;
 
-  ProfilerHelper::Enable_CPU();
+  ProfilerHelper::EnableCPU();
 
   LOG(INFO) << "Usage 1: RecordEvent for HOST";
   std::vector<EventType> types = {

--- a/python/cinn/utils.py
+++ b/python/cinn/utils.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .core_api.utils import *

--- a/python/tests/test_matmul.py
+++ b/python/tests/test_matmul.py
@@ -21,6 +21,7 @@ from cinn import runtime
 from cinn import ir
 from cinn import lang
 from cinn import Target
+from cinn import utils
 from cinn.poly import create_stages
 
 
@@ -37,6 +38,8 @@ class TestMamul(unittest.TestCase):
         self.bn = 32
 
         self.engine = cinn.ExecutionEngine()
+        utils.ProfilerHelper.enable_cpu()
+        self.assertTrue(utils.ProfilerHelper.is_enble_cpu())
 
     def test_matmul_basic(self):
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)
@@ -48,6 +51,7 @@ class TestMamul(unittest.TestCase):
         cd = c.numpy()
         cd_target = c_target.numpy()
         self.assertTrue(np.allclose(cd, cd_target, atol=1e-4))
+        print(utils.HostEventRecorder.table())
 
     def test_matmul_tile(self):
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)

--- a/python/tests/test_matmul.py
+++ b/python/tests/test_matmul.py
@@ -39,7 +39,7 @@ class TestMamul(unittest.TestCase):
 
         self.engine = cinn.ExecutionEngine()
         utils.ProfilerHelper.enable_cpu()
-        self.assertTrue(utils.ProfilerHelper.is_enble_cpu())
+        self.assertTrue(utils.ProfilerHelper.is_enable_cpu())
 
     def test_matmul_basic(self):
         a, b, c, c_target, *args = create_data(self.m, self.n, self.k, self.bn)


### PR DESCRIPTION
### What's New?

#### 1. 功能优化

+ 优化了Profiler Event 的统计功能，将同名的Event进行合并，累积cost展示
+ 将`is_cpu_enable`、`is_cuda_enable`、`is_profiler_enable`三个接口整合到ProfilerHelper静态方法中

#### 2. 接口绑定

+ 通过`BindUtils`函数将C++端Profiler的核心类和HostEventRecorder单例暴露到Python端
+ 暴露核心的Profiler全局开关、Table展示接口到python端
+ 给CINN whl 包添加了utils 子模块，管理Profiler的功能

#### 3. 单测测试

+ 修改了 `test_matmul.py` 单测，添加了前段端到端验证Profiler的功能
+ 修改了`graph_compiler_test.cc` 单测，添加了C++端到端验证 Profiler的功能（Cmake刻意注释了，故为本地测试）

#### 4. RecordEvent 插桩

+ 给 graph_compiler 模块添加了RecordEvent
+ 给 net_builder 模块添加了 RecordEvent


#### 5. Profiler 实测

添加了部分RecordEvent，并在python端绑定了核心接口。

修改了一个单测，用于测试Profile的效果：
```python
98: ------------------------->     Profiling Report     <-------------------------
98: 
98:  Category             Name                                                        CostTime(ms)         Ratio in Category(%) Ratio in Total(%)   
98: 
98:  Instruction          fn_broadcast_to_0_fill_constant_2_elementwise_add_1_max_3_2  2.624917             94.728046            92.593813           
98:  Instruction          PrepareArgs                                                 0.146086             5.271954             5.153176            
98:  Program              NetBuilder.elementwise_add                                  0.014753             37.290835            0.520411            
98:  Ordinary             ExecutionEngine AddModule                                   0.006385             28.202297            0.225231            
98:  Ordinary             GraphCompiler RemoveInvalidVariables                        0.003698             16.333922            0.130447            
98:  Ordinary             ExecutionEngine RegisterRuntimeSymbols                      0.003359             14.836572            0.118489            
98:  Program              NetBuilder::Build                                           0.002894             7.315100             0.102086            
98:  Program              NetBuilder.relu                                             0.002755             6.963753             0.097182            
98:  Ordinary             ExecutionEngine Lookup                                      0.002472             10.918728            0.087200            
98:  Ordinary             GraphCompiler BuildScope                                    0.002371             10.472615            0.083637            
98:  Program              NetBuilder.fill_constant                                    0.002345             5.927405             0.082720            
98:  Ordinary             ExecutionEngine Link                                        0.002155             9.518551             0.076018            
98:  Program              NetBuilder.broadcast_to                                     0.001812             4.580153             0.063918            
98:  Program              NetBuilder.max                                              0.001788             4.519488             0.063072            
98:  Ordinary             GraphCompiler CompileResult                                 0.001765             7.795936             0.062260            
98:  Graph                GraphCompiler::Build                                        0.001668             100.000000           0.058839            
98:  Ordinary             GraphCompiler MutableData                                   0.000435             1.921378             0.015345  
```