### PR TITLE
fix fold_expand_dims_fill_constant pass when axes have negitive value

### DIFF
--- a/cinn/hlir/pass/constant_folding_pass_test.cc
+++ b/cinn/hlir/pass/constant_folding_pass_test.cc
@@ -308,7 +308,7 @@ TEST(Constant_Folding, fold_expand_dims_to_fill_constant_2) {
 
 TEST(Constant_Folding, fold_expand_dims_to_fill_constant_3) {
   NetBuilder net_builder("fold_expand_dims_to_fill_constant_3");
-  // create model
+  // create model, ExpandDims axes have nagetive value
   int h = 32, w = 32;
   auto A = net_builder.FillConstant<float>({h, w}, 1.0f, "A");
   auto B = net_builder.ExpandDims(A, {1, -1});

--- a/cinn/hlir/pass/constant_folding_pass_util.h
+++ b/cinn/hlir/pass/constant_folding_pass_util.h
@@ -140,9 +140,9 @@ inline void fold_expand_dims_fill_constant(const FusionHelperBase* helper, Graph
   // create constant op.
   Node* node_tmp = new Node(Operator::Get("fill_constant"), "fill_constant", common::UniqName("fill_constant"));
   int shape_size = shape.size();
-  int axes_size = axes.size();
+  int axes_size  = axes.size();
   int total_size = shape_size + axes_size;
-  // check axes in reasonable range [-total_size, total_size-1] and convert all to [0, total_size-1].
+  // check axes whether in range [-total_size, total_size-1] and convert all to [0, total_size-1].
   axes = utils::GetPositiveAxes(axes, total_size);
   // check axes can't repeat.
   std::sort(axes.begin(), axes.end(), std::less<int>());

--- a/cinn/hlir/pass/constant_folding_pass_util.h
+++ b/cinn/hlir/pass/constant_folding_pass_util.h
@@ -136,14 +136,6 @@ inline void fold_expand_dims_fill_constant(const FusionHelperBase* helper, Graph
   auto shape = absl::get<std::vector<int>>(constant_op->attrs.attr_store.at("shape"));
   CHECK(node->attrs.attr_store.count("axes"));
   auto axes = absl::get<std::vector<int>>(node->attrs.attr_store.at("axes"));
-  VLOG(3) << "shape before pass:";
-  for (int i: shape) {
-    VLOG(3) << i;
-  }
-  VLOG(3) << "axes:";
-  for (int i: axes) {
-    VLOG(3) << i;
-  }
 
   // create constant op.
   Node* node_tmp = new Node(Operator::Get("fill_constant"), "fill_constant", common::UniqName("fill_constant"));
@@ -163,10 +155,6 @@ inline void fold_expand_dims_fill_constant(const FusionHelperBase* helper, Graph
     if (std::find(axes.begin(), axes.end(), idx) == axes.end()) {
       n_shape[idx] = shape[index++];
     }
-  }
-  VLOG(3) << "n_shape after pass:";
-  for (int i: n_shape) {
-    VLOG(3) << i;
   }
 
   // set node attr

--- a/cinn/utils/functional.cc
+++ b/cinn/utils/functional.cc
@@ -23,8 +23,8 @@ std::vector<int> GetPositiveAxes(const std::vector<int>& axes, int rank) {
   std::vector<int> new_axes(axes.size());
   for (int i = 0; i < axes.size(); ++i) {
     int axis = axes[i] + (axes[i] < 0 ? rank : 0);
-    CHECK(axis >= 0 && axis < rank) << "The axis should in [" << -rank << ", " << rank << "), but axes[" << i << "]=" << axes[i]
-                                    << " not.";
+    CHECK(axis >= 0 && axis < rank) << "The axis should in [" << -rank << ", " << rank << "), but axes[" << i
+                                    << "]=" << axes[i] << " not.";
     new_axes[i] = axis;
   }
   return new_axes;

--- a/cinn/utils/functional.cc
+++ b/cinn/utils/functional.cc
@@ -23,7 +23,7 @@ std::vector<int> GetPositiveAxes(const std::vector<int>& axes, int rank) {
   std::vector<int> new_axes(axes.size());
   for (int i = 0; i < axes.size(); ++i) {
     int axis = axes[i] + (axes[i] < 0 ? rank : 0);
-    CHECK(axis >= 0 && axis < rank) << "The axis should in [0, " << rank << "), but axes[" << i << "]=" << axes[i]
+    CHECK(axis >= 0 && axis < rank) << "The axis should in [" << -rank << ", " << rank << "), but axes[" << i << "]=" << axes[i]
                                     << " not.";
     new_axes[i] = axis;
   }


### PR DESCRIPTION
assume shape of `fill_constant` is [16, 16] and its subsequent Operation is `expand_dims`.
if attribute `axes` of `expand_dims` have negitive value, eg [1, -1], then the shape of fusing fill_constant and expand_dims may be [16, 1, 16, 0], but the expected value is [16, 1, 16, 1]