### PR TITLE
fix constant_folding_pass when NodeData to be optimized is in outputs of graph 

### DIFF
--- a/cinn/hlir/pass/constant_folding_pass.cc
+++ b/cinn/hlir/pass/constant_folding_pass.cc
@@ -57,6 +57,16 @@ class ConstantFoldingPassHelper : public FusionHelperBase {
             can_fold = false;
             break;
           }
+          // if producer's output in graph_->outputs, then will not fold
+          for (auto& edge : producer->outlinks()) {
+            auto graph_node = edge->sink();
+            auto data       = graph_node->safe_as<NodeData>();
+            CHECK(data);
+            if (std::find(graph_->outputs.begin(), graph_->outputs.end(), data) != graph_->outputs.end()) {
+              can_fold = false;
+              break;
+            }
+          }
         }
 
         if (!can_fold) continue;


### PR DESCRIPTION
If the NodeData between the two nodes to be optimized is in graph ->outputs, it cannot be directly optimized and fused