### PR TITLE
make nvrtc compile cuda-c to cubin directly

### DIFF
--- a/cinn/backends/compiler.cc
+++ b/cinn/backends/compiler.cc
@@ -123,8 +123,8 @@ void Compiler::CompileCudaModule(const Module& module, const std::string& code) 
   auto ptx = compiler(source_code);
   CHECK(!ptx.empty());
 
-  // TODO(Superjomn) Whether to support multiple CUDA modules?
-  cuda_module_.reset(new CUDAModule(ptx, CUDAModule::Kind::PTX));
+  cuda_module_.reset(
+      new CUDAModule(ptx, compiler.compile_to_cubin() ? CUDAModule::Kind::CUBIN : CUDAModule::Kind::PTX));
 
   RuntimeSymbols symbols;
 

--- a/cinn/backends/nvrtc/nvrtc_util.h
+++ b/cinn/backends/nvrtc/nvrtc_util.h
@@ -31,6 +31,8 @@ namespace nvrtc {
  */
 class Compiler {
  public:
+  Compiler();
+
   /**
    * Compile the \p code and get PTX string.
    * @param code The CUDA source code.
@@ -38,6 +40,11 @@ class Compiler {
    * @return Compiled PTX code string.
    */
   std::string operator()(const std::string& code, bool include_headers = true);
+
+  /** Compile into cubin or not
+   * @return Compile into cubin or not.
+   */
+  bool compile_to_cubin();
 
  private:
   /**
@@ -53,11 +60,16 @@ class Compiler {
   std::vector<std::string> FindCINNRuntimeIncludePaths();
 
   /**
-   * Compile CUDA source code and get PTX.
+   * Compile CUDA source code and get PTX or CUBIN.
    * @param code source code string.
-   * @return PTX string.
+   * @return PTX or CUBIN string.
    */
-  std::string CompilePTX(const std::string& code, bool include_headers);
+  std::string CompileCudaSource(const std::string& code, bool include_headers);
+
+  /**
+   * whether to compile the source code into cubin, only works with cuda version > 11.1
+   */
+  bool compile_to_cubin_{false};
 };
 
 }  // namespace nvrtc

--- a/cinn/hlir/framework/op_lowering.cc
+++ b/cinn/hlir/framework/op_lowering.cc
@@ -259,6 +259,7 @@ std::vector<Expr> OpLowerer::IRElementwiseCompute(poly::StageMap& stages,
 
   std::vector<Expr> ast_exprs;
   for (auto& node : sub_group->nodes) {
+    VLOG(4) << "Lower op: " << node->op()->name;
     auto node_data = GetNodeData(node);
     CHECK_EQ(GetAllNodeData(node).size(), 1U);
     std::vector<common::CINNValue> cinn_inputs;

--- a/cinn/hlir/framework/parallel_compiler.cc
+++ b/cinn/hlir/framework/parallel_compiler.cc
@@ -167,7 +167,7 @@ void ParallelCompiler::Task::CodegenAndJit() {
     CHECK(!ptx.empty());
 
     // load cumodule
-    cumodule.reset(new CUDAModule(ptx, CUDAModule::Kind::PTX));
+    cumodule.reset(new CUDAModule(ptx, compiler.compile_to_cubin() ? CUDAModule::Kind::CUBIN : CUDAModule::Kind::PTX));
     // register kernel
     backends::RuntimeSymbols symbols;
     for (auto& fn : dmodule.functions()) {

--- a/cinn/runtime/cuda/cuda_module.h
+++ b/cinn/runtime/cuda/cuda_module.h
@@ -36,7 +36,8 @@ namespace cuda {
 class CUDAModule {
  public:
   enum class Kind {
-    PTX = 0,
+    PTX   = 0,
+    CUBIN = 1,
   };
 
   CUDAModule(const std::string& data, Kind kind);

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -76,6 +76,10 @@ DEFINE_bool(cinn_use_dense_merge_pass,
             BoolFromEnv("FLAGS_cinn_use_dense_merge_pass", false),
             "Whether use dense merge pass.");
 
+DEFINE_bool(nvrtc_compile_to_cubin,
+            BoolFromEnv("FLAGS_nvrtc_compile_to_cubin", false),
+            "Whether nvrtc compile cuda source into cubin instead of ptx (only works after cuda-11.1).");
+
 // FLAGS for performance analysis and accuracy debug
 DEFINE_bool(cinn_sync_run,
             BoolFromEnv("FLAGS_cinn_sync_run", false),


### PR DESCRIPTION
I found there are  significant performance differences between the same cuda-c code compiled by `NVCC` and `NVRTC` for target sm_80 a100 card. And the kernel compiled by `NVCC` is 2 times faster than `NVRTC` .

The cuda-c kernel code:
```
__global__
void __launch_bounds__(1024) fn_fuse_bn_relu_kernel(const float* __restrict__ batch_norm2d_0__w_0, const float* __restrict__ batch_norm2d_0__b_0, const float* __restrict__ var_61, const float* __restrict__ var_49, const float* __restrict__ var_102, float16* __restrict__ var_125)
{
  if (((int)blockIdx.x < 100352)) {
    if (((int)threadIdx.x < 1024)) {
      var_125[((1024 * (int)blockIdx.x) + (int)threadIdx.x)] = max(((float16)(((batch_norm2d_0__w_0[((int)threadIdx.x & 63)] * ((var_49[((1024 * (int)blockIdx.x) + (int)threadIdx.x)] - var_61[((int)threadIdx.x & 63)]) / var_102[((int)threadIdx.x & 63)])) + batch_norm2d_0__b_0[((int)threadIdx.x & 63)]))), (float16)0.0000f);
    };
  };
}
```

It does elementwise compute on tensor with shape [100352, 1024],

The cost of kernel compiled by NVCC is 957us,
![image](https://user-images.githubusercontent.com/6888866/228258991-3eae0631-2dfe-4980-b540-a300115c57b1.png)

The cost of kernel compiled by NVRTC is 2.25ms
![image](https://user-images.githubusercontent.com/6888866/228259022-b145c731-5cb5-4dff-990b-e0d0b5a16c7e.png)

After further analysis, I found the the `ptx` generated by `NVCC` and `NVRTC` are nearly the same, while the `SASS` code is different. It seems `cuModuleLoadDataEx` loads the same `PTX` but generates low-performance `SASS`.

After tring many options, I don't know how to generate high-performance code using `cuModuleLoadDataEx`. 

However, I found `nvrtcCreateProgram` is able to generate CUBIN (device-related code) directly after CUDA 11.1, and its performance is equal to the kernel generated by `NVCC`.