### PR TITLE
remove useless FLAGS_cinn_use_cublas_gemm flag

### DIFF
--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -41,8 +41,6 @@ DEFINE_int32(cinn_parallel_compile_size,
 
 DEFINE_bool(cinn_use_op_fusion, BoolFromEnv("FLAGS_cinn_use_op_fusion", true), "Whether to use op fusion pass.");
 
-DEFINE_bool(cinn_use_cublas_gemm, BoolFromEnv("FLAGS_cinn_use_cublas_gemm", true), "Whether to use cublas gemm.");
-
 DEFINE_bool(cinn_use_common_subexpression_elimination,
             BoolFromEnv("FLAGS_cinn_use_common_subexpression_elimination", false),
             "Whether to use common subexpression elimination pass.");


### PR DESCRIPTION
现`gemm`是否走cublas的逻辑不再是由`FLAGS_cinn_use_cublas_gemm`控制的，而是由`FLAGS_cinn_use_custom_call`和`FLAGS_cinn_custom_call_deny_ops` 进行控制。本PR移除了无用的`FLAGS_cinn_use_cublas_gemm`flag，并修改了相关逻辑。