### PR TITLE
fix link_in_order function may core dump in parallel compile bug

### DIFF
--- a/cinn/auto_schedule/measure/simple_runner.cc
+++ b/cinn/auto_schedule/measure/simple_runner.cc
@@ -109,8 +109,9 @@ static std::unordered_set<std::string> ParamsNeedInitWithZero(const MeasureInput
   for (auto* node : nodes) {
     if (kInitWithZeroParams.count(node->op()->name) != 0) {
       std::vector<int> param_idxs = kInitWithZeroParams.at(node->op()->name);
+      const auto& inlinks         = node->inlinks_in_order();
       for (int param_idx : param_idxs) {
-        const auto& inlinks    = node->inlinks_in_order();
+        CHECK_GT(inlinks.size(), param_idx);
         auto& edge             = inlinks.at(param_idx);
         std::string param_name = edge->source()->as<hlir::framework::NodeData>()->id();
         VLOG(6) << "param needs to be init with 0: " << param_name;

--- a/cinn/auto_schedule/measure/simple_runner.cc
+++ b/cinn/auto_schedule/measure/simple_runner.cc
@@ -110,7 +110,8 @@ static std::unordered_set<std::string> ParamsNeedInitWithZero(const MeasureInput
     if (kInitWithZeroParams.count(node->op()->name) != 0) {
       std::vector<int> param_idxs = kInitWithZeroParams.at(node->op()->name);
       for (int param_idx : param_idxs) {
-        auto& edge             = node->inlinks_in_order().at(param_idx);
+        const auto& inlinks    = node->inlinks_in_order();
+        auto& edge             = inlinks.at(param_idx);
         std::string param_name = edge->source()->as<hlir::framework::NodeData>()->id();
         VLOG(6) << "param needs to be init with 0: " << param_name;
         res.insert(param_name);

--- a/cinn/hlir/framework/graph.cc
+++ b/cinn/hlir/framework/graph.cc
@@ -481,7 +481,7 @@ std::unordered_set<NodeData*> Graph::Group::GetOutputNodeDatas() {
   std::unordered_set<NodeData*> group_outputs;
 
   for (auto node : this->output_nodes) {
-    for (auto& link : node->outlinks_in_order(true)) {
+    for (auto& link : node->outlinks_in_order()) {
       auto node_data = link->sink()->safe_as<NodeData>();
       if (!node_data) {
         continue;

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -1041,8 +1041,9 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
             instr->attrs.push_back(1);
           }
           // output shape
-          CHECK(!node->outlinks_in_order().empty());
-          auto& out_node     = node->outlinks_in_order().front();
+          const auto& out_links = node->outlinks_in_order();
+          CHECK(!out_links.empty());
+          auto& out_node     = out_links.front();
           std::string out_id = out_node->sink()->safe_as<NodeData>()->id();
           auto out_shape     = shape_dict.at(out_id);
           instr->attrs.insert(instr->attrs.end(), out_shape.begin(), out_shape.end());
@@ -1072,8 +1073,9 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
             instr->attrs.push_back(instr->attrs[1]);
           }
           // output shape
-          CHECK(!node->outlinks_in_order().empty());
-          auto& out_node     = node->outlinks_in_order().front();
+          const auto& out_links = node->outlinks_in_order();
+          CHECK(!out_links.empty());
+          auto& out_node     = out_links.front();
           std::string out_id = out_node->sink()->safe_as<NodeData>()->id();
           auto out_shape     = shape_dict.at(out_id);
           instr->attrs.insert(instr->attrs.end(), out_shape.begin(), out_shape.end());

--- a/cinn/hlir/framework/graph_compiler.cc
+++ b/cinn/hlir/framework/graph_compiler.cc
@@ -298,7 +298,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFuncWithIRSchedule(
   VLOG(3) << "GetOpFunc of op " << node->id();
 
   // 1.Collect inputs info and outputs info
-  for (auto& i : node->inlinks_in_order(true)) {
+  for (auto& i : node->inlinks_in_order()) {
     std::string id = i->source()->as<NodeData>()->id();
     auto shape     = shape_dict_.at(id);
     Type dtype     = type_dict_.at(id);
@@ -364,7 +364,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const Node* node) {
   std::vector<common::CINNValue> cinn_inputs;
   std::vector<std::vector<int>> output_shapes;
   VLOG(3) << "GetOpFunc of op " << node->id();
-  for (auto& i : node->inlinks_in_order(true)) {
+  for (auto& i : node->inlinks_in_order()) {
     std::string input_id = i->source()->as<NodeData>()->id();
     auto in_shape        = shape_dict.at(input_id);
     Type dtype           = dtype_dict.at(input_id);
@@ -400,7 +400,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const Node* node) {
     cinn_inputs.push_back(common::CINNValue(temp));
   }
   std::vector<Type> out_types;
-  for (auto& out : node->outlinks_in_order(true)) {
+  for (auto& out : node->outlinks_in_order()) {
     std::string out_id = out->sink()->safe_as<NodeData>()->id();
     auto out_shape     = shape_dict.at(out_id);
     Type dtype         = dtype_dict.at(out_id);
@@ -474,7 +474,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const std::vector<Node*>& 
     std::vector<common::CINNValue> cinn_inputs;
     std::vector<std::vector<int>> output_shapes;
     fuse_name += node->id() + "_";
-    for (auto& link : node->inlinks_in_order(true)) {
+    for (auto& link : node->inlinks_in_order()) {
       auto source = link->source();
       CHECK(source);
       auto source_data = source->as<NodeData>();
@@ -525,7 +525,7 @@ std::vector<ir::LoweredFunc> GraphCompiler::GetOpFunc(const std::vector<Node*>& 
     }
     std::vector<Type> out_types;
     std::vector<NodeData*> temp_outvars;
-    for (auto& out : node->outlinks_in_order(true)) {
+    for (auto& out : node->outlinks_in_order()) {
       auto out_var = out->sink()->safe_as<NodeData>();
       CHECK(out_var);
       out_vars.insert(out_var);
@@ -1009,8 +1009,8 @@ std::vector<std::unique_ptr<Instruction>> GraphCompiler::BuildInstructions(
       auto instr_name = node->op()->name;
       if (node->op()->name == "reshape" && compile_options_.with_instantiate_variables) {
         // not run instruction and shares buffer only when instantiate_variables
-        auto& inlinks  = node->inlinks_in_order();
-        auto& outlinks = node->outlinks_in_order();
+        const auto& inlinks  = node->inlinks_in_order();
+        const auto& outlinks = node->outlinks_in_order();
         CHECK_EQ(inlinks.size(), 1U);
         CHECK_EQ(outlinks.size(), 1U);
         std::string in_id       = inlinks[0]->source()->safe_as<NodeData>()->id();

--- a/cinn/hlir/framework/node.h
+++ b/cinn/hlir/framework/node.h
@@ -90,10 +90,10 @@ class Node : public common::GraphNode {
   NodeAttr attrs;
 
   //! Get the input tensors in order to match tensors correctly. If do refresh, we will update the links.
-  const std::vector<common::Shared<common::GraphEdge>> &inlinks_in_order(bool refresh = false) const;
+  std::vector<common::Shared<common::GraphEdge>> inlinks_in_order() const;
 
   //! Get the output tensors in order to match tensors correctly. If do refresh, we will update the links.
-  const std::vector<common::Shared<common::GraphEdge>> &outlinks_in_order(bool refresh = false) const;
+  std::vector<common::Shared<common::GraphEdge>> outlinks_in_order() const;
 
   inline const Operator *op() const { return this->attrs.op; }
 
@@ -126,8 +126,6 @@ class Node : public common::GraphNode {
    * \brief The unique id of the node.
    */
   std::string id_;
-  mutable std::vector<common::Shared<common::GraphEdge>> outlinks_in_order_{};
-  mutable std::vector<common::Shared<common::GraphEdge>> inlinks_in_order_{};
 };
 
 /**

--- a/cinn/hlir/framework/op_lowering.cc
+++ b/cinn/hlir/framework/op_lowering.cc
@@ -1134,7 +1134,7 @@ std::vector<ir::LoweredFunc> OpLowerer::IRLowerNonFusibleOp(GroupPtr& group, boo
     CHECK_EQ(pack.size(), 1UL);
     // reset input names as extern api input args can't be remove duplicate.
     group->input_names.clear();
-    for (auto& inode : node->inlinks_in_order(true)) {
+    for (auto& inode : node->inlinks_in_order()) {
       group->input_names.push_back(inode->source()->as<NodeData>()->id());
     }
     return {pack[0].operator ir::Expr().as_lowered_func_ref()};

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -30,7 +30,7 @@ struct NodeCompare {
 
 std::vector<NodeData*> GetInputNodeData(const Node* node) {
   std::vector<NodeData*> producers;
-  for (auto& link : node->inlinks_in_order(true)) {
+  for (auto& link : node->inlinks_in_order()) {
     auto node_data = link->source()->safe_as<NodeData>();
     producers.push_back(node_data);
   }
@@ -98,7 +98,7 @@ NodeData* GetNodeData(const Node* node) {
 
 std::vector<NodeData*> GetAllNodeData(const Node* node) {
   std::vector<NodeData*> node_datas;
-  for (auto& link : node->outlinks_in_order(true)) {
+  for (auto& link : node->outlinks_in_order()) {
     auto node_data = link->sink()->safe_as<NodeData>();
     CHECK(node_data);
     node_datas.push_back(node_data);
@@ -133,7 +133,7 @@ std::vector<Node*> GetConsumersInSet(const Node* node, const std::unordered_set<
 
 std::vector<Node*> GetProducers(const Node* node) {
   std::vector<Node*> producers;
-  for (auto& link : node->inlinks_in_order(true)) {
+  for (auto& link : node->inlinks_in_order()) {
     auto data = link->source()->safe_as<NodeData>();
     CHECK(data);
     if (data->source_node.get()) {
@@ -145,7 +145,7 @@ std::vector<Node*> GetProducers(const Node* node) {
 
 std::vector<Node*> GetProducersInSet(const Node* node, const std::unordered_set<Node*>& node_set) {
   std::vector<Node*> producers;
-  for (auto& link : node->inlinks_in_order(true)) {
+  for (auto& link : node->inlinks_in_order()) {
     auto data = link->source()->safe_as<NodeData>();
     CHECK(data);
     if (data->source_node.get() && node_set.count(data->source_node.get())) {

--- a/cinn/hlir/framework/visualize_helper.cc
+++ b/cinn/hlir/framework/visualize_helper.cc
@@ -296,7 +296,7 @@ void Summary(const std::vector<std::vector<Node*>>& groups, const std::string& v
 
 std::string DebugString(const Node* node) {
   std::vector<std::string> out_names;
-  for (auto& outlink : node->outlinks_in_order(true)) {
+  for (auto& outlink : node->outlinks_in_order()) {
     auto* outnode = outlink->sink()->safe_as<NodeData>();
     if (outnode) {
       out_names.emplace_back(outnode->id());
@@ -304,7 +304,7 @@ std::string DebugString(const Node* node) {
   }
 
   std::vector<std::string> in_names;
-  for (auto& inlink : node->inlinks_in_order(true)) {
+  for (auto& inlink : node->inlinks_in_order()) {
     auto* innode = inlink->source()->safe_as<NodeData>();
     if (innode) {
       in_names.emplace_back(innode->id());

--- a/cinn/hlir/pass/common_subexpression_elimination.cc
+++ b/cinn/hlir/pass/common_subexpression_elimination.cc
@@ -67,8 +67,8 @@ std::unordered_map<std::string, int> special_attrs = {
 
 bool IsSameSubexpression(Node* op1, Node* op2, shape_dict_t& shape_dict) {
   // Get the input edges for op1 and op2 in order.
-  auto op1_in_edges = op1->inlinks_in_order(true);
-  auto op2_in_edges = op2->inlinks_in_order(true);
+  auto op1_in_edges = op1->inlinks_in_order();
+  auto op2_in_edges = op2->inlinks_in_order();
   // Get the number of input edges for op1 and op2
   auto op1_inputs_size = op1_in_edges.size();
   auto op2_inputs_size = op2_in_edges.size();
@@ -202,7 +202,7 @@ void RemoveNodes(framework::Graph* graph, std::vector<NodeData*>& nodes_data) {
 
 void ReplaceNode(NodeData* src_new, NodeData* src_old, Node* trt) {
   std::vector<NodeData*> in_nodes;
-  for (auto& in_edge : trt->inlinks_in_order(true)) {
+  for (auto& in_edge : trt->inlinks_in_order()) {
     auto* in_node = in_edge->source()->safe_as<NodeData>();
     in_node->UnLinkSingleTo(trt);
     if (in_node->id() == src_old->id()) {
@@ -234,8 +234,8 @@ void CommonSubexpressionElimination(Graph* graph, std::vector<GraphNode*> store_
         // If node is different from candidate_node, continue the next.
         if (!IsSameSubexpression(node, candidate_node, shape_dict)) continue;
         found = true;
-        for (int k = 0; k < node->outlinks_in_order(true).size(); ++k) {
-          CHECK(node->outlinks_in_order(true).size() == candidate_node->outlinks_in_order(true).size());
+        for (int k = 0; k < node->outlinks_in_order().size(); ++k) {
+          CHECK(node->outlinks_in_order().size() == candidate_node->outlinks_in_order().size());
           auto* sink_node           = node->outlinks_in_order()[k]->sink()->safe_as<NodeData>();
           auto* candidate_sink_node = candidate_node->outlinks_in_order()[k]->sink()->safe_as<NodeData>();
           CHECK(sink_node);
@@ -282,7 +282,7 @@ void CommonSubexpressionEliminationPass(Graph* graph) {
   for (auto& graph_node : store_nodes) {
     auto node = graph_node->safe_as<Node>();
     if (node) {
-      for (auto& in_edge : node->inlinks_in_order(true)) {
+      for (auto& in_edge : node->inlinks_in_order()) {
         auto* source_node = in_edge->source()->safe_as<NodeData>();
         in2node[source_node->id()].insert(node);
       }

--- a/cinn/hlir/pass/common_subexpression_elimination.cc
+++ b/cinn/hlir/pass/common_subexpression_elimination.cc
@@ -235,9 +235,11 @@ void CommonSubexpressionElimination(Graph* graph, std::vector<GraphNode*> store_
         if (!IsSameSubexpression(node, candidate_node, shape_dict)) continue;
         found = true;
         for (int k = 0; k < node->outlinks_in_order().size(); ++k) {
-          CHECK(node->outlinks_in_order().size() == candidate_node->outlinks_in_order().size());
-          auto* sink_node           = node->outlinks_in_order()[k]->sink()->safe_as<NodeData>();
-          auto* candidate_sink_node = candidate_node->outlinks_in_order()[k]->sink()->safe_as<NodeData>();
+          const auto& out_links           = node->outlinks_in_order();
+          const auto& candidate_out_links = candidate_node->outlinks_in_order();
+          CHECK(out_links.size() == candidate_out_links.size());
+          auto* sink_node           = out_links[k]->sink()->safe_as<NodeData>();
+          auto* candidate_sink_node = candidate_out_links[k]->sink()->safe_as<NodeData>();
           CHECK(sink_node);
           CHECK(candidate_sink_node);
           remove_nodes_data.push_back(sink_node);

--- a/cinn/hlir/pass/const_propagate.cc
+++ b/cinn/hlir/pass/const_propagate.cc
@@ -36,7 +36,7 @@ void ConstPropagatePass(Graph* graph) {
     auto node = n->safe_as<Node>();
     if (node) {
       bool is_all_const = true;
-      for (auto& in_edge : node->inlinks_in_order(true)) {
+      for (auto& in_edge : node->inlinks_in_order()) {
         auto* source_node = in_edge->source()->safe_as<NodeData>();
         CHECK(source_node);
         if (!source_node->is_const()) {
@@ -47,7 +47,7 @@ void ConstPropagatePass(Graph* graph) {
       if (is_all_const) {
         node->attrs.attr_store["pre_run"] = true;
         VLOG(4) << node->id() << " do pre_run";
-        for (auto& out_edge : node->outlinks_in_order(true)) {
+        for (auto& out_edge : node->outlinks_in_order()) {
           // mark all out nodedatas as const
           auto* sink_node = out_edge->sink()->safe_as<NodeData>();
           CHECK(sink_node);

--- a/cinn/hlir/pass/custom_call_pass.cc
+++ b/cinn/hlir/pass/custom_call_pass.cc
@@ -58,7 +58,7 @@ class GraphAlterHelper {
       // codegen-registered is not consistent with cudnn
       if ((node->op()->name == "conv2d" || node->op()->name == "depthwise_conv2d") &&
           target == common::DefaultNVGPUTarget()) {
-        auto out_links = node->outlinks_in_order(true);
+        auto out_links = node->outlinks_in_order();
         for (int idx = 1; idx < out_links.size(); ++idx) {
           auto link = out_links[idx];
           CHECK(link->sink()->safe_as<NodeData>());

--- a/cinn/hlir/pass/dense_merge_pass.cc
+++ b/cinn/hlir/pass/dense_merge_pass.cc
@@ -89,7 +89,7 @@ class DenseMergePassHelper : public FusionHelperBase {
     // split dense op by it's attr
     std::unordered_map<std::string, std::vector<Node*>> dense_op_map;
     for (auto dense_op : dense_ops) {
-      auto sign = GenOpSign(dense_op->inlinks_in_order(true)[pos]->source()->safe_as<NodeData>(), dense_op->attrs);
+      auto sign = GenOpSign(dense_op->inlinks_in_order()[pos]->source()->safe_as<NodeData>(), dense_op->attrs);
       if (dense_op_map.count(sign)) {
         dense_op_map[sign].push_back(dense_op);
       } else {

--- a/cinn/hlir/pass/fusion_helper_base.h
+++ b/cinn/hlir/pass/fusion_helper_base.h
@@ -89,7 +89,7 @@ class FusionHelperBase {
 
   static std::vector<NodeData*> GetProducerNodeData(const Node* node) {
     std::vector<NodeData*> producer_node_data;
-    for (auto& edge : node->inlinks_in_order(true)) {
+    for (auto& edge : node->inlinks_in_order()) {
       auto graph_node    = edge->source();
       auto producer_data = graph_node->safe_as<NodeData>();
       CHECK(producer_data);
@@ -100,7 +100,7 @@ class FusionHelperBase {
 
   std::vector<Node*> GetProducerNode(const Node* node) const {
     std::vector<Node*> producer_node;
-    for (auto& edge : node->inlinks_in_order(true)) {
+    for (auto& edge : node->inlinks_in_order()) {
       auto graph_node    = edge->source();
       auto producer_data = graph_node->safe_as<NodeData>();
       CHECK(producer_data);

--- a/cinn/hlir/pass/opfusion.cc
+++ b/cinn/hlir/pass/opfusion.cc
@@ -124,8 +124,8 @@ class DomTree {
     DomNode* parent = nullptr;
     int count       = 0;
     if (graph_node->safe_as<Node>()) {
-      auto* node      = graph_node->safe_as<Node>();
-      auto& out_links = node->outlinks_in_order(true);
+      auto* node            = graph_node->safe_as<Node>();
+      const auto& out_links = node->outlinks_in_order();
       for (int i = 0; i < out_links.size(); i++) {
         auto sink         = out_links[i]->sink();
         bool has_no_links = sink->outlinks().empty();
@@ -319,7 +319,7 @@ class GraphPartition {
     if (source == sink) return true;
     auto op_node = source->safe_as<Node>();
     if (op_node) {
-      auto& out_links = op_node->outlinks_in_order(true);
+      const auto& out_links = op_node->outlinks_in_order();
       for (int i = 0; i < out_links.size(); i++) {
         auto new_source = out_links[i]->sink();
         // judge only the first out var of the op node can fuse
@@ -357,7 +357,7 @@ class GraphPartition {
       }
     }
     if (op_node) {
-      auto& outlinks = op_node->outlinks_in_order(true);
+      const auto& outlinks = op_node->outlinks_in_order();
       for (int i = 0; i < outlinks.size(); i++) {
         auto* new_source = outlinks[i]->sink();
         if (!i) {
@@ -405,7 +405,7 @@ class GraphPartition {
     MergeNodes(group_node, target);
     auto op_node = source->safe_as<Node>();
     if (op_node) {
-      auto& outlinks = op_node->outlinks_in_order(true);
+      const auto& outlinks = op_node->outlinks_in_order();
       for (int i = 0; i < outlinks.size(); i++) {
         auto* new_source = outlinks[i]->sink();
         if (!i) {


### PR DESCRIPTION
As title. 现`inlink_in_order`和`outlink_in_order`函数会修改Node里成员变量`inlink_in_order_`和`outlink_in_order_`的值，而OpLowering步骤中，这两个函数会被经常调用。同时由于recompute的存在，同一个node可能会被多个group同时用到，因此并行编译时，这两函数极有可能会出现core dump。本PR在不引入mutex的情况下，修复了该问题。