### PR TITLE
add FLAGS_cinn_pass_visualize_dir

### DIFF
--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -112,7 +112,7 @@ std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
                                                  const std::unordered_set<std::string>& fetch_ids,
                                                  common::Target target,
                                                  const OptimizeOptions& options) {
-  cinn::hlir::framework::PassPrinter::GetInstance()->Start();
+  cinn::hlir::framework::PassPrinter::GetInstance()->Begin();
   // Apply program passes
   VLOG(3) << "Before frontend::ProgramPass::Apply";
   frontend::ProgramPass::Apply(program, fetch_ids, target, options.program_passes);

--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -25,6 +25,7 @@
 #include "cinn/frontend/syntax.h"
 #include "cinn/hlir/framework/graph.h"
 #include "cinn/hlir/framework/pass.h"
+#include "cinn/hlir/framework/visualize_helper.h"
 #include "cinn/hlir/pass/use_pass.h"
 
 DECLARE_bool(cinn_use_fill_constant_folding);
@@ -111,6 +112,7 @@ std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
                                                  const std::unordered_set<std::string>& fetch_ids,
                                                  common::Target target,
                                                  const OptimizeOptions& options) {
+  cinn::hlir::framework::PassPrinter::GetInstance()->Start();
   // Apply program passes
   VLOG(3) << "Before frontend::ProgramPass::Apply";
   frontend::ProgramPass::Apply(program, fetch_ids, target, options.program_passes);
@@ -119,6 +121,7 @@ std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
 
   VLOG(3) << "Before hlir::framework::ApplyPasses";
   hlir::framework::ApplyPasses(graph.get(), options.graph_passes);
+  cinn::hlir::framework::PassPrinter::GetInstance()->End();
   return graph;
 }
 }  // namespace frontend

--- a/cinn/frontend/pass/auto_cast.cc
+++ b/cinn/frontend/pass/auto_cast.cc
@@ -219,8 +219,6 @@ class AutoCastPass : public ProgramPass {
   void ApplyImpl(Program* program,
                  const std::unordered_set<std::string>& fetch_ids,
                  const common::Target& target) override {
-    VLOG(3) << "Before AutoCastPass: " << *program;
-
     NetBuilder builder("auto_cast_builder");
     for (auto& var : program->GetInputs()) {
       builder.CreateInput(var);
@@ -235,7 +233,6 @@ class AutoCastPass : public ProgramPass {
       }
     }
     *program = builder.Build();
-    VLOG(3) << "After AutoCastPass: " << *program;
   }
 
   void Clear() override {}

--- a/cinn/frontend/pass/cast_collapsing.cc
+++ b/cinn/frontend/pass/cast_collapsing.cc
@@ -59,7 +59,6 @@ class CastCollapsingPass : public ProgramPass {
   void ApplyImpl(Program* program,
                  const std::unordered_set<std::string>& fetch_ids,
                  const common::Target& target) const override {
-    VLOG(3) << "-- Before CastCollapsingPass:\n" << *program;
     // `out2instr` is used to represent the mapping of Output to Instruction.
     OutputToOpMap out2instr;
     // `in2instr` is used to represent the mapping of Input to Instruction.
@@ -104,7 +103,6 @@ class CastCollapsingPass : public ProgramPass {
       }
     }
     *program = builder.Build();
-    VLOG(3) << "-- After CastCollapsingPass:\n" << *program;
   }
 
  private:

--- a/cinn/frontend/pass/fill_constant_rewriter.cc
+++ b/cinn/frontend/pass/fill_constant_rewriter.cc
@@ -142,7 +142,6 @@ class FillConstantRewriterPass : public ProgramPass {
   void ApplyImpl(Program* program,
                  const std::unordered_set<std::string>& fetch_ids,
                  const common::Target& target) override {
-    VLOG(3) << "Before FillConstantRewriterPass:\n" << *program;
     auto input2instr = GetInput2Instr(program);
 
     std::unordered_set<const Instruction*> remove_instr;
@@ -168,8 +167,6 @@ class FillConstantRewriterPass : public ProgramPass {
       }
     }
     *program = builder.Build();
-
-    VLOG(3) << "After FillConstantRewriterPass:\n" << *program;
   }
 
  private:

--- a/cinn/frontend/pass/gemm_rewriter.cc
+++ b/cinn/frontend/pass/gemm_rewriter.cc
@@ -44,8 +44,6 @@ class GemmRewriterPass : public ProgramPass {
       return;
     }
 
-    VLOG(4) << "-- Before rewriting: " << *prog;
-
     CollectInfo(*prog);
 
     NetBuilder builder("gemm_rewriter_builder");
@@ -79,7 +77,6 @@ class GemmRewriterPass : public ProgramPass {
         }
       }
     }
-    VLOG(4) << "-- After rewriting: " << *prog;
     ClearResources();
   }
 

--- a/cinn/frontend/pass/remove_identity.cc
+++ b/cinn/frontend/pass/remove_identity.cc
@@ -134,7 +134,6 @@ class RemoveIdentityPass : public ProgramPass {
                  const common::Target& target) override {
     CollectInfo(*program, fetch_ids);
 
-    VLOG(3) << "Before RemoveIdentityPass: " << *program;
     VLOG(3) << "Total remove " << remove_idxs_.size() << " instructions.";
 
     NetBuilder builder("remove_identity_builder");
@@ -179,7 +178,6 @@ class RemoveIdentityPass : public ProgramPass {
       builder.AppendInstruction(instr);
     }
     *program = builder.Build();
-    VLOG(3) << "After RemoveIdentityPass: " << *program;
   }
 
   void Clear() override {

--- a/cinn/frontend/pass/transpose_collapsing.cc
+++ b/cinn/frontend/pass/transpose_collapsing.cc
@@ -69,7 +69,6 @@ class TransposeCollapsingPass : public ProgramPass {
   void ApplyImpl(Program* program,
                  const std::unordered_set<std::string>& fetch_ids,
                  const common::Target& target) const override {
-    VLOG(3) << "-- Before TransposeCollapsingPass:\n" << *program;
     // `out2instr` is used to represent the mapping of Output to Instruction.
     OutputToOpMap out2instr;
     // `in2instr` is used to represent the mapping of Input to Instruction.
@@ -114,7 +113,6 @@ class TransposeCollapsingPass : public ProgramPass {
       }
     }
     *program = builder.Build();
-    VLOG(3) << "-- After TransposeCollapsingPass:\n" << *program;
   }
 
  private:

--- a/cinn/frontend/pass/transpose_folding_base.h
+++ b/cinn/frontend/pass/transpose_folding_base.h
@@ -47,7 +47,6 @@ class TransposeFoldingBase : public ProgramPass {
   void ApplyImpl(Program* program,
                  const std::unordered_set<std::string>& fetch_ids,
                  const common::Target& target) override {
-    VLOG(4) << "-- Before folding: " << *program;
     set_target_instrs();
     set_fold_instrs();
     set_skip_instrs();
@@ -84,7 +83,6 @@ class TransposeFoldingBase : public ProgramPass {
       }
     }
     *program = builder.Build();
-    VLOG(4) << "-- After folding: " << *program;
   }
 
   // get can fold instruction in order, more front, more near from dot op

--- a/cinn/frontend/program_pass.cc
+++ b/cinn/frontend/program_pass.cc
@@ -32,7 +32,7 @@ void ProgramPass::Apply(Program* prog,
   }
   for (const auto* pass : fpass) {
     int before = prog->size();
-    cinn::hlir::framework::PassPrinter::GetInstance()->PassStart(pass->name(), *prog);
+    cinn::hlir::framework::PassPrinter::GetInstance()->PassBegin(pass->name(), *prog);
     pass->ApplyImpl(prog, fetch_ids, target);
     const_cast<ProgramPass*>(pass)->Clear();
     int after = prog->size();

--- a/cinn/frontend/program_pass.cc
+++ b/cinn/frontend/program_pass.cc
@@ -16,6 +16,8 @@
 
 #include <unordered_set>
 
+#include "cinn/hlir/framework/visualize_helper.h"
+
 namespace cinn {
 namespace frontend {
 
@@ -30,10 +32,11 @@ void ProgramPass::Apply(Program* prog,
   }
   for (const auto* pass : fpass) {
     int before = prog->size();
-    VLOG(1) << "Before ApplyPass: " << pass->name();
+    cinn::hlir::framework::PassPrinter::GetInstance()->PassStart(pass->name(), *prog);
     pass->ApplyImpl(prog, fetch_ids, target);
     const_cast<ProgramPass*>(pass)->Clear();
     int after = prog->size();
+    cinn::hlir::framework::PassPrinter::GetInstance()->PassEnd(pass->name(), *prog);
     VLOG(1) << "Apply " << pass->name() << " pass, program size: " << before << " -> " << after
             << ", diff: " << after - before;
   }

--- a/cinn/hlir/framework/graph.cc
+++ b/cinn/hlir/framework/graph.cc
@@ -299,8 +299,8 @@ void Graph::VisualizeGroupedGraph(const std::vector<std::vector<Node*>>& groups,
   WriteToFile(viz_path_ + "grouped_graph.dot", VisualizeGraph(groups, fetch_var_ids));
 
   const auto& group_dots = VisualizeGroups(groups, fetch_var_ids);
-  for (int group_id = 1; group_id < group_dots.size(); ++group_id) {
-    WriteToFile(GetFilePathForGroup(groups, group_id - 1, viz_path_), group_dots[group_id]);
+  for (int i = 0; i < group_dots.size(); ++i) {
+    WriteToFile(GetFilePathForGroup(groups, i, viz_path_), group_dots[i]);
   }
 }
 

--- a/cinn/hlir/framework/graph.h
+++ b/cinn/hlir/framework/graph.h
@@ -180,14 +180,14 @@ class Graph : public cinn::common::Graph {
    * \brief Debug the grouped graph according to fusion_groups.
    */
   std::string DebugGroupedGraph(const std::unordered_set<std::string>& fetch_var_ids = {});
-
-  /**
-   * \brief Debug the grouped graph according to user specified groups.
-   */
   std::string DebugGroupedGraph(const std::vector<Node*>& group,
                                 const std::unordered_set<std::string>& fetch_var_ids = {});
-  std::string DebugGroupedGraph(const std::vector<std::vector<Node*>>& groups,
-                                const std::unordered_set<std::string>& fetch_var_ids = {});
+
+  /**
+   * \brief Debug the grouped graph with GraphViz dot format according to fusion_groups.
+   */
+  std::string VisualizeGraph(const std::unordered_set<std::string>& fetch_var_ids = {});
+  std::vector<std::string> VisualizeGroups(const std::unordered_set<std::string>& fetch_var_ids = {});
 
   /**
    * \brief Genereate the python test code for group test
@@ -207,8 +207,14 @@ class Graph : public cinn::common::Graph {
                              const std::unordered_set<std::string>& fetch_var_ids = {});
 
  private:
-  void VisualizeGroups(const std::vector<std::vector<Node*>>& groups,
-                       const std::unordered_set<std::string>& fetch_var_ids = {});
+  std::string DebugGroupedGraph(const std::vector<std::vector<Node*>>& groups,
+                                const std::unordered_set<std::string>& fetch_var_ids = {});
+
+  std::string VisualizeGraph(const std::vector<std::vector<Node*>>& groups,
+                             const std::unordered_set<std::string>& fetch_var_ids = {});
+
+  std::vector<std::string> VisualizeGroups(const std::vector<std::vector<Node*>>& groups,
+                                           const std::unordered_set<std::string>& fetch_var_ids = {});
 
   std::vector<std::vector<Node*>> FusionGroupsToGroups();
 

--- a/cinn/hlir/framework/pass.cc
+++ b/cinn/hlir/framework/pass.cc
@@ -14,6 +14,7 @@
 
 #include "cinn/hlir/framework/pass.h"
 
+#include "cinn/hlir/framework/visualize_helper.h"
 #include "cinn/hlir/pass/use_pass.h"
 
 namespace cinn {
@@ -29,6 +30,7 @@ void ApplyPasses(Graph* g, const std::vector<std::string>& passes) {
     fpass.push_back(reg);
   }
   for (auto* r : fpass) {
+    cinn::hlir::framework::PassPrinter::GetInstance()->PassStart(r->name, g);
     for (auto& dep : r->graph_attr_dependency) {
       CHECK_NE(g->attrs.count(dep), 0) << "To apply pass [" << r->name << "], Graph's attribute [" << dep
                                        << "] is required, but it is not available.";
@@ -38,6 +40,7 @@ void ApplyPasses(Graph* g, const std::vector<std::string>& passes) {
       }
     }
     r->body(g);
+    cinn::hlir::framework::PassPrinter::GetInstance()->PassEnd(r->name, g);
   }
 }
 

--- a/cinn/hlir/framework/pass.cc
+++ b/cinn/hlir/framework/pass.cc
@@ -30,7 +30,7 @@ void ApplyPasses(Graph* g, const std::vector<std::string>& passes) {
     fpass.push_back(reg);
   }
   for (auto* r : fpass) {
-    cinn::hlir::framework::PassPrinter::GetInstance()->PassStart(r->name, g);
+    cinn::hlir::framework::PassPrinter::GetInstance()->PassBegin(r->name, g);
     for (auto& dep : r->graph_attr_dependency) {
       CHECK_NE(g->attrs.count(dep), 0) << "To apply pass [" << r->name << "], Graph's attribute [" << dep
                                        << "] is required, but it is not available.";

--- a/cinn/hlir/framework/visualize_helper.cc
+++ b/cinn/hlir/framework/visualize_helper.cc
@@ -34,7 +34,7 @@ namespace cinn {
 namespace hlir {
 namespace framework {
 
-bool PassPrinter::Start() {
+bool PassPrinter::Begin() {
   if (FLAGS_cinn_pass_visualize_dir.empty()) {
     VLOG(3) << "No set \"FLAGS_cinn_pass_visualize_dir\", the pass visualize information will print directly.";
     save_path_.clear();
@@ -53,7 +53,7 @@ bool PassPrinter::Start() {
   return true;
 }
 
-bool PassPrinter::PassStart(const std::string& pass_name, const frontend::Program& program) {
+bool PassPrinter::PassBegin(const std::string& pass_name, const frontend::Program& program) {
   const auto& program_info = utils::GetStreamCnt(program);
   if (save_path_.empty()) {
     VLOG(3) << "Before " << pass_name << " Pass:\n" << program_info;
@@ -79,7 +79,7 @@ bool PassPrinter::PassEnd(const std::string& pass_name, const frontend::Program&
   return true;
 }
 
-bool PassPrinter::PassStart(const std::string& pass_name, Graph* g) {
+bool PassPrinter::PassBegin(const std::string& pass_name, Graph* g) {
   const auto& graph_info = g->DebugGroupedGraph();
   if (save_path_.empty()) {
     VLOG(3) << "Before " << pass_name << " Pass:\n" << graph_info;
@@ -88,6 +88,11 @@ bool PassPrinter::PassStart(const std::string& pass_name, Graph* g) {
   const std::string& file_path =
       utils::StringFormat("%s/pass_%d_%s_before.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
   WriteToFile(file_path, graph_info);
+
+  const auto& dot_info = g->VisualizeGraph();
+  const std::string& dot_path =
+      utils::StringFormat("%s/pass_%d_%s_before.dot", save_path_.c_str(), pass_id_, pass_name.c_str());
+  WriteToFile(dot_path, dot_info);
   return true;
 }
 
@@ -100,6 +105,11 @@ bool PassPrinter::PassEnd(const std::string& pass_name, Graph* g) {
   const std::string& file_path =
       utils::StringFormat("%s/pass_%d_%s_after.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
   WriteToFile(file_path, graph_info);
+
+  const auto& dot_info = g->VisualizeGraph();
+  const std::string& dot_path =
+      utils::StringFormat("%s/pass_%d_%s_after.dot", save_path_.c_str(), pass_id_, pass_name.c_str());
+  WriteToFile(dot_path, dot_info);
 
   ++pass_id_;
   return true;

--- a/cinn/hlir/framework/visualize_helper.cc
+++ b/cinn/hlir/framework/visualize_helper.cc
@@ -29,9 +29,86 @@
 #include "cinn/utils/dot_lang.h"
 #include "cinn/utils/string.h"
 
+DECLARE_string(cinn_pass_visualize_dir);
 namespace cinn {
 namespace hlir {
 namespace framework {
+
+bool PassPrinter::Start() {
+  if (FLAGS_cinn_pass_visualize_dir.empty()) {
+    VLOG(3) << "No set \"FLAGS_cinn_pass_visualize_dir\", the pass visualize information will print directly.";
+    save_path_.clear();
+    return false;
+  }
+  pass_id_ = 0;
+
+  save_path_ = utils::StringFormat("%s/fusion_groups_%d/", FLAGS_cinn_pass_visualize_dir.c_str(), graph_id_);
+  if (!MakeDirectory(save_path_, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)) {
+    LOG_IF(WARNING, graph_id_ == 0) << "Failed to make directory: \"" << save_path_
+                                    << "\", the CINN subgraph's pass visualize information will not print.";
+    return false;
+  }
+  LOG_IF(INFO, graph_id_ == 0) << "The CINN subgraph's pass visualize information will writing into path: \""
+                               << FLAGS_cinn_pass_visualize_dir << "\"";
+  return true;
+}
+
+bool PassPrinter::PassStart(const std::string& pass_name, const frontend::Program& program) {
+  const auto& program_info = utils::GetStreamCnt(program);
+  if (save_path_.empty()) {
+    VLOG(3) << "Before " << pass_name << " Pass:\n" << program_info;
+    return false;
+  }
+  const std::string& file_path =
+      utils::StringFormat("%s/pass_%d_%s_before.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
+  WriteToFile(file_path, program_info);
+  return true;
+}
+
+bool PassPrinter::PassEnd(const std::string& pass_name, const frontend::Program& program) {
+  const auto& program_info = utils::GetStreamCnt(program);
+  if (save_path_.empty()) {
+    VLOG(3) << "After " << pass_name << " Pass:\n" << program_info;
+    return false;
+  }
+  const std::string& file_path =
+      utils::StringFormat("%s/pass_%d_%s_after.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
+  WriteToFile(file_path, program_info);
+
+  ++pass_id_;
+  return true;
+}
+
+bool PassPrinter::PassStart(const std::string& pass_name, Graph* g) {
+  const auto& graph_info = g->DebugGroupedGraph();
+  if (save_path_.empty()) {
+    VLOG(3) << "Before " << pass_name << " Pass:\n" << graph_info;
+    return false;
+  }
+  const std::string& file_path =
+      utils::StringFormat("%s/pass_%d_%s_before.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
+  WriteToFile(file_path, graph_info);
+  return true;
+}
+
+bool PassPrinter::PassEnd(const std::string& pass_name, Graph* g) {
+  const auto& graph_info = g->DebugGroupedGraph();
+  if (save_path_.empty()) {
+    VLOG(3) << "After " << pass_name << " Pass:\n" << graph_info;
+    return false;
+  }
+  const std::string& file_path =
+      utils::StringFormat("%s/pass_%d_%s_after.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
+  WriteToFile(file_path, graph_info);
+
+  ++pass_id_;
+  return true;
+}
+
+bool PassPrinter::End() {
+  ++graph_id_;
+  return true;
+}
 
 bool MakeDirectory(const std::string& dirname, mode_t mode) {
   auto len = dirname.length();

--- a/cinn/hlir/framework/visualize_helper.h
+++ b/cinn/hlir/framework/visualize_helper.h
@@ -25,12 +25,33 @@
 #include <unordered_map>
 #include <vector>
 
+#include "cinn/frontend/syntax.h"
 #include "cinn/hlir/framework/graph.h"
 #include "cinn/utils/dot_lang.h"
 
 namespace cinn {
 namespace hlir {
 namespace framework {
+
+class PassPrinter {
+ public:
+  static PassPrinter* GetInstance() {
+    static PassPrinter printer;
+    return &printer;
+  }
+
+  bool Start();
+  bool PassStart(const std::string& pass_name, const frontend::Program& program);
+  bool PassEnd(const std::string& pass_name, const frontend::Program& program);
+  bool PassStart(const std::string& pass_name, Graph* g);
+  bool PassEnd(const std::string& pass_name, Graph* g);
+  bool End();
+
+ private:
+  std::string save_path_;
+  int64_t graph_id_{0};
+  int64_t pass_id_{0};
+};
 
 inline void WriteToFile(const std::string& filepath, const std::string& content) {
   VLOG(4) << "Write to " << filepath;

--- a/cinn/hlir/framework/visualize_helper.h
+++ b/cinn/hlir/framework/visualize_helper.h
@@ -40,10 +40,10 @@ class PassPrinter {
     return &printer;
   }
 
-  bool Start();
-  bool PassStart(const std::string& pass_name, const frontend::Program& program);
+  bool Begin();
+  bool PassBegin(const std::string& pass_name, const frontend::Program& program);
   bool PassEnd(const std::string& pass_name, const frontend::Program& program);
-  bool PassStart(const std::string& pass_name, Graph* g);
+  bool PassBegin(const std::string& pass_name, Graph* g);
   bool PassEnd(const std::string& pass_name, Graph* g);
   bool End();
 

--- a/cinn/hlir/pass/check_fusion_accuracy_pass.cc
+++ b/cinn/hlir/pass/check_fusion_accuracy_pass.cc
@@ -514,13 +514,7 @@ GroupList CheckFusionAccuracyPass::Apply() {
   return check_fusion_groups;
 }
 
-void CheckFusionAccuracyPassImpl(Graph* graph) {
-  VLOG(3) << "Before CheckFusionAccuracyPass:\n" << graph->DebugGroupedGraph();
-
-  graph->fusion_groups = CheckFusionAccuracyPass(graph).Apply();
-
-  VLOG(3) << "After CheckFusionAccuracyPass:\n" << graph->DebugGroupedGraph();
-}
+void CheckFusionAccuracyPassImpl(Graph* graph) { graph->fusion_groups = CheckFusionAccuracyPass(graph).Apply(); }
 
 }  // namespace cinn::hlir::pass
 

--- a/cinn/hlir/pass/check_fusion_accuracy_pass.cc
+++ b/cinn/hlir/pass/check_fusion_accuracy_pass.cc
@@ -474,7 +474,7 @@ GroupList CheckFusionAccuracyPass::Apply() {
 
     // split orign group and create group for each node
     const auto& ordered_nodes = TopologicalOrder(group_nodes);
-    VLOG(4) << "Check the accuracy of group " << graph_->DebugGroupedGraph({ordered_nodes});
+    VLOG(4) << "Check the accuracy of group " << graph_->DebugGroupedGraph(ordered_nodes);
 
     for (auto* node : ordered_nodes) {
       if (node->is_variable()) {
@@ -503,7 +503,7 @@ GroupList CheckFusionAccuracyPass::Apply() {
     msg.SetMsg("Group id", group->unique_id);
     msg.SetMsg("Input list", input_list);
     msg.SetMsg("Output list", output_list);
-    msg.SetMsg("Group graph", graph_->DebugGroupedGraph({ordered_nodes}));
+    msg.SetMsg("Group graph", graph_->DebugGroupedGraph(ordered_nodes));
 
     LOG(INFO) << msg.str();
 

--- a/cinn/hlir/pass/common_subexpression_elimination.cc
+++ b/cinn/hlir/pass/common_subexpression_elimination.cc
@@ -222,7 +222,7 @@ void CommonSubexpressionElimination(Graph* graph, std::vector<GraphNode*> store_
   while (!store_nodes.empty()) {
     auto* graph_node = store_nodes[0];
     store_nodes.erase(store_nodes.begin());
-    LOG(INFO) << "size of store_nodes is " << store_nodes.size();
+    VLOG(4) << "size of store_nodes is " << store_nodes.size();
     auto node = graph_node->safe_as<Node>();
     if (node) {
       auto& node_type  = node->op()->name;
@@ -260,7 +260,7 @@ void CommonSubexpressionElimination(Graph* graph, std::vector<GraphNode*> store_
           }
         }
         remove_nodes.push_back(node);
-        LOG(INFO) << "remove " << node->id() << " node.";
+        VLOG(4) << "remove " << node->id() << " node.";
         break;
       }
       if (!found) {

--- a/cinn/hlir/pass/fusion_merge_pass.cc
+++ b/cinn/hlir/pass/fusion_merge_pass.cc
@@ -927,7 +927,6 @@ class FusionMergePassHelper : public FusionHelperBase {
 };
 
 void FusionMergePassInternal(Graph* graph) {
-  VLOG(3) << "Before FusionMergePass:\n" << graph->DebugGroupedGraph(std::unordered_set<std::string>{});
   if (graph->fusion_groups.size() <= 1) {
     VLOG(3) << "Don't do Fusoin Merge Pass...!";
     return;
@@ -935,7 +934,6 @@ void FusionMergePassInternal(Graph* graph) {
 
   FusionMergePassHelper fusion_merge_pass_helper(graph);
   graph->fusion_groups = fusion_merge_pass_helper();
-  VLOG(3) << "After FusionMergePass:\n" << graph->DebugGroupedGraph(std::unordered_set<std::string>{});
 }
 
 }  // namespace pass

--- a/cinn/hlir/pass/reduce_split_pass.cc
+++ b/cinn/hlir/pass/reduce_split_pass.cc
@@ -182,10 +182,8 @@ class ReduceSplitPass {
 }  // namespace
 
 void ReduceSplitFunc(framework::Graph* graph) {
-  VLOG(3) << "Before ReduceSplitPass:\n" << graph->DebugGroupedGraph(std::unordered_set<std::string>{}) << std::endl;
   int n = ReduceSplitPass::Apply(graph);
   VLOG(3) << "ReduceSplit was performed " << n << " times.";
-  VLOG(3) << "After ReduceSplitPass:\n" << graph->DebugGroupedGraph(std::unordered_set<std::string>{}) << std::endl;
 }
 
 }  // namespace pass

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -194,7 +194,7 @@ void BindFrontend(pybind11::module *m) {
 
             std::shared_ptr<hlir::framework::Graph> graph;
             if (!passes.empty()) {
-              cinn::hlir::framework::PassPrinter::GetInstance()->Start();
+              cinn::hlir::framework::PassPrinter::GetInstance()->Begin();
               frontend::ProgramPass::Apply(&self, fetch_ids, target, program_passes);
               graph = std::make_shared<hlir::framework::Graph>(self, fetch_ids, target);
               hlir::framework::ApplyPasses(graph.get(), graph_passes);

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -32,6 +32,7 @@
 #include "cinn/hlir/framework/graph_compiler.h"
 #include "cinn/hlir/framework/pass.h"
 #include "cinn/hlir/framework/tensor.h"
+#include "cinn/hlir/framework/visualize_helper.h"
 #include "cinn/hlir/op/use_ops.h"
 #include "cinn/pybind/bind.h"
 #include "cinn/utils/string.h"
@@ -193,9 +194,11 @@ void BindFrontend(pybind11::module *m) {
 
             std::shared_ptr<hlir::framework::Graph> graph;
             if (!passes.empty()) {
+              cinn::hlir::framework::PassPrinter::GetInstance()->Start();
               frontend::ProgramPass::Apply(&self, fetch_ids, target, program_passes);
               graph = std::make_shared<hlir::framework::Graph>(self, fetch_ids, target);
               hlir::framework::ApplyPasses(graph.get(), graph_passes);
+              cinn::hlir::framework::PassPrinter::GetInstance()->End();
             } else {
               graph = Optimize(&self, fetch_ids, target);
             }

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -101,6 +101,10 @@ DEFINE_string(cinn_source_code_save_path,
               StringFromEnv("FLAGS_cinn_source_code_save_path", ""),
               "Specify the directory path of generated source code, which is used for debug.");
 
+DEFINE_string(cinn_pass_visualize_dir,
+              StringFromEnv("FLAGS_cinn_pass_visualize_dir", ""),
+              "Specify the directory path of pass visualize file of graph, which is used for debug.");
+
 DEFINE_bool(enable_auto_tuner, BoolFromEnv("FLAGS_enable_auto_tuner", false), "Whether enable auto tuner.");
 
 DEFINE_bool(auto_schedule_use_cost_model,


### PR DESCRIPTION
增加`FLAGS_cinn_pass_visualize_dir`用于保存Pass优化前后的图结构。

该FLAG用于将CINN内Pass前后的program or graph保存到fusion_groups_*目录下，比如若指定文件夹为./cinn_pass，则会保存到cinn_pass/fusion_groups_*目录下。
![image](https://user-images.githubusercontent.com/31386411/231631406-5d9f8a79-f2b9-4a4a-a8a5-82d6378f18aa.png)
生成的文件名含义从左至右依次为：
1. pass字符串前缀
2. pass序号，也是实际执行时的序号，比如图中AutoCastPass就是第一个执行，Decomposer紧随其后
3. pass名称
4. 文件是在pass之前还是之后生成的，before表示之前，after表示之后

CINN内的pass分为Program Pass和Graph Pass，上图示例中是Program Pass。而Graph Pass还会生成额外的graphviz格式文件用于图结构可视化（即图中的.dot文件）：
![image](https://user-images.githubusercontent.com/31386411/231631426-f2cded98-9beb-47a4-b0c2-98b569e19a82.png)
