### PR TITLE
Add Op UnitTest for divide

### DIFF
--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -92,8 +92,98 @@ class TestDivAll(TestCaseHelper):
                 "y_shape": [1, 5, 2],
             },
             {
-                "x_shape": [2, 2, 32],
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 8, 4, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
+            {
+                "x_dtype": "float32",
+                "y_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+                "y_dtype": "float64",
+            },
+        ]
+        self.attrs = []
+
+
+class TestDivNegOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.init_case()
+
+    def init_case(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-10,
+            high=10)
+        self.y_np = self.random(
+            shape=self.case["y_shape"],
+            dtype=self.case["y_dtype"],
+            low=-10,
+            high=-1)
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        y = paddle.to_tensor(self.y_np, stop_gradient=True)
+
+        out = paddle.divide(x, y)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("div")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        y = builder.create_input(
+            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
+            "y")
+        out = builder.divide(x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.x_np, self.y_np], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
+
+
+class TestDivNegAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestDivNegOpCase"
+        self.cls = TestDivNegOp
+        self.inputs = [
+            {
+                "x_shape": [32],
                 "y_shape": [32],
+            },
+            {
+                "x_shape": [32, 64],
+                "y_shape": [32, 64],
+            },
+            {
+                "x_shape": [2, 3, 4],
+                "y_shape": [1, 5, 2],
             },
             {
                 "x_shape": [16, 8, 4, 2],
@@ -127,3 +217,4 @@ class TestDivAll(TestCaseHelper):
 
 if __name__ == "__main__":
     TestDivAll().run()
+    TestDivNegAll().run()

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -41,7 +41,7 @@ class TestDivOp(OpTest):
         self.y_np = self.random(
             shape=self.case["y_shape"],
             dtype=self.case["y_dtype"],
-            low=-10,
+            low=1,
             high=10)
 
     def build_paddle_program(self, target):
@@ -80,31 +80,39 @@ class TestDivAll(TestCaseHelper):
         self.cls = TestDivOp
         self.inputs = [
             {
-                "x_shape": [2, 3, 4],
-                "y_shape": [1, 5, 2],
+                "x_shape": [32],
+                "y_shape": [32],
             },
             {
                 "x_shape": [32, 64],
                 "y_shape": [32, 64],
             },
             {
+                "x_shape": [2, 3, 4],
+                "y_shape": [1, 5, 2],
+            },
+            {
                 "x_shape": [2, 2, 32],
                 "y_shape": [32],
             },
             {
-                "x_shape": [32],
-                "y_shape": [32],
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 8, 4, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
             },
         ]
         self.dtypes = [
-            #{
-            #    "x_dtype": "int32",
-            #    "y_dtype": "int32",
-            #},
-            #{
-            #    "x_dtype": "int64",
-            #    "y_dtype": "int64",
-            #},
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
             {
                 "x_dtype": "float32",
                 "y_dtype": "float32",

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -74,6 +74,10 @@ class TestDivAll(TestCaseHelper):
         self.cls = TestDivOp
         self.inputs = [
             {
+                "x_shape": [2, 3, 4],
+                "y_shape": [1, 5, 2],
+            },
+            {
                 "x_shape": [32, 64],
                 "y_shape": [32, 64],
             },
@@ -82,8 +86,8 @@ class TestDivAll(TestCaseHelper):
                 "y_shape": [32],
             },
             {
-                "x_shape": [2, 32],
-                "y_shape": [1],
+                "x_shape": [32],
+                "y_shape": [32],
             },
         ]
         self.dtypes = [

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -91,14 +91,14 @@ class TestDivAll(TestCaseHelper):
             },
         ]
         self.dtypes = [
-            {
-                "x_dtype": "int32",
-                "y_dtype": "int32",
-            },
-            {
-                "x_dtype": "int64",
-                "y_dtype": "int64",
-            },
+            #{
+            #    "x_dtype": "int32",
+            #    "y_dtype": "int32",
+            #},
+            #{
+            #    "x_dtype": "int64",
+            #    "y_dtype": "int64",
+            #},
             {
                 "x_dtype": "float32",
                 "y_dtype": "float32",

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -95,6 +95,10 @@ class TestDivAll(TestCaseHelper):
                 "x_shape": [16, 8, 4, 2],
                 "y_shape": [16, 8, 4, 2],
             },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
+            },
         ]
         self.dtypes = [
             {
@@ -184,6 +188,10 @@ class TestDivNegAll(TestCaseHelper):
             {
                 "x_shape": [16, 8, 4, 2],
                 "y_shape": [16, 8, 4, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
             },
         ]
         self.dtypes = [

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -97,14 +97,14 @@ class TestDivAll(TestCaseHelper):
             },
         ]
         self.dtypes = [
-            {
-                "x_dtype": "int32",
-                "y_dtype": "int32",
-            },
-            {
-                "x_dtype": "int64",
-                "y_dtype": "int64",
-            },
+            #{
+            #    "x_dtype": "int32",
+            #    "y_dtype": "int32",
+            #},
+            #{
+            #    "x_dtype": "int64",
+            #    "y_dtype": "int64",
+            #},
             {
                 "x_dtype": "float32",
                 "y_dtype": "float32",

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -95,10 +95,6 @@ class TestDivAll(TestCaseHelper):
                 "x_shape": [16, 8, 4, 2],
                 "y_shape": [16, 8, 4, 2],
             },
-            {
-                "x_shape": [16, 8, 4, 2, 1],
-                "y_shape": [16, 8, 4, 2, 1],
-            },
         ]
         self.dtypes = [
             {
@@ -188,10 +184,6 @@ class TestDivNegAll(TestCaseHelper):
             {
                 "x_shape": [16, 8, 4, 2],
                 "y_shape": [16, 8, 4, 2],
-            },
-            {
-                "x_shape": [16, 8, 4, 2, 1],
-                "y_shape": [16, 8, 4, 2, 1],
             },
         ]
         self.dtypes = [

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -34,9 +34,15 @@ class TestDivOp(OpTest):
 
     def init_case(self):
         self.x_np = self.random(
-            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-10,
+            high=10)
         self.y_np = self.random(
-            shape=self.case["y_shape"], dtype=self.case["y_dtype"])
+            shape=self.case["y_shape"],
+            dtype=self.case["y_dtype"],
+            low=-10,
+            high=10)
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)
@@ -91,14 +97,14 @@ class TestDivAll(TestCaseHelper):
             },
         ]
         self.dtypes = [
-            #{
-            #    "x_dtype": "int32",
-            #    "y_dtype": "int32",
-            #},
-            #{
-            #    "x_dtype": "int64",
-            #    "y_dtype": "int64",
-            #},
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
             {
                 "x_dtype": "float32",
                 "y_dtype": "float32",


### PR DESCRIPTION
## 描述
为 divide 算子增加单测文件

## 算子类型

- [x]  ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ]  Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ]  Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [ ]  Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ]  OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [ ]  kNonFusible：无法融合的算子

## OpMapper
否

## Test Cases Checklist

## 张量维度

- [x]  1D 张量
- [x]  2D 张量
- [x]  3D 张量
- [x]  4D 张量

special shape
挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x]  其中一个维度为 1
- [x]  其中一个维度小于 1024
- [ ]  其中一个维度大于 1024
- [ ]  向量的所有维度都是 1

## 张量数据类型

- [ ]  bool
- [ ]  int16
- [x]  int32
- [x]  int64
- [ ]  float16
- [x]  float32
- [x]  float64

## 广播

- [ ]  这个算子是否支持广播？
- [ ]  广播的测试样例

## 算子属性
算子属性的测试用例。

- [ ]  属性：属性类型-可取值