### PR TITLE
feat(reduction): support warp reduce

### DIFF
--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -11,13 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "cinn/common/target.h"
+#ifdef CINN_WITH_CUDA
+#include <cuda_runtime_api.h>
+#include <driver_types.h>
+#endif
 
 #include <glog/logging.h>
 
 #include <sstream>
 
+#include "cinn/common/target.h"
 #include "cinn/runtime/cinn_runtime.h"
 
 namespace cinn {
@@ -47,6 +50,20 @@ int Target::runtime_arch() const {
 int Target::max_num_threads() const {
   CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max number of threads.";
   return 1024;
+}
+
+int Target::get_multi_processor_count() const {
+  CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get multi processor count";
+  int num_sm = 0;
+  cudaDeviceGetAttribute(&num_sm, cudaDeviceAttr::cudaDevAttrMultiProcessorCount, 0);
+  return num_sm;
+}
+
+int Target::get_max_threads_per_sm() const {
+  CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max threads per stream processor";
+  int max_thread = 0;
+  cudaDeviceGetAttribute(&max_thread, cudaDeviceAttr::cudaDevAttrMaxThreadsPerMultiProcessor, 0);
+  return max_thread;
 }
 
 std::vector<Target::Lib> Target::get_target_libs() const { return libs; }

--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -55,14 +55,18 @@ int Target::max_num_threads() const {
 int Target::get_multi_processor_count() const {
   CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get multi processor count";
   int num_sm = 0;
+#ifdef CINN_WITH_CUDA
   cudaDeviceGetAttribute(&num_sm, cudaDeviceAttr::cudaDevAttrMultiProcessorCount, 0);
+#endif
   return num_sm;
 }
 
 int Target::get_max_threads_per_sm() const {
   CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max threads per stream processor";
   int max_thread = 0;
+#ifdef CINN_WITH_CUDA
   cudaDeviceGetAttribute(&max_thread, cudaDeviceAttr::cudaDevAttrMaxThreadsPerMultiProcessor, 0);
+#endif
   return max_thread;
 }
 

--- a/cinn/common/target.h
+++ b/cinn/common/target.h
@@ -80,6 +80,10 @@ struct Target {
 
   int max_num_threads() const;
 
+  int get_multi_processor_count() const;
+
+  int get_max_threads_per_sm() const;
+
   int get_target_bits() const;
 
   std::vector<Lib> get_target_libs() const;

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -114,7 +114,14 @@ Variable NetBuilder::Reduce(const std::string& op_type, const Variable& x, const
       return Reshape(x, new_shape);
     }
   }
-  return CustomInstr(op_type, {x}, {{"dim", dim}, {"keep_dim", keep_dim}}).front();
+  // Convert the negative dim to a positive number
+  std::vector<int> reduce_dim(dim.begin(), dim.end());
+  for (int i = 0; i < dim.size(); i++) {
+    if (reduce_dim[i] < 0) {
+      reduce_dim[i] = x->shape.size() + reduce_dim[i];
+    }
+  }
+  return CustomInstr(op_type, {x}, {{"dim", reduce_dim}, {"keep_dim", keep_dim}}).front();
 }
 
 #define NETBUILDER_UNARY_OP_DEF(func_name__, op_type__) \

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -1171,6 +1171,75 @@ TEST(OP_LOWERING, Reduce_Fusion_Test_21) {
   Compile(net_builder);
 }
 
+TEST(OpFusionPass, Block_Reduce_Fuse_Broadcast) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold - 10;
+  int w                     = 256;
+  NetBuilder net_builder("Block_Reduce_Fuse_Broadcast");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.ReduceSum(A, {1}, true);
+    auto C = net_builder.BroadcastTo(B, {h, w}, {0, 1});
+  }
+
+  Compile(net_builder);
+}
+
+TEST(OpFusionPass, Block_Reduce_Fuse_Elementwise) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold - 10;
+  int w                     = 256;
+  NetBuilder net_builder("Block_Reduce_Fuse_Elementwise");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {h}, "B");
+    auto C = net_builder.ReduceSum(A, {1}, true);
+    auto D = net_builder.Add(B, C);
+  }
+
+  Compile(net_builder);
+}
+TEST(OpFusionPass, Warp_Reduce_Fuse_Broadcast) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold + 10;
+  int w                     = 256;
+  NetBuilder net_builder("Warp_Reduce_Fuse_Broadcast");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.ReduceSum(A, {1}, true);
+    auto C = net_builder.BroadcastTo(B, {h, w}, {0, 1});
+  }
+
+  Compile(net_builder);
+}
+
+TEST(OpFusionPass, Warp_Reduce_Fuse_Elementwise) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold + 10;
+  int w                     = 256;
+  NetBuilder net_builder("Warp_Reduce_Fuse_Elementwise");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {h}, "B");
+    auto C = net_builder.ReduceSum(A, {1}, true);
+    auto D = net_builder.Add(B, C);
+  }
+
+  Compile(net_builder);
+}
+
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -464,25 +464,25 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
                               std::vector<int>& axes,
                               const common::Target& target) {
   axes[0] = inshape.size() - 1;
+  // If the number of current device SM is smaller than the number of SM
+  // required by Warp Reduce, the performance of Warp Reduce is better.
+  // Otherwise, use Block Reduce.
+  auto max_num_threads       = common::DefaultNVGPUTarget().max_num_threads();
+  int need_reduce_last_count = 1;
+  for (int i = 0; i < inshape.size(); i++) {
+    if (find(axes.begin(), axes.end(), i) == axes.end()) {
+      need_reduce_last_count *= inshape[i];
+    }
+  }
+  int warp_reduce_need_sm_count = (need_reduce_last_count * 32) / target.get_max_threads_per_sm();
+  // Set Num_max_threads to 32 is Warp Reduce
+  if (target.get_multi_processor_count() < warp_reduce_need_sm_count) {
+    max_num_threads = 32;
+  }
   // find first reduce and second reduce axis.
   int lane  = 1;
   int index = static_cast<int>(axes.size()) - 1;
-  int P     = 1;
-  for (int i = 0; i < inshape.size(); i++) {
-    if (find(axes.begin(), axes.end(), i) != axes.end()) {
-      continue;
-    }
-    if (find(axes.begin(), axes.end(), i - inshape.size()) != axes.end()) {
-      continue;
-    }
-    P = P * inshape[i];
-  }
-  int M                = target.get_multi_processor_count();
-  int N                = target.get_max_threads_per_sm();
-  int L                = N / 32;
-  int C                = P / L;
-  auto max_num_threads = common::DefaultNVGPUTarget().max_num_threads();
-  if (M < C) max_num_threads = 32;
+
   for (; index >= 0; --index) {
     if (index + 1 < axes.size() && axes[index] != axes[index + 1] - 1) {
       break;

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -461,19 +461,35 @@ void LoopAssignReduceWithoutLast(ir::IRSchedule& ir_sch,
 void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
                               const std::string& block_name,
                               const std::vector<int>& inshape,
-                              const std::vector<int>& axes,
+                              std::vector<int>& axes,
                               const common::Target& target) {
+  axes[0] = inshape.size() - 1;
   // find first reduce and second reduce axis.
-  int lane             = 1;
-  int index            = static_cast<int>(axes.size()) - 1;
-  auto max_num_threads = target.max_num_threads();
+  int lane  = 1;
+  int index = static_cast<int>(axes.size()) - 1;
+  int P     = 1;
+  for (int i = 0; i < inshape.size(); i++) {
+    if (find(axes.begin(), axes.end(), i) != axes.end()) {
+      continue;
+    }
+    if (find(axes.begin(), axes.end(), i - inshape.size()) != axes.end()) {
+      continue;
+    }
+    P = P * inshape[i];
+  }
+  int M                = target.get_multi_processor_count();
+  int N                = target.get_max_threads_per_sm();
+  int L                = N / 32;
+  int C                = P / L;
+  auto max_num_threads = common::DefaultNVGPUTarget().max_num_threads();
+  if (M < C) max_num_threads = 32;
   for (; index >= 0; --index) {
     if (index + 1 < axes.size() && axes[index] != axes[index + 1] - 1) {
       break;
     }
     lane *= inshape[axes[index]];
     if (index == 0 && lane <= max_num_threads) {
-      LOG(FATAL) << "Error! lane is less equal than max_num_threads, Please check!";
+      LOG(FATAL) << "Error! lane is less equal than max_num_threads, Please check!" << lane;
     }
     if (lane >= max_num_threads / 2) {
       if (lane <= max_num_threads) {

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -461,7 +461,7 @@ void LoopAssignReduceWithoutLast(ir::IRSchedule& ir_sch,
 void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
                               const std::string& block_name,
                               const std::vector<int>& inshape,
-                              std::vector<int>& axes,
+                              const std::vector<int>& axes,
                               const common::Target& target) {
   // If the number of current device SM is smaller than the number of SM
   // required by Warp Reduce, the performance of Warp Reduce is better.
@@ -475,7 +475,7 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
   }
   int warp_reduce_need_sm_count = ceil((need_reduce_last_count * 32) / float(target.get_max_threads_per_sm()));
   // Set Num_max_threads to 32 is Warp Reduce
-  if (target.get_multi_processor_count() < warp_reduce_need_sm_count / 2) {
+  if (target.get_multi_processor_count() < warp_reduce_need_sm_count) {
     max_num_threads = 32;
   }
   // find first reduce and second reduce axis.

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -463,7 +463,6 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
                               const std::vector<int>& inshape,
                               std::vector<int>& axes,
                               const common::Target& target) {
-  axes[0] = inshape.size() - 1;
   // If the number of current device SM is smaller than the number of SM
   // required by Warp Reduce, the performance of Warp Reduce is better.
   // Otherwise, use Block Reduce.
@@ -489,7 +488,7 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
     }
     lane *= inshape[axes[index]];
     if (index == 0 && lane <= max_num_threads) {
-      LOG(FATAL) << "Error! lane is less equal than max_num_threads, Please check!" << lane;
+      LOG(FATAL) << "Error! lane is less equal than max_num_threads, Please check!";
     }
     if (lane >= max_num_threads / 2) {
       if (lane <= max_num_threads) {

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -473,9 +473,9 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
       need_reduce_last_count *= inshape[i];
     }
   }
-  int warp_reduce_need_sm_count = (need_reduce_last_count * 32) / target.get_max_threads_per_sm();
+  int warp_reduce_need_sm_count = ceil((need_reduce_last_count * 32) / float(target.get_max_threads_per_sm()));
   // Set Num_max_threads to 32 is Warp Reduce
-  if (target.get_multi_processor_count() < warp_reduce_need_sm_count) {
+  if (target.get_multi_processor_count() < warp_reduce_need_sm_count / 2) {
     max_num_threads = 32;
   }
   // find first reduce and second reduce axis.

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -465,6 +465,30 @@ TEST(Operator, Operator_Reduction_Case_11) {
   GenReduceCode(shape, dim, "Operator_Reduction_Case_11");
 }
 
+TEST(Operator, Operator_Reduction_Case_Warp_Reduce) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {warp_reduce_threshold + 10, 256};
+  std::vector<int> dim   = {1};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Warp_Reduce");
+  CHECK(res.second.find("threadIdx.x < 32") != std::string::npos);
+}
+
+TEST(Operator, Operator_Reduction_Case_Block_Reduce) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {warp_reduce_threshold - 10, 33};
+  std::vector<int> dim   = {1};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Block_Reduce");
+  CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
+}
+
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -489,6 +489,29 @@ TEST(Operator, Operator_Reduction_Case_Block_Reduce) {
   CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
 }
 
+TEST(Operator, Operator_Reduction_Case_Warp_Reduce_Case_1) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {(warp_reduce_threshold + 32) / 2, 2, 10, 256};
+  std::vector<int> dim   = {2, 3};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Warp_Reduce_Case_1");
+  CHECK(res.second.find("threadIdx.x < 32") != std::string::npos);
+}
+
+TEST(Operator, Operator_Reduction_Case_Block_Reduce_Case_1) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {(warp_reduce_threshold - 32) / 2, 2, 10, 33};
+  std::vector<int> dim   = {2, 3};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Block_Reduce_Case_2");
+  CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
+}
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -694,7 +694,8 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
       need_reduce_last_count *= A->shape[i].as_int32();
     }
   }
-  int warp_reduce_need_sm_count = (need_reduce_last_count * 32) / common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_need_sm_count =
+      ceil((need_reduce_last_count * 32) / float(common::DefaultNVGPUTarget().get_max_threads_per_sm()));
   // Set Num_max_threads to 32 is Warp Reduce
   if (common::DefaultNVGPUTarget().get_multi_processor_count() < warp_reduce_need_sm_count) {
     max_num_threads = 32;

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -19,7 +19,6 @@
 #include <algorithm>
 
 #include "cinn/common/ir_util.h"
-#include "cinn/common/target.h"
 #include "cinn/hlir/pe/broadcast.h"
 #include "cinn/ir/ir_operators.h"
 #include "cinn/ir/tensor.h"

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -685,26 +685,24 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
                                                    BlockReduceFunc block_reduce_func,
                                                    ir::Expr initial) {
   CHECK(!WithoutLastDimInReduce(A->shape, axes)) << "Can't find last axis in reduce!";
+  // If the number of current device SM is smaller than the number of SM
+  // required by Warp Reduce, the performance of Warp Reduce is better.
+  // Otherwise, use Block Reduce.
+  auto max_num_threads       = common::DefaultNVGPUTarget().max_num_threads();
+  int need_reduce_last_count = 1;
+  for (int i = 0; i < A->shape.size(); i++) {
+    if (find(axes.begin(), axes.end(), i) == axes.end()) {
+      need_reduce_last_count *= A->shape[i].as_int32();
+    }
+  }
+  int warp_reduce_need_sm_count = (need_reduce_last_count * 32) / common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  // Set Num_max_threads to 32 is Warp Reduce
+  if (common::DefaultNVGPUTarget().get_multi_processor_count() < warp_reduce_need_sm_count) {
+    max_num_threads = 32;
+  }
 
   int lane  = A->shape[axes.back()].as_int32();
   int index = static_cast<int>(axes.size()) - 2;
-  int P     = 1;
-  for (int i = 0; i < A->shape.size(); i++) {
-    if (find(axes.begin(), axes.end(), i) != axes.end()) {
-      continue;
-    }
-    if (find(axes.begin(), axes.end(), i - A->shape.size()) != axes.end()) {
-      continue;
-    }
-    P = P * A->shape[i].as_int32();
-  }
-  int M                = common::DefaultNVGPUTarget().get_multi_processor_count();
-  int N                = common::DefaultNVGPUTarget().get_max_threads_per_sm();
-  int L                = N / 32;
-  int C                = P / L;
-  auto max_num_threads = common::DefaultNVGPUTarget().max_num_threads();
-  if (M < C) max_num_threads = 32;
-
   for (; index >= 0; --index) {
     if (lane >= max_num_threads / 2) {
       break;


### PR DESCRIPTION
CINN provides two strategies for reduce implementation: 
block reduce and warp reduce. block reduce used by default.

The performance of block reduce is not necessarily optimal. 
Theoretically, when the number of SM on the device is less than the number of SM required by warp reduce, warp reduce has better performance advantage. This has also been confirmed in the A100 experiment.

The experimental data of a100 is as follows: 8192 is the number of sm required by warp reduce. It can be seen that when the data scale keeps increasing, warp reduce has better performance advantage。
```bash
# N is the number of non-reduce element
# C is the scale of reduce 
# block_reduce, warp_reduce indicates the time of the corresponding policy, in ms
N, C, block_reduce, warp_reduce, faster
802, 256, 0.015062, 0.015410, block
902, 256, 0.015327, 0.015592, block
1002, 256, 0.015331, 0.015186, warp
1102, 256, 0.015242, 0.014902, warp
...
...
7096, 256, 0.025904, 0.022672, warp
8096, 256, 0.027820, 0.024762, warp
9096, 256, 0.027624, 0.024254, warp
10096, 256, 0.030151, 0.025956, warp
11096, 256, 0.031304, 0.027315, warp
```