### PR TITLE
Add some ops' unit tests

### DIFF
--- a/cinn/backends/extern_func_emitter.cc
+++ b/cinn/backends/extern_func_emitter.cc
@@ -24,7 +24,10 @@
 #include "cinn/backends/extern_func_emitter_builtin.h"
 #include "cinn/backends/llvm/runtime_symbol_registry.h"
 #include "cinn/runtime/cpu/host_intrinsics.h"
+#include "cinn/runtime/flags.h"
 #include "cinn/utils/string.h"
+
+DECLARE_bool(verbose_function_register);
 
 namespace cinn {
 namespace backends {
@@ -36,7 +39,9 @@ ExternFunctionEmitterRegistry& ExternFunctionEmitterRegistry::Global() {
 
 void ExternFunctionEmitterRegistry::Register(const ExternFuncID& name, const std::string& x) {
 #ifdef CINN_WITH_DEBUG
-  RAW_LOG_INFO("Register extern function emitter [%s]", utils::GetStreamCnt(name).c_str());
+  if (FLAGS_verbose_function_register) {
+    RAW_LOG_INFO("Register extern function emitter [%s]", utils::GetStreamCnt(name).c_str());
+  }
 #endif  // CINN_WITH_DEBUG
   CHECK(!x.empty()) << "Extern Function name is empty.";
   data_[name] = x;

--- a/cinn/backends/function_prototype.cc
+++ b/cinn/backends/function_prototype.cc
@@ -19,6 +19,9 @@
 #include <iostream>
 
 #include "cinn/ir/tensor.h"
+#include "cinn/runtime/flags.h"
+
+DECLARE_bool(verbose_function_register);
 
 namespace cinn {
 namespace backends {
@@ -108,7 +111,9 @@ FunctionProto *FunctionProtoRegistry::Lookup(const std::string &name) {
 
 FunctionProto *FunctionProtoRegistry::Register(absl::string_view name, FunctionProto *x) {
 #ifdef CINN_WITH_DEBUG
-  RAW_LOG_INFO("Register function prototype  [%s]", name.data());
+  if (FLAGS_verbose_function_register) {
+    RAW_LOG_INFO("Register function prototype  [%s]", name.data());
+  }
 #endif  // CINN_WITH_DEBUG
   data_.emplace(name, std::unique_ptr<FunctionProto>(x));
   return x;

--- a/cinn/backends/llvm/runtime_symbol_registry.cc
+++ b/cinn/backends/llvm/runtime_symbol_registry.cc
@@ -19,6 +19,11 @@
 
 #include <iostream>
 
+#include "cinn/runtime/flags.h"
+#include "gflags/gflags_declare.h"
+
+DECLARE_bool(verbose_function_register);
+
 namespace cinn {
 namespace backends {
 
@@ -39,7 +44,9 @@ void *RuntimeSymbols::Lookup(absl::string_view name) const {
 
 void RuntimeSymbols::Register(const std::string &name, void *address) {
 #ifdef CINN_WITH_DEBUG
-  RAW_LOG_INFO("JIT Register function [%s]: %p", name.c_str(), address);
+  if (FLAGS_verbose_function_register) {
+    RAW_LOG_INFO("JIT Register function [%s]: %p", name.c_str(), address);
+  }
 #endif  // CINN_WITH_DEBUG
   std::lock_guard<std::mutex> lock(mu_);
   auto it = symbols_.find(name);

--- a/cinn/hlir/pe/nn.cc
+++ b/cinn/hlir/pe/nn.cc
@@ -1254,19 +1254,12 @@ Tensor DropoutInfer(const ir::Tensor &tensor,
                     const std::string &dropout_implementation,
                     const std::string &output_name) {
   if (dropout_implementation == "downgrade_in_infer") {
-    if (tensor->type().bits() == 32) {
-      return Compute(
-          tensor->shape,
-          [=](const std::vector<Expr> &indice) { return tensor(indice) * (1 - dropout_prob); },
-          output_name);
-    } else if (tensor->type().bits() == 64) {
-      return Compute(
-          tensor->shape,
-          [=](const std::vector<Expr> &indice) { return tensor(indice) * static_cast<double>(1 - dropout_prob); },
-          output_name);
-    } else {
-      LOG(FATAL) << "Unsupport dtype in dropout_infer: " << tensor->type();
-    }
+    return Compute(
+        tensor->shape,
+        [=](const std::vector<Expr> &indice) {
+          return tensor(indice) * common::make_const(tensor->type(), 1 - dropout_prob);
+        },
+        output_name);
   } else if (dropout_implementation == "upscale_in_train") {
     // The name here must be consistent, otherwise it cannot participate in the fusion schedule.
     return Identity(tensor, output_name).front();

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -116,6 +116,10 @@ DEFINE_bool(enhance_vertical_fusion_with_recompute,
             BoolFromEnv("FLAGS_enhance_vertical_fusion_with_recompute", false),
             "Whether to enhance check logic on vertical fusion with recompute");
 
+DEFINE_bool(verbose_function_register,
+            BoolFromEnv("FLAGS_verbose_function_register", false),
+            "Whether to verbose function regist log. This will only work if CINN build with flag -DWITH_DEBUG=ON.");
+
 namespace cinn {
 namespace runtime {
 

--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -241,7 +241,10 @@ class OpTest(unittest.TestCase):
             return np.random.uniform(low, high, shape).astype(dtype)
         elif dtype == "bool":
             return np.random.choice(a=[False, True], size=shape).astype(dtype)
-        elif dtype in ["int8", "uint8", "int32", "int64"]:
+        elif dtype in [
+                "uint8", "uint16", "uint32", "uint64", "int8", "int16",
+                "int32", "int64"
+        ]:
             return np.random.randint(low, high, shape).astype(dtype)
         else:
             raise Exception("Not supported yet.")

--- a/python/tests/ops/op_test_helper.py
+++ b/python/tests/ops/op_test_helper.py
@@ -67,7 +67,7 @@ class TestCaseHelper():
         self.init_attrs()
         self._init_cases()
         self.all_classes = []
-        if len(self.specify_test) is not 0:
+        if args.case is not None:
             for test_name in self.specify_test:
                 no = int(re.search(r'\d+$', test_name).group(0))
                 assert 0 <= no and no < len(self.all_cases)

--- a/python/tests/ops/op_test_helper.py
+++ b/python/tests/ops/op_test_helper.py
@@ -50,10 +50,13 @@ class TestCaseHelper():
         """
         Generate all test cases
         """
+        assert type(self.inputs) is list
+        assert type(self.dtypes) is list
+        assert type(self.attrs) is list
         self.all_cases = []
-        attrs_cases = (dict(zip(self.attrs.keys(), values))
-                       for values in itertools.product(*self.attrs.values()))
-        for case in itertools.product(self.inputs, self.dtypes, attrs_cases):
+        all_lists = [self.inputs, self.dtypes, self.attrs]
+        filtered_lists = filter(lambda x: len(x) > 0, all_lists)
+        for case in itertools.product(*filtered_lists):
             self.all_cases.append(self._flatten_tuple(case))
 
     def _make_all_classes(self):

--- a/python/tests/ops/op_test_helper.py
+++ b/python/tests/ops/op_test_helper.py
@@ -67,12 +67,13 @@ class TestCaseHelper():
         self.init_attrs()
         self._init_cases()
         self.all_classes = []
-        if args.case is not None:
-            no = int(re.search(r'\d+$', self.specify_test[1]).group(0))
-            assert 0 <= no and no < len(self.all_cases)
-            self.all_classes.append(
-                type(f'{self.__class__.__name__}.{self.class_name}{no}',
-                     (self.cls, ), {"case": self.all_cases[no]}))
+        if len(self.specify_test) is not 0:
+            for test_name in self.specify_test:
+                no = int(re.search(r'\d+$', test_name).group(0))
+                assert 0 <= no and no < len(self.all_cases)
+                self.all_classes.append(
+                    type(f'{self.__class__.__name__}.{self.class_name}{no}',
+                         (self.cls, ), {"case": self.all_cases[no]}))
         else:
             for i, case in enumerate(self.all_cases):
                 self.all_classes.append(
@@ -84,9 +85,14 @@ class TestCaseHelper():
         Run all test classes
         """
         if args.case is not None:
-            self.specify_test = args.case.split('.')
-            assert len(self.specify_test) is 2
-            if self.__class__.__name__ != self.specify_test[0]:
+            self.specify_test = []
+            all_tests = args.case.split(',')
+            for test in all_tests:
+                test_info = test.split('.')
+                assert len(test_info) is 2
+                if self.__class__.__name__ == test_info[0]:
+                    self.specify_test.append(test_info[1])
+            if len(self.specify_test) is 0:
                 return
         self._make_all_classes()
         test_suite = unittest.TestSuite()

--- a/python/tests/ops/test_add_op_new.py
+++ b/python/tests/ops/test_add_op_new.py
@@ -130,9 +130,7 @@ class TestAddAll(TestCaseHelper):
                 "dout_dtype": "float32"
             },
         ]
-        self.attrs = {
-            # "axis": [-1, 0],
-        }
+        self.attrs = []
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_add_op_new.py
+++ b/python/tests/ops/test_add_op_new.py
@@ -91,7 +91,9 @@ class TestElementwiseAddOp(OpTest):
         self.cinn_grads = [res[1], res[2]]
 
     def test_check_results(self):
-        self.check_outputs_and_grads()
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
 class TestAddAll(TestCaseHelper):
@@ -100,34 +102,152 @@ class TestAddAll(TestCaseHelper):
         self.cls = TestElementwiseAddOp
         self.inputs = [
             {
-                "x_shape": [3],
-                "y_shape": [3],
-                "dout_shape": [3],
-                "axis": -1
-            },
-            {
-                "x_shape": [3, 3],
+                "x_shape": [1],
                 "y_shape": [1],
-                "dout_shape": [3, 3],
-                "axis": -1
+                "dout_shape": [1],
+                "axis": 0,
             },
             {
-                "x_shape": [3, 3, 3],
-                "y_shape": [3, 3, 3],
-                "dout_shape": [3, 3, 3],
-                "axis": 0
+                "x_shape": [1024],
+                "y_shape": [1024],
+                "dout_shape": [1024],
+                "axis": -1,
+            },
+            {
+                "x_shape": [512, 256],
+                "y_shape": [512, 256],
+                "dout_shape": [512, 256],
+                "axis": 0,
+            },
+            {
+                "x_shape": [128, 64, 32],
+                "y_shape": [128, 64, 32],
+                "dout_shape": [128, 64, 32],
+                "axis": -1,
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 8, 4, 2],
+                "dout_shape": [16, 8, 4, 2],
+                "axis": 0,
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
+                "dout_shape": [16, 8, 4, 2, 1],
+                "axis": -1,
             },
         ]
         self.dtypes = [
             {
+                "x_dtype": "int16",
+                "y_dtype": "int16",
+                "dout_dtype": "int16",
+            },
+            {
                 "x_dtype": "int32",
                 "y_dtype": "int32",
-                "dout_dtype": "int32"
+                "dout_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+                "dout_dtype": "int64",
+            },
+            {
+                "x_dtype": "float16",
+                "y_dtype": "float16",
+                "dout_dtype": "float16",
+                "max_relative_error": 1e-3,
             },
             {
                 "x_dtype": "float32",
                 "y_dtype": "float32",
-                "dout_dtype": "float32"
+                "dout_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+                "y_dtype": "float64",
+                "dout_dtype": "float64",
+            },
+        ]
+        self.attrs = []
+
+
+class TestAddAllWithBroadcast(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestElementwiseAddOpCase"
+        self.cls = TestElementwiseAddOp
+        self.inputs = [
+            {
+                "x_shape": [1],
+                "y_shape": [1],
+                "dout_shape": [1],
+                "axis": 0,
+            },
+            {
+                "x_shape": [1024],
+                "y_shape": [1],
+                "dout_shape": [1024],
+                "axis": -1,
+            },
+            {
+                "x_shape": [512, 256],
+                "y_shape": [1, 1],
+                "dout_shape": [512, 256],
+                "axis": 0,
+            },
+            {
+                "x_shape": [128, 64, 32],
+                "y_shape": [1, 1, 1],
+                "dout_shape": [128, 64, 32],
+                "axis": -1,
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [1, 1, 1, 1],
+                "dout_shape": [16, 8, 4, 2],
+                "axis": 0,
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [1, 1, 1, 1, 1],
+                "dout_shape": [16, 8, 4, 2, 1],
+                "axis": -1,
+            },
+        ]
+        self.dtypes = [
+            # Todo: Reduce does in support int16
+            # {
+            #     "x_dtype": "int16",
+            #     "y_dtype": "int16",
+            #     "dout_dtype": "int16",
+            # },
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+                "dout_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+                "dout_dtype": "int64",
+            },
+            {
+                "x_dtype": "float16",
+                "y_dtype": "float16",
+                "dout_dtype": "float16",
+                "max_relative_error": 1e-3,
+            },
+            {
+                "x_dtype": "float32",
+                "y_dtype": "float32",
+                "dout_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+                "y_dtype": "float64",
+                "dout_dtype": "float64",
             },
         ]
         self.attrs = []
@@ -135,3 +255,4 @@ class TestAddAll(TestCaseHelper):
 
 if __name__ == "__main__":
     TestAddAll().run()
+    TestAddAllWithBroadcast().run()

--- a/python/tests/ops/test_dropout_infer_op.py
+++ b/python/tests/ops/test_dropout_infer_op.py
@@ -83,13 +83,17 @@ class TestDropoutInferAll(TestCaseHelper):
         self.cls = TestDropoutInferOp
         # Initialize shape for test cases
         self.inputs = [{
+            "x_shape": [1],
+        }, {
             "x_shape": [1024],
         }, {
-            "x_shape": [32, 64],
+            "x_shape": [512, 256],
         }, {
-            "x_shape": [3, 32, 64],
+            "x_shape": [128, 64, 32],
         }, {
-            "x_shape": [1, 32, 32, 3],
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
         }]
         # Initialize dtype for test cases
         self.dtypes = [

--- a/python/tests/ops/test_dropout_infer_op.py
+++ b/python/tests/ops/test_dropout_infer_op.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestDropoutInferOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+        if self.case["mode"] is 'upscale_in_train':
+            self.case["cinn_mode"] = 'upscale_in_train'
+        elif self.case["mode"] is 'downscale_in_infer':
+            self.case["cinn_mode"] = 'downgrade_in_infer'
+        else:
+            raise f"Unknown mode for dropout_infer: {self.case['mode']}"
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = paddle.nn.functional.dropout(
+            x, p=self.case["p"], mode=self.case["mode"], training=False)
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("dropout_infer")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.dropout_infer(x, self.case["p"], self.case["cinn_mode"])
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
+
+
+class TestDropoutInferAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestDropoutInferOpCase"
+        self.cls = TestDropoutInferOp
+        self.inputs = [{
+            "x_shape": [1024],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [3, 32, 64],
+        }, {
+            "x_shape": [1, 32, 32, 3],
+        }]
+        self.dtypes = [
+            {
+                "x_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+            },
+        ]
+        self.attrs = {
+            "p": [0.1, 0.5],
+            "mode": ['upscale_in_train', 'downscale_in_infer'],
+        }
+
+
+if __name__ == "__main__":
+    TestDropoutInferAll().run()

--- a/python/tests/ops/test_dropout_infer_op.py
+++ b/python/tests/ops/test_dropout_infer_op.py
@@ -96,33 +96,25 @@ class TestDropoutInferAll(TestCaseHelper):
             "x_shape": [16, 8, 4, 2, 1],
         }]
         # Initialize dtype for test cases
-        self.dtypes = [
-            {
-                "x_dtype": "float32",
-            },
-            {
-                "x_dtype": "float64",
-            },
-        ]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }, {
+            "x_dtype": "float64",
+        }]
         # Initialize attributes for test cases
-        self.attrs = [
-            {
-                "p": 0.1,
-                "mode": "upscale_in_train"
-            },
-            {
-                "p": 0.5,
-                "mode": "downscale_in_infer"
-            },
-            {
-                "p": 0.7,
-                "mode": "upscale_in_train"
-            },
-            {
-                "p": 0.9,
-                "mode": "downscale_in_infer"
-            },
-        ]
+        self.attrs = [{
+            "p": 0.1,
+            "mode": "upscale_in_train"
+        }, {
+            "p": 0.5,
+            "mode": "downscale_in_infer"
+        }, {
+            "p": 0.7,
+            "mode": "upscale_in_train"
+        }, {
+            "p": 0.9,
+            "mode": "downscale_in_infer"
+        }]
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_left_shift_op.py
+++ b/python/tests/ops/test_left_shift_op.py
@@ -96,7 +96,7 @@ class TestLeftShiftAll(TestCaseHelper):
             #     "y_dtype": "int64",
             # },
         ]
-        self.attrs = {}
+        self.attrs = []
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_left_shift_op.py
+++ b/python/tests/ops/test_left_shift_op.py
@@ -140,7 +140,7 @@ class TestLeftShiftAllWithBroadcast(TestCaseHelper):
             # {
             #     "x_dtype": "int64",
             #     "y_dtype": "int64",
-            # },
+            # }
         ]
         self.attrs = []
 

--- a/python/tests/ops/test_left_shift_op.py
+++ b/python/tests/ops/test_left_shift_op.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestLeftShiftOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-100,
+            high=100)
+        self.y_np = self.random(
+            shape=self.case["y_shape"],
+            dtype=self.case["y_dtype"],
+            low=0,
+            high=16)
+
+    def build_paddle_program(self, target):
+        np_out = np.left_shift(self.x_np, self.y_np)
+        out = paddle.to_tensor(np_out, stop_gradient=True)
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("left_shift")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        y = builder.create_input(
+            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
+            "y")
+        out = builder.left_shift(x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.x_np, self.y_np], [out])
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestLeftShiftAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestLeftShiftOpCase"
+        self.cls = TestLeftShiftOp
+        self.inputs = [{
+            "x_shape": [10],
+            "y_shape": [1],
+        }, {
+            "x_shape": [32, 64],
+            "y_shape": [32, 64],
+        }, {
+            "x_shape": [3, 32, 64],
+            "y_shape": [3, 1, 64],
+        }, {
+            "x_shape": [1, 32, 32, 3],
+            "y_shape": [1, 32, 32, 1],
+        }]
+        self.dtypes = [
+            # {
+            #     "x_dtype": "uint8",
+            #     "y_dtype": "uint8",
+            # },
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            # {
+            #     "x_dtype": "int64",
+            #     "y_dtype": "int64",
+            # },
+        ]
+        self.attrs = {}
+
+
+if __name__ == "__main__":
+    TestLeftShiftAll().run()

--- a/python/tests/ops/test_left_shift_op.py
+++ b/python/tests/ops/test_left_shift_op.py
@@ -70,17 +70,63 @@ class TestLeftShiftAll(TestCaseHelper):
         self.class_name = "TestLeftShiftOpCase"
         self.cls = TestLeftShiftOp
         self.inputs = [{
-            "x_shape": [10],
+            "x_shape": [1],
             "y_shape": [1],
         }, {
-            "x_shape": [32, 64],
-            "y_shape": [32, 64],
+            "x_shape": [1024],
+            "y_shape": [1024],
         }, {
-            "x_shape": [3, 32, 64],
-            "y_shape": [3, 1, 64],
+            "x_shape": [512, 256],
+            "y_shape": [512, 256],
         }, {
-            "x_shape": [1, 32, 32, 3],
-            "y_shape": [1, 32, 32, 1],
+            "x_shape": [128, 64, 32],
+            "y_shape": [128, 64, 32],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+            "y_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [
+            # {
+            #     "x_dtype": "uint8",
+            #     "y_dtype": "uint8",
+            # },
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            # {
+            #     "x_dtype": "int64",
+            #     "y_dtype": "int64",
+            # },
+        ]
+        self.attrs = []
+
+
+class TestLeftShiftAllWithBroadcast(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestLeftShiftOpCase"
+        self.cls = TestLeftShiftOp
+        self.inputs = [{
+            "x_shape": [1],
+            "y_shape": [1],
+        }, {
+            "x_shape": [1024],
+            "y_shape": [1],
+        }, {
+            "x_shape": [512, 256],
+            "y_shape": [1, 1],
+        }, {
+            "x_shape": [128, 64, 32],
+            "y_shape": [1, 1, 1],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+            "y_shape": [1, 1, 1, 1],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+            "y_shape": [1, 1, 1, 1, 1],
         }]
         self.dtypes = [
             # {
@@ -101,3 +147,4 @@ class TestLeftShiftAll(TestCaseHelper):
 
 if __name__ == "__main__":
     TestLeftShiftAll().run()
+    TestLeftShiftAllWithBroadcast().run()

--- a/python/tests/ops/test_relu6_op.py
+++ b/python/tests/ops/test_relu6_op.py
@@ -70,6 +70,9 @@ class TestRelu6All(TestCaseHelper):
             "x_shape": [1, 32, 32, 3],
         }]
         self.dtypes = [
+            # {
+            #     "x_dtype": "bfloat16",
+            # },
             {
                 "x_dtype": "float16",
             },
@@ -80,7 +83,7 @@ class TestRelu6All(TestCaseHelper):
                 "x_dtype": "float64",
             },
         ]
-        self.attrs = {}
+        self.attrs = []
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_relu6_op.py
+++ b/python/tests/ops/test_relu6_op.py
@@ -61,13 +61,17 @@ class TestRelu6All(TestCaseHelper):
         self.class_name = "TestRelu6OpCase"
         self.cls = TestRelu6Op
         self.inputs = [{
+            "x_shape": [1],
+        }, {
             "x_shape": [1024],
         }, {
-            "x_shape": [32, 64],
+            "x_shape": [512, 256],
         }, {
-            "x_shape": [3, 32, 64],
+            "x_shape": [128, 64, 32],
         }, {
-            "x_shape": [1, 32, 32, 3],
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
         }]
         self.dtypes = [
             # {

--- a/python/tests/ops/test_relu6_op.py
+++ b/python/tests/ops/test_relu6_op.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestRelu6Op(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-10,
+            high=10)
+
+    def build_paddle_program(self, target):
+        f = paddle.nn.ReLU6()
+        x = paddle.to_tensor(self.x_np, stop_gradient=False)
+        self.paddle_outputs = [f(x)]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("relu6")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.relu6(x)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestRelu6All(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestRelu6OpCase"
+        self.cls = TestRelu6Op
+        self.inputs = [{
+            "x_shape": [1024],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [3, 32, 64],
+        }, {
+            "x_shape": [1, 32, 32, 3],
+        }]
+        self.dtypes = [
+            {
+                "x_dtype": "float16",
+            },
+            {
+                "x_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+            },
+        ]
+        self.attrs = {}
+
+
+if __name__ == "__main__":
+    TestRelu6All().run()

--- a/python/tests/ops/test_right_shift_op.py
+++ b/python/tests/ops/test_right_shift_op.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestRightShiftOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-100,
+            high=100)
+        self.y_np = self.random(
+            shape=self.case["y_shape"],
+            dtype=self.case["y_dtype"],
+            low=0,
+            high=16)
+
+    def build_paddle_program(self, target):
+        np_out = np.right_shift(self.x_np, self.y_np)
+        out = paddle.to_tensor(np_out, stop_gradient=True)
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("right_shift")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        y = builder.create_input(
+            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
+            "y")
+        out = builder.right_shift(x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.x_np, self.y_np], [out])
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestRightShiftAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestRightShiftOpCase"
+        self.cls = TestRightShiftOp
+        self.inputs = [{
+            "x_shape": [10],
+            "y_shape": [1],
+        }, {
+            "x_shape": [32, 64],
+            "y_shape": [32, 64],
+        }, {
+            "x_shape": [3, 32, 64],
+            "y_shape": [3, 1, 64],
+        }, {
+            "x_shape": [1, 32, 32, 3],
+            "y_shape": [1, 32, 32, 1],
+        }]
+        self.dtypes = [
+            # {
+            #     "x_dtype": "uint8",
+            #     "y_dtype": "uint8",
+            # },
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            # {
+            #     "x_dtype": "int64",
+            #     "y_dtype": "int64",
+            # },
+        ]
+        self.attrs = {}
+
+
+if __name__ == "__main__":
+    TestRightShiftAll().run()

--- a/python/tests/ops/test_right_shift_op.py
+++ b/python/tests/ops/test_right_shift_op.py
@@ -96,7 +96,7 @@ class TestRightShiftAll(TestCaseHelper):
             #     "y_dtype": "int64",
             # },
         ]
-        self.attrs = {}
+        self.attrs = []
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_right_shift_op.py
+++ b/python/tests/ops/test_right_shift_op.py
@@ -140,7 +140,7 @@ class TestRightShiftAllWithBroadcast(TestCaseHelper):
             # {
             #     "x_dtype": "int64",
             #     "y_dtype": "int64",
-            # },
+            # }
         ]
         self.attrs = []
 

--- a/python/tests/ops/test_right_shift_op.py
+++ b/python/tests/ops/test_right_shift_op.py
@@ -70,17 +70,63 @@ class TestRightShiftAll(TestCaseHelper):
         self.class_name = "TestRightShiftOpCase"
         self.cls = TestRightShiftOp
         self.inputs = [{
-            "x_shape": [10],
+            "x_shape": [1],
             "y_shape": [1],
         }, {
-            "x_shape": [32, 64],
-            "y_shape": [32, 64],
+            "x_shape": [1024],
+            "y_shape": [1024],
         }, {
-            "x_shape": [3, 32, 64],
-            "y_shape": [3, 1, 64],
+            "x_shape": [512, 256],
+            "y_shape": [512, 256],
         }, {
-            "x_shape": [1, 32, 32, 3],
-            "y_shape": [1, 32, 32, 1],
+            "x_shape": [128, 64, 32],
+            "y_shape": [128, 64, 32],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+            "y_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [
+            # {
+            #     "x_dtype": "uint8",
+            #     "y_dtype": "uint8",
+            # },
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            # {
+            #     "x_dtype": "int64",
+            #     "y_dtype": "int64",
+            # },
+        ]
+        self.attrs = []
+
+
+class TestRightShiftAllWithBroadcast(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestRightShiftOpCase"
+        self.cls = TestRightShiftOp
+        self.inputs = [{
+            "x_shape": [1],
+            "y_shape": [1],
+        }, {
+            "x_shape": [1024],
+            "y_shape": [1],
+        }, {
+            "x_shape": [512, 256],
+            "y_shape": [1, 1],
+        }, {
+            "x_shape": [128, 64, 32],
+            "y_shape": [1, 1, 1],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+            "y_shape": [1, 1, 1, 1],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+            "y_shape": [1, 1, 1, 1, 1],
         }]
         self.dtypes = [
             # {
@@ -101,3 +147,4 @@ class TestRightShiftAll(TestCaseHelper):
 
 if __name__ == "__main__":
     TestRightShiftAll().run()
+    TestRightShiftAllWithBroadcast().run()

--- a/python/tests/ops/test_scale_op.py
+++ b/python/tests/ops/test_scale_op.py
@@ -98,11 +98,38 @@ class TestScaleAll(TestCaseHelper):
                 "x_dtype": "float64",
             },
         ]
-        self.attrs = {
-            "scale": [0.1, 10],
-            "bias": [1, 10],
-            "bias_after_scale": [True, False],
-        }
+        self.attrs = [
+            {
+                "scale": 0,
+                "bias": 10,
+                "bias_after_scale": True
+            },
+            {
+                "scale": 0.5,
+                "bias": -10,
+                "bias_after_scale": False
+            },
+            {
+                "scale": 0.1,
+                "bias": 1,
+                "bias_after_scale": True
+            },
+            {
+                "scale": -0.1,
+                "bias": 100,
+                "bias_after_scale": False
+            },
+            {
+                "scale": -10,
+                "bias": -100,
+                "bias_after_scale": True
+            },
+            {
+                "scale": 10,
+                "bias": 100,
+                "bias_after_scale": False
+            },
+        ]
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_scale_op.py
+++ b/python/tests/ops/test_scale_op.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestScaleOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = paddle.scale(x, self.case["scale"], self.case["bias"],
+                           self.case["bias_after_scale"])
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("scale")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.scale(x, self.case["scale"], self.case["bias"],
+                            self.case["bias_after_scale"])
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
+
+
+class TestScaleAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestScaleOpCase"
+        self.cls = TestScaleOp
+        self.inputs = [{
+            "x_shape": [1024],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [3, 32, 64],
+        }, {
+            "x_shape": [1, 32, 32, 3],
+        }]
+        self.dtypes = [
+            # {
+            #     # Todo: Support uint8 in op scale
+            #     "x_dtype": "uint8",
+            # },
+            {
+                "x_dtype": "int8",
+            },
+            {
+                "x_dtype": "int16"
+            },
+            {
+                "x_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64"
+            },
+            {
+                "x_dtype": "float16",
+                "max_relative_error": 1e-3
+            },
+            {
+                "x_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+            },
+        ]
+        self.attrs = {
+            "scale": [0.1, 10],
+            "bias": [1, 10],
+            "bias_after_scale": [True, False],
+        }
+
+
+if __name__ == "__main__":
+    TestScaleAll().run()

--- a/python/tests/ops/test_scale_op.py
+++ b/python/tests/ops/test_scale_op.py
@@ -102,48 +102,39 @@ class TestScaleAll(TestCaseHelper):
                 "x_dtype": "float64",
             },
         ]
-        self.attrs = [
-            {
-                "scale": 0,
-                "bias": 0,
-                "bias_after_scale": True
-            },
-            {
-                "scale": 0,
-                "bias": 0,
-                "bias_after_scale": False
-            },
-            {
-                "scale": 0.1,
-                "bias": 10,
-                "bias_after_scale": True
-            },
-            {
-                "scale": -0.1,
-                "bias": 10,
-                "bias_after_scale": False
-            },
-            {
-                "scale": 1,
-                "bias": 0,
-                "bias_after_scale": True
-            },
-            {
-                "scale": -1,
-                "bias": 0,
-                "bias_after_scale": False
-            },
-            {
-                "scale": 0,
-                "bias": 10,
-                "bias_after_scale": True
-            },
-            {
-                "scale": 0,
-                "bias": 10,
-                "bias_after_scale": False
-            },
-        ]
+        self.attrs = [{
+            "scale": 0,
+            "bias": 0,
+            "bias_after_scale": True
+        }, {
+            "scale": 0,
+            "bias": 0,
+            "bias_after_scale": False
+        }, {
+            "scale": 0.1,
+            "bias": 10,
+            "bias_after_scale": True
+        }, {
+            "scale": -0.1,
+            "bias": 10,
+            "bias_after_scale": False
+        }, {
+            "scale": 1,
+            "bias": 0,
+            "bias_after_scale": True
+        }, {
+            "scale": -1,
+            "bias": 0,
+            "bias_after_scale": False
+        }, {
+            "scale": 0,
+            "bias": 10,
+            "bias_after_scale": True
+        }, {
+            "scale": 0,
+            "bias": 10,
+            "bias_after_scale": False
+        }]
 
 
 if __name__ == "__main__":

--- a/python/tests/ops/test_scale_op.py
+++ b/python/tests/ops/test_scale_op.py
@@ -62,13 +62,17 @@ class TestScaleAll(TestCaseHelper):
         self.class_name = "TestScaleOpCase"
         self.cls = TestScaleOp
         self.inputs = [{
+            "x_shape": [1],
+        }, {
             "x_shape": [1024],
         }, {
-            "x_shape": [32, 64],
+            "x_shape": [512, 256],
         }, {
-            "x_shape": [3, 32, 64],
+            "x_shape": [128, 64, 32],
         }, {
-            "x_shape": [1, 32, 32, 3],
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
         }]
         self.dtypes = [
             # {
@@ -101,32 +105,42 @@ class TestScaleAll(TestCaseHelper):
         self.attrs = [
             {
                 "scale": 0,
-                "bias": 10,
+                "bias": 0,
                 "bias_after_scale": True
             },
             {
-                "scale": 0.5,
-                "bias": -10,
+                "scale": 0,
+                "bias": 0,
                 "bias_after_scale": False
             },
             {
                 "scale": 0.1,
-                "bias": 1,
+                "bias": 10,
                 "bias_after_scale": True
             },
             {
                 "scale": -0.1,
-                "bias": 100,
+                "bias": 10,
                 "bias_after_scale": False
             },
             {
-                "scale": -10,
-                "bias": -100,
+                "scale": 1,
+                "bias": 0,
                 "bias_after_scale": True
             },
             {
-                "scale": 10,
-                "bias": 100,
+                "scale": -1,
+                "bias": 0,
+                "bias_after_scale": False
+            },
+            {
+                "scale": 0,
+                "bias": 10,
+                "bias_after_scale": True
+            },
+            {
+                "scale": 0,
+                "bias": 10,
                 "bias_after_scale": False
             },
         ]


### PR DESCRIPTION
1. 添加部分算子缺失的单测：`relu6`, `left_shift`, `right_shift`, `scale`, `dropout_infer`
2. 修复`scale`算子在数据类型为`float64`下的错误
3. `op_test`的`self.random`支持完整的`uint`和`int`类型
4. 添加了`FLAGS_verbose_function_register `，以控制CINN在开启debug编译后，每次运行都会产生一大堆函数原型注册的日志