### PR TITLE
Fix bugs in denseMergePass

### DIFF
--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -34,6 +34,7 @@ DECLARE_bool(cinn_use_common_subexpression_elimination);
 DECLARE_bool(cinn_check_fusion_accuracy_pass);
 DECLARE_bool(cinn_use_custom_call);
 DECLARE_bool(use_reduce_split_pass);
+DECLARE_bool(cinn_use_dense_merge_pass);
 
 namespace cinn {
 namespace frontend {
@@ -65,7 +66,9 @@ OptimizeOptions DefaultTrainingOptimizeOptions() {
   options.program_passes.emplace_back("DeadCodeEliminate");
 
   options.graph_passes = {"ConstantFolding"};
-  // options.graph_passes.push_back("DenseMergePass");
+  if (FLAGS_cinn_use_dense_merge_pass) {
+    options.graph_passes.push_back("DenseMergePass");
+  }
 
   if (FLAGS_cinn_use_custom_call) {
     options.graph_passes.emplace_back("TransToCustomCallPass");

--- a/cinn/hlir/pass/dense_merge_pass.cc
+++ b/cinn/hlir/pass/dense_merge_pass.cc
@@ -73,7 +73,9 @@ class DenseMergePassHelper : public FusionHelperBase {
       auto sink = link->sink()->safe_as<Node>();
       if (sink->op()->name == "matmul" || sink->op()->name == "mul" || sink->op()->name == "cublas_gemm" ||
           sink->op()->name == "cublas_matmul") {
-        dense_ops.push_back(sink);
+        if (std::find(dense_ops.begin(), dense_ops.end(), sink) == dense_ops.end()) {
+          dense_ops.push_back(sink);
+        }
       }
     }
     return dense_ops;

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -72,6 +72,10 @@ DEFINE_bool(cinn_ir_schedule,
 
 DEFINE_bool(use_reduce_split_pass, BoolFromEnv("FLAGS_use_reduce_split_pass", false), "Whether use reduce split pass.");
 
+DEFINE_bool(cinn_use_dense_merge_pass,
+            BoolFromEnv("FLAGS_cinn_use_dense_merge_pass", false),
+            "Whether use dense merge pass.");
+
 // FLAGS for performance analysis and accuracy debug
 DEFINE_bool(cinn_sync_run,
             BoolFromEnv("FLAGS_cinn_sync_run", false),


### PR DESCRIPTION
当一个 mul,cublas_gemm 的 op 的两个输入为同一个 NodeData 时，会在后续unlink 时报错，修复了这个 bug，并增加了一个 Flag 可以开启 DenseMergePass