### PR TITLE
disable auto_tuner_test temporarily

### DIFF
--- a/cinn/auto_schedule/CMakeLists.txt
+++ b/cinn/auto_schedule/CMakeLists.txt
@@ -15,7 +15,7 @@ core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS auto_tuner.cc)
 
-cc_test(test_auto_tuner SRCS auto_tuner_test.cc DEPS cinncore)
+#cc_test(test_auto_tuner SRCS auto_tuner_test.cc DEPS cinncore)
 
 foreach(header ${auto_schedule_proto_HDRS})
   set(core_proto_includes "${core_proto_includes};${header}" CACHE INTERNAL "")


### PR DESCRIPTION
目前test_auto_tuner在ci流水线会出现随机挂的现象，目前线下还无法复现，先禁用以避免影响正常开发，同步跟进修复