### PR TITLE
Add Op UnitTest for floor_divide

### DIFF
--- a/python/tests/ops/test_floor_divide_op.py
+++ b/python/tests/ops/test_floor_divide_op.py
@@ -80,20 +80,20 @@ class TestFloorDivideAll(TestCaseHelper):
         self.cls = TestFloorDivideOp
         self.inputs = [
             {
-                "x_shape": [32],
-                "y_shape": [32],
+                "x_shape": [1],
+                "y_shape": [1],
             },
             {
-                "x_shape": [32, 64],
-                "y_shape": [32, 64],
+                "x_shape": [1024],
+                "y_shape": [1024],
             },
             {
-                "x_shape": [2, 3, 4],
-                "y_shape": [2, 3, 4],
+                "x_shape": [512, 256],
+                "y_shape": [512, 256],
             },
             {
-                "x_shape": [2, 2, 32],
-                "y_shape": [2, 2, 32],
+                "x_shape": [128, 64, 32],
+                "y_shape": [128, 64, 32],
             },
             {
                 "x_shape": [16, 8, 4, 2],
@@ -102,6 +102,49 @@ class TestFloorDivideAll(TestCaseHelper):
             {
                 "x_shape": [16, 8, 4, 2, 1],
                 "y_shape": [16, 8, 4, 2, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
+        ]
+        self.attrs = []
+
+
+class TestFloorDivideAllWithBroadcast(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestFloorDivideOpCase"
+        self.cls = TestFloorDivideOp
+        self.inputs = [
+            {
+                "x_shape": [1],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [1024],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [512, 256],
+                "y_shape": [1, 1],
+            },
+            {
+                "x_shape": [128, 64, 32],
+                "y_shape": [1, 1, 1],
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [1, 1, 1, 1],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [1, 1, 1, 1, 1],
             },
         ]
         self.dtypes = [
@@ -170,20 +213,20 @@ class TestFloorDivideNegAll(TestCaseHelper):
         self.cls = TestFloorDivideNegOp
         self.inputs = [
             {
-                "x_shape": [32],
-                "y_shape": [32],
+                "x_shape": [1],
+                "y_shape": [1],
             },
             {
-                "x_shape": [32, 64],
-                "y_shape": [32, 64],
+                "x_shape": [1024],
+                "y_shape": [1024],
             },
             {
-                "x_shape": [2, 3, 4],
-                "y_shape": [2, 3, 4],
+                "x_shape": [512, 256],
+                "y_shape": [512, 256],
             },
             {
-                "x_shape": [2, 2, 32],
-                "y_shape": [2, 2, 32],
+                "x_shape": [128, 64, 32],
+                "y_shape": [128, 64, 32],
             },
             {
                 "x_shape": [16, 8, 4, 2],
@@ -207,6 +250,51 @@ class TestFloorDivideNegAll(TestCaseHelper):
         self.attrs = []
 
 
+class TestFloorDivideNegAllWithBroadcast(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestFloorDivideNegOpCase"
+        self.cls = TestFloorDivideNegOp
+        self.inputs = [
+            {
+                "x_shape": [1],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [1024],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [512, 256],
+                "y_shape": [1, 1],
+            },
+            {
+                "x_shape": [128, 64, 32],
+                "y_shape": [1, 1, 1],
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [1, 1, 1, 1],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [1, 1, 1, 1, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
+        ]
+        self.attrs = []
+
+
 if __name__ == "__main__":
     TestFloorDivideAll().run()
     TestFloorDivideNegAll().run()
+    TestFloorDivideAllWithBroadcast().run()
+    TestFloorDivideNegAllWithBroadcast().run()

--- a/python/tests/ops/test_floor_divide_op.py
+++ b/python/tests/ops/test_floor_divide_op.py
@@ -17,6 +17,7 @@
 import unittest
 import numpy as np
 from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
 import paddle
 import paddle.nn.functional as F
 import cinn
@@ -28,17 +29,24 @@ from cinn.common import *
                     "x86 test will be skipped due to timeout.")
 class TestFloorDivideOp(OpTest):
     def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
         self.init_case()
 
     def init_case(self):
-        self.inputs = {
-            "x": np.array([7]).astype('int32'),
-            "y": np.array([-3]).astype('int32')
-        }
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-10,
+            high=10)
+        self.y_np = self.random(
+            shape=self.case["y_shape"],
+            dtype=self.case["y_dtype"],
+            low=1,
+            high=10)
 
     def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        y = paddle.to_tensor(self.y_np, stop_gradient=True)
 
         out = paddle.floor_divide(x, y)
 
@@ -47,38 +55,158 @@ class TestFloorDivideOp(OpTest):
     def build_cinn_program(self, target):
         builder = NetBuilder("pow")
         x = builder.create_input(
-            self.nptype2cinntype(self.inputs["x"].dtype),
-            self.inputs["x"].shape, "x")
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
         y = builder.create_input(
-            self.nptype2cinntype(self.inputs["y"].dtype),
-            self.inputs["y"].shape, "y")
+            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
+            "y")
         out = builder.floor_divide(x, y)
 
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [x, y],
-                                   [self.inputs["x"], self.inputs["y"]], [out])
+                                   [self.x_np, self.y_np], [out])
 
         self.cinn_outputs = [res[0]]
 
     def test_check_results(self):
-        self.check_outputs_and_grads()
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
-class TestFloorDivideCase1(TestFloorDivideOp):
+class TestFloorDivideAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestFloorDivideOpCase"
+        self.cls = TestFloorDivideOp
+        self.inputs = [
+            {
+                "x_shape": [32],
+                "y_shape": [32],
+            },
+            {
+                "x_shape": [32, 64],
+                "y_shape": [32, 64],
+            },
+            {
+                "x_shape": [2, 3, 4],
+                "y_shape": [2, 3, 4],
+            },
+            {
+                "x_shape": [2, 2, 32],
+                "y_shape": [2, 2, 32],
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 8, 4, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
+        ]
+        self.attrs = []
+
+
+class TestFloorDivideNegOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.init_case()
+
     def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "int32", 20, 100),
-            "y": self.random([32, 64], "int32", 1, 20),
-        }
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-10,
+            high=10)
+        self.y_np = self.random(
+            shape=self.case["y_shape"],
+            dtype=self.case["y_dtype"],
+            low=-10,
+            high=-1)
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        y = paddle.to_tensor(self.y_np, stop_gradient=True)
+
+        out = paddle.floor_divide(x, y)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("pow")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        y = builder.create_input(
+            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
+            "y")
+        out = builder.floor_divide(x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.x_np, self.y_np], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
-class TestFloorDivideCase2(TestFloorDivideOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "int32", 20, 100),
-            "y": self.random([32, 64], "int32", -20, -1),
-        }
+class TestFloorDivideNegAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestFloorDivideNegOpCase"
+        self.cls = TestFloorDivideNegOp
+        self.inputs = [
+            {
+                "x_shape": [32],
+                "y_shape": [32],
+            },
+            {
+                "x_shape": [32, 64],
+                "y_shape": [32, 64],
+            },
+            {
+                "x_shape": [2, 3, 4],
+                "y_shape": [2, 3, 4],
+            },
+            {
+                "x_shape": [2, 2, 32],
+                "y_shape": [2, 2, 32],
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 8, 4, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "x_dtype": "int32",
+                "y_dtype": "int32",
+            },
+            {
+                "x_dtype": "int64",
+                "y_dtype": "int64",
+            },
+        ]
+        self.attrs = []
 
 
 if __name__ == "__main__":
-    unittest.main()
+    TestFloorDivideAll().run()
+    TestFloorDivideNegAll().run()


### PR DESCRIPTION
## 描述
为 floor_divide 算子增加单测文件

## 算子类型

- [x]  ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ]  Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ]  Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [ ]  Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ]  OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [ ]  kNonFusible：无法融合的算子

## OpMapper
否

## Test Cases Checklist

## 张量维度

- [x]  1D 张量
- [x]  2D 张量
- [x]  3D 张量
- [x]  4D 张量

special shape
挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x]  其中一个维度为 1
- [x]  其中一个维度小于 1024
- [ ]  其中一个维度大于 1024
- [ ]  向量的所有维度都是 1

## 张量数据类型

- [ ]  bool
- [ ]  int16
- [x]  int32
- [x]  int64
- [ ]  float16
- [ ]  float32
- [ ]  float64

## 广播

- [ ]  这个算子是否支持广播？
- [ ]  广播的测试样例

## 算子属性
算子属性的测试用例。

- [ ]  属性：属性类型-可取值