### PR TITLE
Optimize Power Call When it Can be Replaced by Sqrt or Rsqrt

### DIFF
--- a/cinn/optim/map_extern_call.cc
+++ b/cinn/optim/map_extern_call.cc
@@ -76,7 +76,7 @@ void MapExternCall(Expr *e, Target target) {
         return;
       }
       const auto &dtype = node->read_args.front().type();
-      string &name      = node->name;
+      const auto &name  = node->name;
 
       bool node_in_extern_fp32  = kExternFp32CallsGPU.count(name);
       bool node_in_extern_int32 = kExternInt32CallsGPU.count(name);


### PR DESCRIPTION
Combine with PR: https://github.com/PaddlePaddle/Paddle/pull/52712 , we speed up LayerNorm backward for 30% - 40%