### PR TITLE
fix resnet50 loss may random bug

### DIFF
--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -22,6 +22,12 @@ namespace cinn {
 namespace hlir {
 namespace framework {
 
+namespace utils {
+struct NodeCompare {
+  bool operator()(Node* lhs, Node* rhs) const { return lhs->id() < rhs->id(); }
+};
+}  // namespace utils
+
 std::vector<NodeData*> GetInputNodeData(const Node* node) {
   std::vector<NodeData*> producers;
   for (auto& link : node->inlinks_in_order(true)) {
@@ -298,7 +304,7 @@ std::vector<Node*> TopologicalOrder(const GroupPtr& group, const std::unordered_
   std::unordered_set<Node*> nodes_set = group->NodeSet();
 
   while (!nodes_set.empty()) {
-    auto tmp_node_set = nodes_set;
+    std::set<Node*, utils::NodeCompare> tmp_node_set(nodes_set.begin(), nodes_set.end());
     for (auto node : tmp_node_set) {
       auto consumers     = FindConsumers(node, nodes_set, virtual_consumers);
       bool cant_be_erase = false;


### PR DESCRIPTION
尝试修复Paddle中resnet50单测`test/prim/model/test_resnet_prim_cinn.py TestResnet.test_prim_cinn`的loss值可能随机的问题。问题子图为：
```
builder = NetBuilder("reduce")

batch_norm_27__tmp_1 = builder.create_input(type="float32", shape=[1024], id_hint="batch_norm_27__tmp_1")
batch_norm_26__tmp_1 = builder.create_input(type="float32", shape=[1024], id_hint="batch_norm_26__tmp_1")
var_12412 = builder.create_input(type="float32", shape=[2, 14, 14, 1024], id_hint="var_12412")
var_12408 = builder.create_input(type="float32", shape=[2, 14, 14, 1024], id_hint="var_12408")
var_12404 = builder.create_input(type="float32", shape=[2, 14, 14, 1024], id_hint="var_12404")
var_12402 = builder.create_input(type="float32", shape=[2, 14, 14, 1024], id_hint="var_12402")

var_12410 = builder.reduce_sum(var_12404, dim=[0, 1, 2], keep_dim=False)
var_12406 = builder.reduce_sum(var_12402, keep_dim=False, dim=[0, 1, 2])
var_12420 = builder.reduce_sum(var_12412, keep_dim=False, dim=[0, 1, 2])
var_12416 = builder.reduce_sum(var_12408, keep_dim=False, dim=[0, 1, 2])
var_12432 = builder.elementwise_mul(var_12420, batch_norm_26__tmp_1, axis=-1)
var_12426 = builder.elementwise_mul(var_12416, batch_norm_27__tmp_1, axis=-1)

feed_list = [batch_norm_27__tmp_1, batch_norm_26__tmp_1, var_12412, var_12408, var_12404, var_12402]
fetch_list = [var_12426, var_12432, var_12410, var_12406]
```
sheng生成的错误代码如下，该问题随机出现，大概运行4次才会出现一次：
<img width="838" alt="image" src="https://user-images.githubusercontent.com/31386411/230755601-e59fcdaf-c89b-4bbb-8ecb-4d479a796eeb.png">

但CINN python单测无法复现，在CINN单测中该子图并不会被融合为一个kernel，原因未知。