### PR TITLE
fix argmax/argmin float64 error

### DIFF
--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -1211,11 +1211,7 @@ TEST(net_build, program_argmax_case2) {
   Variable output   = builder.Argmax(input, 1, false);
   auto program      = builder.Build();
 
-#ifdef CINN_WITH_CUDA
-  Target target = common::DefaultNVGPUTarget();
-#else
   Target target = common::DefaultHostTarget();
-#endif
   std::unordered_set<std::string> fetch_ids;
   auto graph = Optimize(&program, fetch_ids, target);
 

--- a/cinn/frontend/net_builder_test.cc
+++ b/cinn/frontend/net_builder_test.cc
@@ -1211,7 +1211,11 @@ TEST(net_build, program_argmax_case2) {
   Variable output   = builder.Argmax(input, 1, false);
   auto program      = builder.Build();
 
+#ifdef CINN_WITH_CUDA
+  Target target = common::DefaultNVGPUTarget();
+#else
   Target target = common::DefaultHostTarget();
+#endif
   std::unordered_set<std::string> fetch_ids;
   auto graph = Optimize(&program, fetch_ids, target);
 

--- a/cinn/hlir/op/contrib/argmax_test.cc
+++ b/cinn/hlir/op/contrib/argmax_test.cc
@@ -85,7 +85,7 @@ void TestGenerateCodeCpu_Argmax_Keep(void* _args, int32_t num_args)
     for (int32_t j = 0; j < 3; j += 1) {
       for (int32_t k = 0; k < 28; k += 1) {
         for (int32_t a = 0; a < 28; a += 1) {
-          test_argmax_in_index_temp[((2352 * i) + ((784 * j) + ((28 * k) + a)))] = cinn_host_gt_num_float(_in, 3, in[((2352 * i) + ((784 * j) + ((28 * k) + a)))], ((2352 * i) + ((28 * k) + a)), 784);
+          test_argmax_in_index_temp[((2352 * i) + ((784 * j) + ((28 * k) + a)))] = cinn_host_gt_num_fp32(_in, 3, in[((2352 * i) + ((784 * j) + ((28 * k) + a)))], ((2352 * i) + ((28 * k) + a)), 784);
         };
       };
     };

--- a/cinn/hlir/op/contrib/argmin_test.cc
+++ b/cinn/hlir/op/contrib/argmin_test.cc
@@ -84,7 +84,7 @@ void TestGenerateCodeCpu_Argmin_Keep(void* _args, int32_t num_args)
     for (int32_t j = 0; j < 3; j += 1) {
       for (int32_t k = 0; k < 28; k += 1) {
         for (int32_t a = 0; a < 28; a += 1) {
-          test_argmin_in_index_temp[((2352 * i) + ((784 * j) + ((28 * k) + a)))] = cinn_host_lt_num_float(_in, 3, in[((2352 * i) + ((784 * j) + ((28 * k) + a)))], ((2352 * i) + ((28 * k) + a)), 784);
+          test_argmin_in_index_temp[((2352 * i) + ((784 * j) + ((28 * k) + a)))] = cinn_host_lt_num_fp32(_in, 3, in[((2352 * i) + ((784 * j) + ((28 * k) + a)))], ((2352 * i) + ((28 * k) + a)), 784);
         };
       };
     };

--- a/cinn/hlir/op/contrib/sort.cc
+++ b/cinn/hlir/op/contrib/sort.cc
@@ -28,6 +28,7 @@
 #include "cinn/hlir/framework/node.h"
 #include "cinn/hlir/framework/op.h"
 #include "cinn/hlir/framework/op_strategy.h"
+#include "cinn/hlir/op/op_util.h"
 #include "cinn/hlir/pe/elementwise.h"
 #include "cinn/hlir/pe/ir_schedule_pe.h"
 #include "cinn/hlir/pe/transform.h"
@@ -55,18 +56,16 @@ std::vector<ir::Tensor> ArgSort(const ir::Tensor &A,
   std::string find_func_name;
   std::string index_func_name;
   if (target.arch == common::Target::Arch::NVGPU) {
-    index_func_name.assign("cinn_cuda_");
     find_func_name.assign("cinn_cuda_find_int_nd");
   } else if (target.arch == common::Target::Arch::X86) {
-    index_func_name.assign("cinn_host_");
     find_func_name.assign("cinn_host_find_int_nd");
   } else {
     LOG(FATAL) << "ArgSort only supports X86 and NVGPU ! Please Check.\n";
   }
   if (is_ascend) {
-    index_func_name.append("lt_num_float");
+    index_func_name = cinn::hlir::GetExternFuncName(target, A->type(), "lt_num");
   } else {
-    index_func_name.append("gt_num_float");
+    index_func_name = cinn::hlir::GetExternFuncName(target, A->type(), "gt_num");
   }
   int pos_axis = axis;
   if (pos_axis < 0) {

--- a/cinn/hlir/op/contrib/sort_test.cc
+++ b/cinn/hlir/op/contrib/sort_test.cc
@@ -107,7 +107,7 @@ void TestGenerateCodeCpu_Sort(void* _args, int32_t num_args)
   int32_t* test_sort_out_index_temp = ((int32_t*)(_test_sort_out_index_temp->memory));
   for (int32_t i = 0; i < 4; i += 1) {
     for (int32_t j = 0; j < 28; j += 1) {
-      test_sort_out_index_temp[((28 * i) + j)] = cinn_host_lt_num_float(_in, 28, in[((28 * i) + j)], (28 * i), 1);
+      test_sort_out_index_temp[((28 * i) + j)] = cinn_host_lt_num_fp32(_in, 28, in[((28 * i) + j)], (28 * i), 1);
     };
   };
   for (int32_t i = 0; i < 4; i += 1) {

--- a/cinn/hlir/op/contrib/sort_test.cc
+++ b/cinn/hlir/op/contrib/sort_test.cc
@@ -107,7 +107,7 @@ void TestGenerateCodeCpu_Sort(void* _args, int32_t num_args)
   int32_t* test_sort_out_index_temp = ((int32_t*)(_test_sort_out_index_temp->memory));
   for (int32_t i = 0; i < 4; i += 1) {
     for (int32_t j = 0; j < 28; j += 1) {
-      test_sort_out_index_temp[((28 * i) + j)] = cinn_host_lt_num_fp32(_in, 28, in[((28 * i) + j)], (28 * i), 1);
+      test_sort_out_index_temp[((28 * i) + j)] = cinn_host_lt_num_int32(_in, 28, in[((28 * i) + j)], (28 * i), 1);
     };
   };
   for (int32_t i = 0; i < 4; i += 1) {

--- a/cinn/hlir/op/op_util.cc
+++ b/cinn/hlir/op/op_util.cc
@@ -104,5 +104,32 @@ CINNSchedule GetInjectiveScheduleFunc(const std::vector<std::vector<int>>& outpu
   });
 }
 
+std::string GetExternFuncName(const common::Target& target, const common::Type& type, const std::string& func_name) {
+  std::string target_func_name_type;
+  if (target.arch == common::Target::Arch::NVGPU) {
+    target_func_name_type.assign("cinn_cuda_");
+  } else if (target.arch == common::Target::Arch::X86) {
+    target_func_name_type.assign("cinn_host_");
+  } else {
+    LOG(FATAL) << func_name << "only supports X86 and NVGPU ! Please Check.\n";
+  }
+  target_func_name_type.append(func_name);
+  target_func_name_type.append("_");
+  if (type.is_float(16)) {
+    target_func_name_type.append("fp16");
+  } else if (type.is_float(32)) {
+    target_func_name_type.append("fp32");
+  } else if (type.is_float(64)) {
+    target_func_name_type.append("fp64");
+  } else if (type.is_int(32)) {
+    target_func_name_type.append("int32");
+  } else if (type.is_int(64)) {
+    target_func_name_type.append("int64");
+  } else {
+    LOG(FATAL) << func_name << "only supports fp16, fp32, fp64, int32 and int64 ! Please Check.\n";
+  }
+  return target_func_name_type;
+}
+
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/op/op_util.h
+++ b/cinn/hlir/op/op_util.h
@@ -115,5 +115,8 @@ CINNSchedule GetElementwiseScheduleFunc(const std::vector<std::vector<int>> &out
 CINNSchedule GetInjectiveScheduleFunc(const std::vector<std::vector<int>> &output_shapes,
                                       const Target &target,
                                       bool vectorizable = true);
+
+std::string GetExternFuncName(const common::Target &target, const common::Type &type, const std::string &func_name);
+
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/runtime/cpu/host_intrinsics.cc
+++ b/cinn/runtime/cpu/host_intrinsics.cc
@@ -63,47 +63,39 @@ inline int cinn_host_find_float_nd(const cinn_buffer_t* buf, int size, float num
 
 #undef __cinn_host_find_kernel
 
-#define __cinn_host_lt_num_kernel(buf, size, num, offset, stride, type)    \
-  do {                                                                     \
-    int out = 0;                                                           \
-    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) { \
-      if (reinterpret_cast<type*>(buf->memory)[i] < num) out++;            \
-    }                                                                      \
-    return out;                                                            \
-  } while (0)
+#define CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)                                                           \
+  inline int cinn_host_lt_num_##TYPE_SUFFIX(                                                          \
+      const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride) { \
+    int out = 0;                                                                                      \
+    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) {                            \
+      if (reinterpret_cast<TYPE*>(buf->memory)[i] < num) out++;                                       \
+    }                                                                                                 \
+    return out;                                                                                       \
+  }
 
-inline int cinn_host_lt_num_float(
-    const cinn_buffer_t* buf, const int size, const float num, const int offset, const int stride) {
-  __cinn_host_lt_num_kernel(buf, size, num, offset, stride, float);
-}
+CINN_HOST_LT_NUM(fp32, float)
+CINN_HOST_LT_NUM(fp64, double)
+CINN_HOST_LT_NUM(int32, int)
+CINN_HOST_LT_NUM(int64, int64_t)
 
-inline int cinn_host_lt_num_int(
-    const cinn_buffer_t* buf, const int size, const int num, const int offset, const int stride) {
-  __cinn_host_lt_num_kernel(buf, size, num, offset, stride, int);
-}
+#undef CINN_HOST_LT_NUM
 
-#undef __cinn_host_lt_num_kernel
+#define CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                                                           \
+  inline int cinn_host_gt_num_##TYPE_SUFFIX(                                                          \
+      const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride) { \
+    int out = 0;                                                                                      \
+    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) {                            \
+      if (reinterpret_cast<TYPE*>(buf->memory)[i] > num) out++;                                       \
+    }                                                                                                 \
+    return out;                                                                                       \
+  }
 
-#define __cinn_host_gt_num_kernel(buf, size, num, offset, stride, type)    \
-  do {                                                                     \
-    int out = 0;                                                           \
-    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) { \
-      if (reinterpret_cast<type*>(buf->memory)[i] > num) out++;            \
-    }                                                                      \
-    return out;                                                            \
-  } while (0)
+CINN_HOST_GT_NUM(fp32, float)
+CINN_HOST_GT_NUM(fp64, double)
+CINN_HOST_GT_NUM(int32, int)
+CINN_HOST_GT_NUM(int64, int64_t)
 
-inline int cinn_host_gt_num_float(
-    const cinn_buffer_t* buf, const int size, const float num, const int offset, const int stride) {
-  __cinn_host_gt_num_kernel(buf, size, num, offset, stride, float);
-}
-
-inline int cinn_host_gt_num_int(
-    const cinn_buffer_t* buf, const int size, const int num, const int offset, const int stride) {
-  __cinn_host_gt_num_kernel(buf, size, num, offset, stride, int);
-}
-
-#undef __cinn_host_gt_num_kernel
+#undef CINN_HOST_GT_NUM
 
 #define FN_FP32(func) cinn_host_##func##_fp32
 
@@ -246,41 +238,39 @@ CINN_REGISTER_HELPER(host_intrinsics) {
       .AddInputType<int>()
       .End();
 
-  REGISTER_EXTERN_FUNC_HELPER(cinn_host_lt_num_int, host_target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t*>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
+#define _REGISTER_CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)                             \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_host_lt_num_##TYPE_SUFFIX, host_target) \
+      .SetRetType<int>()                                                          \
+      .AddInputType<cinn_buffer_t*>()                                             \
+      .AddInputType<int>()                                                        \
+      .AddInputType<TYPE>()                                                       \
+      .AddInputType<int>()                                                        \
+      .AddInputType<int>()                                                        \
       .End();
 
-  REGISTER_EXTERN_FUNC_HELPER(cinn_host_lt_num_float, host_target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t*>()
-      .AddInputType<int>()
-      .AddInputType<float>()
-      .AddInputType<int>()
-      .AddInputType<int>()
+  _REGISTER_CINN_HOST_LT_NUM(fp32, float);
+  _REGISTER_CINN_HOST_LT_NUM(fp64, double);
+  _REGISTER_CINN_HOST_LT_NUM(int32, int);
+  _REGISTER_CINN_HOST_LT_NUM(int64, int64_t);
+
+#undef _REGISTER_CINN_HOST_LT_NUM
+
+#define _REGISTER_CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                             \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_gt_num_##TYPE_SUFFIX, host_target) \
+      .SetRetType<int>()                                                          \
+      .AddInputType<cinn_buffer_t*>()                                             \
+      .AddInputType<int>()                                                        \
+      .AddInputType<TYPE>()                                                       \
+      .AddInputType<int>()                                                        \
+      .AddInputType<int>()                                                        \
       .End();
 
-  REGISTER_EXTERN_FUNC_HELPER(cinn_host_gt_num_int, host_target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t*>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .End();
+  _REGISTER_CINN_HOST_GT_NUM(fp32, float);
+  _REGISTER_CINN_HOST_GT_NUM(fp64, double);
+  _REGISTER_CINN_HOST_GT_NUM(int32, int);
+  _REGISTER_CINN_HOST_GT_NUM(int64, int64_t);
 
-  REGISTER_EXTERN_FUNC_HELPER(cinn_host_gt_num_float, host_target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t*>()
-      .AddInputType<int>()
-      .AddInputType<float>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .End();
+#undef _REGISTER_CINN_HOST_GT_NUM
 
   using cinn::runtime::cinn_call_cholesky_host;
   REGISTER_EXTERN_FUNC_HELPER(cinn_call_cholesky_host, host_target)

--- a/cinn/runtime/cpu/host_intrinsics.cc
+++ b/cinn/runtime/cpu/host_intrinsics.cc
@@ -238,14 +238,14 @@ CINN_REGISTER_HELPER(host_intrinsics) {
       .AddInputType<int>()
       .End();
 
-#define _REGISTER_CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)                             \
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_host_lt_num_##TYPE_SUFFIX, host_target) \
-      .SetRetType<int>()                                                          \
-      .AddInputType<cinn_buffer_t*>()                                             \
-      .AddInputType<int>()                                                        \
-      .AddInputType<TYPE>()                                                       \
-      .AddInputType<int>()                                                        \
-      .AddInputType<int>()                                                        \
+#define _REGISTER_CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)                      \
+  REGISTER_EXTERN_FUNC_HELPER(cinn_host_lt_num_##TYPE_SUFFIX, host_target) \
+      .SetRetType<int>()                                                   \
+      .AddInputType<cinn_buffer_t*>()                                      \
+      .AddInputType<int>()                                                 \
+      .AddInputType<TYPE>()                                                \
+      .AddInputType<int>()                                                 \
+      .AddInputType<int>()                                                 \
       .End();
 
   _REGISTER_CINN_HOST_LT_NUM(fp32, float);
@@ -255,14 +255,14 @@ CINN_REGISTER_HELPER(host_intrinsics) {
 
 #undef _REGISTER_CINN_HOST_LT_NUM
 
-#define _REGISTER_CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                             \
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_host_gt_num_##TYPE_SUFFIX, host_target) \
-      .SetRetType<int>()                                                          \
-      .AddInputType<cinn_buffer_t*>()                                             \
-      .AddInputType<int>()                                                        \
-      .AddInputType<TYPE>()                                                       \
-      .AddInputType<int>()                                                        \
-      .AddInputType<int>()                                                        \
+#define _REGISTER_CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                      \
+  REGISTER_EXTERN_FUNC_HELPER(cinn_host_gt_num_##TYPE_SUFFIX, host_target) \
+      .SetRetType<int>()                                                   \
+      .AddInputType<cinn_buffer_t*>()                                      \
+      .AddInputType<int>()                                                 \
+      .AddInputType<TYPE>()                                                \
+      .AddInputType<int>()                                                 \
+      .AddInputType<int>()                                                 \
       .End();
 
   _REGISTER_CINN_HOST_GT_NUM(fp32, float);

--- a/cinn/runtime/cpu/host_intrinsics.cc
+++ b/cinn/runtime/cpu/host_intrinsics.cc
@@ -256,7 +256,7 @@ CINN_REGISTER_HELPER(host_intrinsics) {
 #undef _REGISTER_CINN_HOST_LT_NUM
 
 #define _REGISTER_CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                             \
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_gt_num_##TYPE_SUFFIX, host_target) \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_host_gt_num_##TYPE_SUFFIX, host_target) \
       .SetRetType<int>()                                                          \
       .AddInputType<cinn_buffer_t*>()                                             \
       .AddInputType<int>()                                                        \

--- a/cinn/runtime/cpu/host_intrinsics.h
+++ b/cinn/runtime/cpu/host_intrinsics.h
@@ -33,17 +33,27 @@ inline int cinn_host_find_int_nd(const cinn_buffer_t* buf, int size, int num, in
 
 inline int cinn_host_find_float_nd(const cinn_buffer_t* buf, int size, float num, int begin, int stride);
 
-inline int cinn_host_lt_num_float(
-    const cinn_buffer_t* buf, const int size, const float num, const int offset, const int stride);
+#define CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)  \
+  inline int cinn_host_lt_num_##TYPE_SUFFIX( \
+      const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride);
 
-inline int cinn_host_lt_num_int(
-    const cinn_buffer_t* buf, const int size, const int num, const int offset, const int stride);
+CINN_HOST_LT_NUM(fp32, float)
+CINN_HOST_LT_NUM(fp64, double)
+CINN_HOST_LT_NUM(int32, int)
+CINN_HOST_LT_NUM(int64, int64_t)
 
-inline int cinn_host_gt_num_float(
-    const cinn_buffer_t* buf, const int size, const float num, const int offset, const int stride);
+#undef CINN_HOST_LT_NUM
 
-inline int cinn_host_gt_num_int(
-    const cinn_buffer_t* buf, const int size, const int num, const int offset, const int stride);
+#define CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)  \
+  inline int cinn_host_gt_num_##TYPE_SUFFIX( \
+      const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride);
+
+CINN_HOST_GT_NUM(fp32, float)
+CINN_HOST_GT_NUM(fp64, double)
+CINN_HOST_GT_NUM(int32, int)
+CINN_HOST_GT_NUM(int64, int64_t)
+
+#undef CINN_HOST_GT_NUM
 
 #define FN_INT32(func) cinn_host_##func##_int32
 

--- a/cinn/runtime/cpu/host_intrinsics.h
+++ b/cinn/runtime/cpu/host_intrinsics.h
@@ -33,8 +33,8 @@ inline int cinn_host_find_int_nd(const cinn_buffer_t* buf, int size, int num, in
 
 inline int cinn_host_find_float_nd(const cinn_buffer_t* buf, int size, float num, int begin, int stride);
 
-#define CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)  \
-  inline int cinn_host_lt_num_##TYPE_SUFFIX( \
+#define CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)                                                          \
+  inline int cinn_host_lt_num_##TYPE_SUFFIX(                                                         \
       const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride);
 
 CINN_HOST_LT_NUM(fp32, float)
@@ -44,8 +44,8 @@ CINN_HOST_LT_NUM(int64, int64_t)
 
 #undef CINN_HOST_LT_NUM
 
-#define CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)  \
-  inline int cinn_host_gt_num_##TYPE_SUFFIX( \
+#define CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                                                          \
+  inline int cinn_host_gt_num_##TYPE_SUFFIX(                                                         \
       const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride);
 
 CINN_HOST_GT_NUM(fp32, float)

--- a/cinn/runtime/cpu/host_intrinsics.h
+++ b/cinn/runtime/cpu/host_intrinsics.h
@@ -33,8 +33,8 @@ inline int cinn_host_find_int_nd(const cinn_buffer_t* buf, int size, int num, in
 
 inline int cinn_host_find_float_nd(const cinn_buffer_t* buf, int size, float num, int begin, int stride);
 
-#define CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)                                                          \
-  inline int cinn_host_lt_num_##TYPE_SUFFIX(                                                         \
+#define CINN_HOST_LT_NUM(TYPE_SUFFIX, TYPE)  \
+  inline int cinn_host_lt_num_##TYPE_SUFFIX( \
       const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride);
 
 CINN_HOST_LT_NUM(fp32, float)
@@ -44,8 +44,8 @@ CINN_HOST_LT_NUM(int64, int64_t)
 
 #undef CINN_HOST_LT_NUM
 
-#define CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)                                                          \
-  inline int cinn_host_gt_num_##TYPE_SUFFIX(                                                         \
+#define CINN_HOST_GT_NUM(TYPE_SUFFIX, TYPE)  \
+  inline int cinn_host_gt_num_##TYPE_SUFFIX( \
       const cinn_buffer_t* buf, const int size, const TYPE num, const int offset, const int stride);
 
 CINN_HOST_GT_NUM(fp32, float)

--- a/cinn/runtime/cpu/host_intrinsics_test.cc
+++ b/cinn/runtime/cpu/host_intrinsics_test.cc
@@ -109,13 +109,13 @@ TEST(find_value_nd, basic) {
   }
 }
 
-TEST(cinn_host_lt_num_float, basic) {
+TEST(cinn_host_lt_num_fp32, basic) {
   Expr M(10), N(20);
   Placeholder<float> x("x", {M, N});
   auto y = Compute(
       {N},
       [&](Expr j) {
-        return CallExtern("cinn_host_lt_num_float", {x, M, x({Expr(0), j}), j, N});
+        return CallExtern("cinn_host_lt_num_fp32", {x, M, x({Expr(0), j}), j, N});
       },
       "y");
 
@@ -156,13 +156,13 @@ TEST(cinn_host_lt_num_float, basic) {
   }
 }
 
-TEST(cinn_host_gt_num_float, basic) {
+TEST(cinn_host_gt_num_fp32, basic) {
   Expr M(10), N(20);
   Placeholder<float> x("x", {M, N});
   auto y = Compute(
       {N},
       [&](Expr j) {
-        return CallExtern("cinn_host_gt_num_float", {x, M, x({Expr(0), j}), j, N});
+        return CallExtern("cinn_host_gt_num_fp32", {x, M, x({Expr(0), j}), j, N});
       },
       "y");
 

--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -467,47 +467,37 @@ __device__ inline int cinn_cuda_find_float_from(const float *buf, int size, floa
 
 #undef __cinn_cuda_find_from_kernel
 
-#define __cinn_cuda_lt_num_kernel(buf, size, num, offset, stride)          \
-  do {                                                                     \
-    int out = 0;                                                           \
-    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) { \
-      if (buf[i] < num) out++;                                             \
-    }                                                                      \
-    return out;                                                            \
-  } while (0)
-
-__device__ inline int cinn_cuda_lt_num_float(
-    const float *buf, const int size, const float num, const int offset, const int stride) {
-  __cinn_cuda_lt_num_kernel(buf, size, num, offset, stride);
+#define CINN_CUDA_LT_NUM(TYPE_SUFFIX, TYPE) __device__ inline int cinn_cuda_lt_num_##TYPE_SUFFIX( \
+    const TYPE *buf, const int size, const TYPE num, const int offset, const int stride) {        \
+    int out = 0;                                                                                  \
+    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) {                        \
+      if (buf[i] < num) out++;                                                                    \
+    }                                                                                             \
+    return out;                                                                                   \
 }
 
-__device__ inline int cinn_cuda_lt_num_int(
-    const int *buf, const int size, const int num, const int offset, const int stride) {
-  __cinn_cuda_lt_num_kernel(buf, size, num, offset, stride);
+CINN_CUDA_LT_NUM(fp32, float)
+CINN_CUDA_LT_NUM(fp64, double)
+CINN_CUDA_LT_NUM(int32, int)
+CINN_CUDA_LT_NUM(int64, long long int)
+
+#undef CINN_CUDA_LT_NUM
+
+#define CINN_CUDA_GT_NUM(TYPE_SUFFIX, TYPE) __device__ inline int cinn_cuda_gt_num_##TYPE_SUFFIX( \
+    const TYPE *buf, const int size, const TYPE num, const int offset, const int stride) {        \
+    int out = 0;                                                                                  \
+    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) {                        \
+      if (buf[i] > num) out++;                                                                    \
+    }                                                                                             \
+    return out;                                                                                   \
 }
 
-#undef __cinn_cuda_lt_num_kernel
+CINN_CUDA_GT_NUM(fp32, float)
+CINN_CUDA_GT_NUM(fp64, double)
+CINN_CUDA_GT_NUM(int32, int)
+CINN_CUDA_GT_NUM(int64, long long int)
 
-#define __cinn_cuda_gt_num_kernel(buf, size, num, offset, stride)          \
-  do {                                                                     \
-    int out = 0;                                                           \
-    for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) { \
-      if (buf[i] > num) out++;                                             \
-    }                                                                      \
-    return out;                                                            \
-  } while (0)
-
-__device__ inline int cinn_cuda_gt_num_float(
-    const float *buf, const int size, const float num, const int offset, const int stride) {
-  __cinn_cuda_gt_num_kernel(buf, size, num, offset, stride);
-}
-
-__device__ inline int cinn_cuda_gt_num_int(
-    const int *buf, const int size, const int num, const int offset, const int stride) {
-  __cinn_cuda_gt_num_kernel(buf, size, num, offset, stride);
-}
-
-#undef __cinn_cuda_gt_num_kernel
+#undef CINN_CUDA_GT_NUM
 
 __device__ inline float cinn_cuda_index_add(const float x,
                                             const int axis_indice,

--- a/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -227,41 +227,39 @@ CINN_REGISTER_HELPER(cuda_intrinsics) {
       .AddInputType<int>()
       .End();
 
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_lt_num_int, target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
+#define _REGISTER_CINN_CUDA_LT_NUM(TYPE_SUFFIX, TYPE)                        \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_lt_num_##TYPE_SUFFIX, target) \
+      .SetRetType<int>()                                                     \
+      .AddInputType<cinn_buffer_t *>()                                       \
+      .AddInputType<int>()                                                   \
+      .AddInputType<TYPE>()                                                  \
+      .AddInputType<int>()                                                   \
+      .AddInputType<int>()                                                   \
       .End();
 
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_lt_num_float, target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddInputType<int>()
-      .AddInputType<float>()
-      .AddInputType<int>()
-      .AddInputType<int>()
+  _REGISTER_CINN_CUDA_LT_NUM(fp32, float);
+  _REGISTER_CINN_CUDA_LT_NUM(fp64, double);
+  _REGISTER_CINN_CUDA_LT_NUM(int32, int);
+  _REGISTER_CINN_CUDA_LT_NUM(int64, int64_t);
+
+#undef _REGISTER_CINN_CUDA_LT_NUM
+
+#define _REGISTER_CINN_CUDA_GT_NUM(TYPE_SUFFIX, TYPE)                        \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_gt_num_##TYPE_SUFFIX, target) \
+      .SetRetType<int>()                                                     \
+      .AddInputType<cinn_buffer_t *>()                                       \
+      .AddInputType<int>()                                                   \
+      .AddInputType<TYPE>()                                                  \
+      .AddInputType<int>()                                                   \
+      .AddInputType<int>()                                                   \
       .End();
 
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_gt_num_int, target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .End();
+  _REGISTER_CINN_CUDA_GT_NUM(fp32, float);
+  _REGISTER_CINN_CUDA_GT_NUM(fp64, double);
+  _REGISTER_CINN_CUDA_GT_NUM(int32, int);
+  _REGISTER_CINN_CUDA_GT_NUM(int64, int64_t);
 
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_gt_num_float, target)
-      .SetRetType<int>()
-      .AddInputType<cinn_buffer_t *>()
-      .AddInputType<int>()
-      .AddInputType<float>()
-      .AddInputType<int>()
-      .AddInputType<int>()
-      .End();
+#undef _REGISTER_CINN_CUDA_GT_NUM
 
   REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_cuda_index_add, target)
       .SetRetType<float>()

--- a/python/tests/op_mappers/test_argmax_op.py
+++ b/python/tests/op_mappers/test_argmax_op.py
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import unittest
-import numpy as np
-from op_mapper_test import OpMapperTest
 import paddle
+import unittest
+from op_mapper_test import OpMapperTest
 from cinn.frontend import *
 from cinn.common import *
-
-paddle.enable_static()
 
 
 class TestArgmaxOp(OpMapperTest):
@@ -88,6 +84,23 @@ class TestArgmaxCase2(TestArgmaxOp):
         self.axis = -1
         self.shape = [2, 3, 4]
         self.input_dtype = "float32"
+        self.output_dtype = "int32"
+        self.flatten = False
+        self.keepdims = True
+        self.feed_data = {
+            'x': self.random(self.shape, self.input_dtype),
+        }
+
+
+class TestArgmaxCase3(TestArgmaxOp):
+    """
+    Test case with input_dtype float64
+    """
+
+    def init_input_data(self):
+        self.axis = -1
+        self.shape = [2, 3, 4]
+        self.input_dtype = "float64"
         self.output_dtype = "int32"
         self.flatten = False
         self.keepdims = True

--- a/python/tests/op_mappers/test_argmin_op.py
+++ b/python/tests/op_mappers/test_argmin_op.py
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import unittest
-import numpy as np
-from op_mapper_test import OpMapperTest
 import paddle
+import unittest
+from op_mapper_test import OpMapperTest
 from cinn.frontend import *
 from cinn.common import *
-
-paddle.enable_static()
 
 
 class TestArgminOp(OpMapperTest):
@@ -88,6 +84,23 @@ class TestArgminCase2(TestArgminOp):
         self.axis = -1
         self.shape = [2, 3, 4]
         self.input_dtype = "float32"
+        self.output_dtype = "int32"
+        self.flatten = False
+        self.keepdims = True
+        self.feed_data = {
+            'x': self.random(self.shape, self.input_dtype),
+        }
+
+
+class TestArgminCase3(TestArgminOp):
+    """
+    Test case with input_dtype float64
+    """
+
+    def init_input_data(self):
+        self.axis = -1
+        self.shape = [2, 3, 4]
+        self.input_dtype = "float64"
         self.output_dtype = "int32"
         self.flatten = False
         self.keepdims = True


### PR DESCRIPTION
# argmin/argmax float64 类型输入报错

```
F0328 08:07:48.080608 588260 nvrtc_util.cc:107] Check failed: compile_res == NVRTC_SUCCESS (6 vs. 0)
default_program(21): error: argument of type "const double *" is incompatible with parameter of type "const float *"
```

错误的原因是使用了 `cinn/runtime/cuda/cinn_cuda_runtime_source.cuh` 中的函数 `cinn_cuda_lt_num_float`，float64 类型和 `cinn_cuda_lt_num_float` 函数声明的参数类型没有匹配，因此抛出了 double 和 float incompatible 的错误。

# 解决办法

添加 host/cuda intrinsics 中关于 `target_lt_num_type` 和 `target_gt_num_type` 相关的函数，支持 int32, int64, float, double 支持类型更多。

- [x] cuda intrinsics 的修改，支持 int32, int64, float, double 四种类型
- [x] host intrinsics 的修改，支持 int32, int64, float, double 四种类型
- [x] cuda intrinsics 函数注册，注册新编写的函数
- [x] host intrinsics 函数注册，注册新编写的函数
- [x] 提供相关工具方法调用
- [x] 修改调用接口的地方，改为新的名称


这个 PR 只修复了 `target_lt_num_type` 和 `target_gt_num_type`，类似的问题在 `cinn_cuda_find_int` 和 `cinn_cuda_find_int_nd` 等函数上也会出现，将会在[其他 PR 中](https://github.com/PaddlePaddle/CINN/pull/1301)修复，虽然可以通过在 op mapper 中加一个 cast 可以避免问题。