### PR TITLE
fix group schedule in elementwise-reduce fusion

### DIFF
--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -270,6 +270,7 @@ std::unordered_map<Node*, Node*> BuildVirtualConsumer(const GroupPtr& group,
           virtual_consumers[t_node] = reducer;
           break;
         }
+        candidates.push(producer);
         visited.insert(producer);
       }
       // if find horizontal reducer.


### PR DESCRIPTION
修复reduce group中element-wise node在ComputeAt时未能寻找正确Master node的问题，导致生成代码计算语义错误，比如下图中`elementwise_mul_16`节点修复前master node是`reshape_24`，但实际上它需要ComputeAt到`reduce_sum_21`，即为master node
<img width="467" alt="image" src="https://user-images.githubusercontent.com/20067404/231447798-fd7cbbd6-d1a1-469b-b99b-2c93d24375db.png">
