### PR TITLE
change the default value to 'true' of some flags

### DIFF
--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -72,14 +72,14 @@ DEFINE_bool(cinn_ir_schedule,
             BoolFromEnv("FLAGS_cinn_ir_schedule", true),
             "Whether use reconstructed schedule primitives.");
 
-DEFINE_bool(use_reduce_split_pass, BoolFromEnv("FLAGS_use_reduce_split_pass", false), "Whether use reduce split pass.");
+DEFINE_bool(use_reduce_split_pass, BoolFromEnv("FLAGS_use_reduce_split_pass", true), "Whether use reduce split pass.");
 
 DEFINE_bool(cinn_use_dense_merge_pass,
             BoolFromEnv("FLAGS_cinn_use_dense_merge_pass", false),
             "Whether use dense merge pass.");
 
 DEFINE_bool(nvrtc_compile_to_cubin,
-            BoolFromEnv("FLAGS_nvrtc_compile_to_cubin", false),
+            BoolFromEnv("FLAGS_nvrtc_compile_to_cubin", true),
             "Whether nvrtc compile cuda source into cubin instead of ptx (only works after cuda-11.1).");
 
 // FLAGS for performance analysis and accuracy debug


### PR DESCRIPTION
change the following flags to 'true' to get better performance:
FLAGS_use_reduce_split_pass
FLAGS_nvrtc_compile_to_cubin
