### PR TITLE
Add reduce test using new test helper

### DIFF
--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -22,6 +22,7 @@
 #include "cinn/hlir/pe/broadcast.h"
 #include "cinn/utils/functional.h"
 #include "cinn/utils/profiler.h"
+#include "glog/logging.h"
 
 namespace cinn {
 namespace frontend {
@@ -109,7 +110,8 @@ Variable NetBuilder::Reduce(const std::string& op_type, const Variable& x, const
     if (keep_dim) {
       return Identity(x);
     } else {
-      int new_rank = dim.empty() ? 1 : x->shape.size() - dim.size() + 1;
+      CHECK_GE(x->shape.size(), dim.size()) << "The inputs rank should be greater than or equal to axes.";
+      int new_rank = x->shape.size() == dim.size() ? 1 : x->shape.size() - dim.size();
       std::vector<int> new_shape(new_rank, 1);
       return Reshape(x, new_shape);
     }

--- a/python/tests/ops/test_reduce_op_new.py
+++ b/python/tests/ops/test_reduce_op_new.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestReduceOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["shape"], dtype=self.case["dtype"])
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        if self.case["op_type"] == "sum":
+            out = paddle.sum(
+                x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+        elif self.case["op_type"] == "prod":
+            out = paddle.prod(
+                x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+        elif self.case["op_type"] == "max":
+            out = paddle.max(
+                x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+        elif self.case["op_type"] == "min":
+            out = paddle.min(
+                x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+        elif self.case["op_type"] == "all":
+            out = paddle.all(
+                x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+        elif self.case["op_type"] == "any":
+            out = paddle.any(
+                x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+        else:
+            out = paddle.nn.Identity(x)
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("reduce")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["dtype"]), self.case["shape"], "x")
+        if self.case["op_type"] == "sum":
+            out = builder.reduce_sum(x, [self.case["axis"]],
+                                     self.case["keepdim"])
+        elif self.case["op_type"] == "prod":
+            out = builder.reduce_prod(x, [self.case["axis"]],
+                                      self.case["keepdim"])
+        elif self.case["op_type"] == "max":
+            out = builder.reduce_max(x, [self.case["axis"]],
+                                     self.case["keepdim"])
+        elif self.case["op_type"] == "min":
+            out = builder.reduce_min(x, [self.case["axis"]],
+                                     self.case["keepdim"])
+        elif self.case["op_type"] == "all":
+            out = builder.reduce_all(x, [self.case["axis"]],
+                                     self.case["keepdim"])
+        elif self.case["op_type"] == "any":
+            out = builder.reduce_any(x, [self.case["axis"]],
+                                     self.case["keepdim"])
+        else:
+            out = builder.identity(x)
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+        self.cinn_outputs = res
+
+    def test_check_results(self):
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
+
+
+class TestReduceAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestReduceOpCase"
+        self.cls = TestReduceOp
+        self.inputs = [
+            {
+                "shape": [1],
+                "axis": -1,
+            },
+            {
+                "shape": [1024],
+                "axis": 0,
+            },
+            {
+                "shape": [512, 256],
+                "axis": 1,
+            },
+            {
+                "shape": [128, 64, 32],
+                "axis": 2,
+            },
+            {
+                "shape": [16, 8, 4, 2],
+                "axis": 3,
+            },
+            {
+                "shape": [16, 8, 4, 2, 1],
+                "axis": 3,
+            },
+            {
+                "shape": [1, 1, 1, 1, 1],
+                "axis": 3,
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "int16",
+            },
+            {
+                "dtype": "int32",
+            },
+            {
+                "dtype": "int64",
+            },
+            {
+                "dtype": "float16",
+            },
+            {
+                "dtype": "float32",
+            },
+            {
+                "dtype": "float64",
+            },
+        ]
+        self.attrs = [
+            {
+                "op_type": "sum",
+                "keepdim": True
+            },
+            {
+                "op_type": "sum",
+                "keepdim": False
+            },
+            {
+                "op_type": "prod",
+                "keepdim": True
+            },
+            {
+                "op_type": "prod",
+                "keepdim": False
+            },
+            {
+                "op_type": "max",
+                "keepdim": True
+            },
+            {
+                "op_type": "max",
+                "keepdim": False
+            },
+            {
+                "op_type": "min",
+                "keepdim": True
+            },
+            {
+                "op_type": "min",
+                "keepdim": False
+            },
+        ]
+
+
+class TestReduceForBool(TestReduceAll):
+    def init_attrs(self):
+        super().init_attrs()
+        self.dtypes = [{"dtype": "bool"}]
+        self.attrs = [
+            {
+                "op_type": "all",
+                "keepdim": True
+            },
+            {
+                "op_type": "all",
+                "keepdim": False
+            },
+            {
+                "op_type": "any",
+                "keepdim": True
+            },
+            {
+                "op_type": "any",
+                "keepdim": False
+            },
+        ]
+
+
+if __name__ == "__main__":
+    TestReduceAll().run()
+    TestReduceForBool().run()

--- a/python/tests/ops/test_reduce_op_new.py
+++ b/python/tests/ops/test_reduce_op_new.py
@@ -56,7 +56,7 @@ class TestReduceOp(OpTest):
             out = paddle.any(
                 x, axis=self.case["axis"], keepdim=self.case["keepdim"])
         else:
-            out = paddle.nn.Identity(x)
+            out = paddle.assign(x)
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
@@ -64,22 +64,22 @@ class TestReduceOp(OpTest):
         x = builder.create_input(
             self.nptype2cinntype(self.case["dtype"]), self.case["shape"], "x")
         if self.case["op_type"] == "sum":
-            out = builder.reduce_sum(x, [self.case["axis"]],
+            out = builder.reduce_sum(x, self.case["axis"],
                                      self.case["keepdim"])
         elif self.case["op_type"] == "prod":
-            out = builder.reduce_prod(x, [self.case["axis"]],
+            out = builder.reduce_prod(x, self.case["axis"],
                                       self.case["keepdim"])
         elif self.case["op_type"] == "max":
-            out = builder.reduce_max(x, [self.case["axis"]],
+            out = builder.reduce_max(x, self.case["axis"],
                                      self.case["keepdim"])
         elif self.case["op_type"] == "min":
-            out = builder.reduce_min(x, [self.case["axis"]],
+            out = builder.reduce_min(x, self.case["axis"],
                                      self.case["keepdim"])
         elif self.case["op_type"] == "all":
-            out = builder.reduce_all(x, [self.case["axis"]],
+            out = builder.reduce_all(x, self.case["axis"],
                                      self.case["keepdim"])
         elif self.case["op_type"] == "any":
-            out = builder.reduce_any(x, [self.case["axis"]],
+            out = builder.reduce_any(x, self.case["axis"],
                                      self.case["keepdim"])
         else:
             out = builder.identity(x)
@@ -100,31 +100,31 @@ class TestReduceAll(TestCaseHelper):
         self.inputs = [
             {
                 "shape": [1],
-                "axis": -1,
+                "axis": [-1],
             },
             {
                 "shape": [1024],
-                "axis": 0,
+                "axis": [0],
             },
             {
                 "shape": [512, 256],
-                "axis": 1,
+                "axis": [1],
             },
             {
                 "shape": [128, 64, 32],
-                "axis": 2,
+                "axis": [2],
             },
             {
                 "shape": [16, 8, 4, 2],
-                "axis": 3,
+                "axis": [3],
             },
             {
                 "shape": [16, 8, 4, 2, 1],
-                "axis": 3,
+                "axis": [3],
             },
             {
                 "shape": [1, 1, 1, 1, 1],
-                "axis": 3,
+                "axis": [3],
             },
         ]
         self.dtypes = [
@@ -185,30 +185,5 @@ class TestReduceAll(TestCaseHelper):
         ]
 
 
-class TestReduceForBool(TestReduceAll):
-    def init_attrs(self):
-        super().init_attrs()
-        self.dtypes = [{"dtype": "bool"}]
-        self.attrs = [
-            {
-                "op_type": "all",
-                "keepdim": True
-            },
-            {
-                "op_type": "all",
-                "keepdim": False
-            },
-            {
-                "op_type": "any",
-                "keepdim": True
-            },
-            {
-                "op_type": "any",
-                "keepdim": False
-            },
-        ]
-
-
 if __name__ == "__main__":
     TestReduceAll().run()
-    TestReduceForBool().run()

--- a/python/tests/ops/test_reduce_op_new.py
+++ b/python/tests/ops/test_reduce_op_new.py
@@ -38,6 +38,8 @@ class TestReduceOp(OpTest):
         if self.case["op_type"] == "sum":
             out = paddle.sum(
                 x, axis=self.case["axis"], keepdim=self.case["keepdim"])
+            if self.case["dtype"] == "int32":
+                out = out.cast(self.case["dtype"])
         elif self.case["op_type"] == "prod":
             out = paddle.prod(
                 x, axis=self.case["axis"], keepdim=self.case["keepdim"])
@@ -126,18 +128,20 @@ class TestReduceAll(TestCaseHelper):
             },
         ]
         self.dtypes = [
-            {
-                "dtype": "int16",
-            },
+            # Paddle reduce not support
+            # {
+            #     "dtype": "int16",
+            # },
             {
                 "dtype": "int32",
             },
             {
                 "dtype": "int64",
             },
-            {
-                "dtype": "float16",
-            },
+            # Paddle reduce not support
+            # {
+            #     "dtype": "float16",
+            # },
             {
                 "dtype": "float32",
             },

--- a/python/tests/ops/test_reduce_op_other.py
+++ b/python/tests/ops/test_reduce_op_other.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test_reduce_op_new import TestReduceAll
+
+
+class TestReduceForBool(TestReduceAll):
+    def init_attrs(self):
+        super().init_attrs()
+        self.dtypes = [{"dtype": "bool"}]
+        self.attrs = [
+            {
+                "op_type": "all",
+                "keepdim": True
+            },
+            {
+                "op_type": "all",
+                "keepdim": False
+            },
+            {
+                "op_type": "any",
+                "keepdim": True
+            },
+            {
+                "op_type": "any",
+                "keepdim": False
+            },
+        ]
+
+
+class TestReduceAxis(TestReduceAll):
+    def init_attrs(self):
+        super().init_attrs()
+        self.inputs = [
+            {
+                "shape": [1, 512, 1],
+                "axis": [1],
+            },
+            {
+                "shape": [1, 1024, 1],
+                "axis": [1],
+            },
+            {
+                "shape": [1, 2048, 1],
+                "axis": [1],
+            },
+            {
+                "shape": [64, 32, 16, 8, 4],
+                "axis": [0, 2],
+            },
+            {
+                "shape": [64, 32, 16, 8, 4],
+                "axis": [1, 2, 3],
+            },
+            {
+                # No axis, all reduce
+                "shape": [64, 32, 16, 8, 4],
+                "axis": [],
+            },
+        ]
+        self.dtypes = [{"dtype": "float32"}]
+        self.attrs = [
+            {
+                "op_type": "sum",
+                "keepdim": True,
+            },
+            {
+                "op_type": "sum",
+                "keepdim": False,
+            },
+        ]
+
+
+if __name__ == "__main__":
+    TestReduceForBool().run()
+    TestReduceAxis().run()


### PR DESCRIPTION
## 描述

From https://github.com/PaddlePaddle/CINN/issues/1378

为Reduce类型算子增加新的测试用例

序号 | 算子名 | 单测文件 | 
-- | -- | -- | 
57 | reduce_sum | test_reduce_op.py | 
58 | reduce_prod | test_reduce_op.py | 
59 | reduce_max | test_reduce_op.py | 
60 | reduce_min | test_reduce_op.py |  
61 | reduce_all | test_reduce_op.py | 
62 | reduce_any | test_reduce_op.py | 

### 算子类型

- [ ] ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ] Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ] Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [x] Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ] OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [ ] kNonFusible：无法融合的算子

### OpMapper

- [ ] 该算子是否 OpMapper? 如果是，请贴出在 Paddle 中对应的 OpMaker 代码路径。（给出 Github 链接更好）

## Test Cases Checklist

### 张量维度

- [x] 1D 张量
- [x] 2D 张量
- [x] 3D 张量
- [x] 4D 张量

#### special shape

挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x] 其中一个维度为 1
- [x] 其中一个维度小于 1024
- [ ] 其中一个维度大于 1024
- [x] 向量的所有维度都是 1

### 张量数据类型

- [x] int32
- [x] int64
- [x] float16
- [x] float32
- [x] float64

### 广播

- [ ] 这个算子是否支持广播？
- [ ] 广播的测试样例

### 算子属性

算子属性的测试用例。

- [x] 属性：属性类型-可取值
    - [x] `op_type`
    - [x] `axis`
    - [x] `keepdim`
- [x] 使用 OpTestHelper 测试上述属性的笛卡尔积组合

### 备注

1. 本PR将作为快乐开源活动的参考，如需更多的参考样例，可查看`python/test/ops`下的`test_add_op_new.py`、`test_relu6_op.py`、`test_left_shift_op.py`、`test_right_shift_op.py`、`test_scale_op.py`和`test_dropout_infer_op.py`
2. 测试过程可能会发现算子在某些`shape`、`dtype`和属性组合的情况下出现错误，如果是较为简单的类型不支持等错误，可尝试在PR中顺带一起解决，如果是较为复杂的错误，可以寻求其他小伙伴协助解决
3. 本PR在测试过程中发现了以下问题：
    - 数据类型为`int32`的情况下，paddle的`sum`得到的输出数据类型为`int64`，需要特殊处理，已添加`cast`算子处理
    - `reduce_all`和`reduce_any`的`keepdim`参数未生效，已修复
    - 特殊case`shape=[64, 32, 16, 8, 4], axis=[], keepdim=True`的计算结果错误，经排查发现生成的代码有数据读写冲突的问题，已修复