### PR TITLE
add fusion python test utils

### DIFF
--- a/cinn/frontend/optimize.cc
+++ b/cinn/frontend/optimize.cc
@@ -136,5 +136,40 @@ std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
   cinn::hlir::framework::PassPrinter::GetInstance()->End();
   return graph;
 }
+
+std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
+                                                 const std::unordered_set<std::string>& fetch_ids,
+                                                 common::Target target,
+                                                 const std::vector<std::string>& passes) {
+  OptimizeOptions options;
+
+  bool enbale_fusion = false;
+  if (!passes.empty()) {
+    for (const auto& pass : passes) {
+      auto* p_pass = ProgramPassRegistry::Global()->Find(pass);
+      auto* g_pass = Registry<hlir::framework::PassFunctionRegister>::Global()->Find(pass);
+      if (p_pass) {
+        options.program_passes.emplace_back(pass);
+      } else if (g_pass) {
+        options.graph_passes.emplace_back(pass);
+        if (pass == "OpFusionPass" || pass == "FusionMergePass") {
+          enbale_fusion = true;
+        }
+      } else {
+        LOG(FATAL) << "Pass " << pass << " unsupported in CINN! Please check.\n";
+      }
+    }
+
+    if (!enbale_fusion) {
+      options.graph_passes.emplace_back("BuildNonFusedGroupsPass");
+    }
+  } else {
+    // if pass empty, default enable all pass
+    options = DefaultTrainingOptimizeOptions();
+  }
+
+  return Optimize(program, fetch_ids, target, options);
+}
+
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/frontend/optimize.h
+++ b/cinn/frontend/optimize.h
@@ -40,5 +40,10 @@ std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
                                                  common::Target target,
                                                  const OptimizeOptions& options = DefaultTrainingOptimizeOptions());
 
+std::shared_ptr<hlir::framework::Graph> Optimize(frontend::Program* program,
+                                                 const std::unordered_set<std::string>& fetch_ids,
+                                                 common::Target target,
+                                                 const std::vector<std::string>& passes);
+
 }  // namespace frontend
 }  // namespace cinn

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -168,40 +168,7 @@ void BindFrontend(pybind11::module *m) {
               fetch_ids.insert(out->id);
             }
 
-            std::vector<std::string> program_passes, graph_passes;
-
-            const auto &default_program_pass = DefaultTrainingOptimizeOptions().program_passes;
-            const auto &default_graph_pass   = DefaultTrainingOptimizeOptions().graph_passes;
-            if (!passes.empty()) {
-              for (const auto &pass : passes) {
-                auto *p_pass = ProgramPassRegistry::Global()->Find(pass);
-                auto *g_pass = Registry<hlir::framework::PassFunctionRegister>::Global()->Find(pass);
-                if (p_pass) {
-                  program_passes.emplace_back(pass);
-                } else if (g_pass) {
-                  graph_passes.emplace_back(pass);
-                } else {
-                  LOG(FATAL) << "Pass " << pass << " unsupported in CINN! Please check.\n";
-                }
-              }
-            }
-            if (program_passes.empty()) {
-              program_passes = default_program_pass;
-            }
-            if (graph_passes.empty()) {
-              graph_passes = default_graph_pass;
-            }
-
-            std::shared_ptr<hlir::framework::Graph> graph;
-            if (!passes.empty()) {
-              cinn::hlir::framework::PassPrinter::GetInstance()->Begin();
-              frontend::ProgramPass::Apply(&self, fetch_ids, target, program_passes);
-              graph = std::make_shared<hlir::framework::Graph>(self, fetch_ids, target);
-              hlir::framework::ApplyPasses(graph.get(), graph_passes);
-              cinn::hlir::framework::PassPrinter::GetInstance()->End();
-            } else {
-              graph = Optimize(&self, fetch_ids, target);
-            }
+            auto graph = Optimize(&self, fetch_ids, target, passes);
 
             scope = hlir::framework::BuildScope(target, graph, scope);
             hlir::framework::GraphCompiler gc(target, scope, graph);
@@ -255,48 +222,8 @@ void BindFrontend(pybind11::module *m) {
               const std::unordered_set<std::string> &fetch_ids,
               const common::Target &target,
               const std::vector<std::string> &passes = {}) {
-             std::vector<std::string> program_passes, graph_passes;
-
-             const auto &default_program_pass = DefaultTrainingOptimizeOptions().program_passes;
-             const auto &default_graph_pass   = DefaultTrainingOptimizeOptions().graph_passes;
-             if (!passes.empty()) {
-               for (const auto &pass : passes) {
-                 auto *p_pass = ProgramPassRegistry::Global()->Find(pass);
-                 auto *g_pass = Registry<hlir::framework::PassFunctionRegister>::Global()->Find(pass);
-                 if (p_pass) {
-                   program_passes.emplace_back(pass);
-                 } else if (g_pass) {
-                   graph_passes.emplace_back(pass);
-                 } else {
-                   LOG(FATAL) << "Pass " << pass << " unsupported in CINN! Please check.\n";
-                 }
-               }
-             }
-
-             if (program_passes.empty()) {
-               program_passes = default_program_pass;
-             }
-             frontend::ProgramPass::Apply(&self, fetch_ids, target, program_passes);
-
-             if (graph_passes.empty()) {
-               // no need run graph pass, return program size
-               return self.size();
-             }
-
-             auto graph = std::make_shared<hlir::framework::Graph>(self, fetch_ids, target);
-             hlir::framework::ApplyPasses(graph.get(), graph_passes);
-
-             size_t node_num = 0;
-             for (auto *graph_node : graph->nodes()) {
-               auto node = graph_node->safe_as<hlir::framework::Node>();
-               // if node is NodeData or not op, continue.
-               if (!node || node->op() == nullptr) {
-                 continue;
-               }
-
-               node_num++;
-             }
-             return node_num;
+             auto graph = Optimize(&self, fetch_ids, target, passes);
+             return graph->fusion_groups.size();
            })
 
       /**

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -220,4 +220,19 @@ foreach(pass_test_name ${CINN_PASS_TEST})
     )
 endforeach()
 
+file(GLOB CINN_FUSION_TEST RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "tests/fusion/test_*.py")
+
+foreach(fusion_test_name ${EXCLUDE_FUSION})
+    list(REMOVE_ITEM CINN_FUSION_TEST tests/fusion/${fusion_test_name}.py)
+endforeach()
+
+foreach(fusion_test_name ${CINN_FUSION_TEST})
+    string(REGEX REPLACE ".py" "" fusion_test_name ${fusion_test_name})
+    ADD_TEST(NAME ${fusion_test_name}
+        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
+        python3 ${CMAKE_CURRENT_SOURCE_DIR}/${fusion_test_name}.py
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+endforeach()
+
 endif()

--- a/python/tests/fusion/fusion_test.py
+++ b/python/tests/fusion/fusion_test.py
@@ -19,6 +19,7 @@ from tests.passes.pass_test import PassTest
 logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO').upper())
 logger = logging.getLogger(name="pass_test")
 
+
 class FusionTest(PassTest):
     def __init__(self, *args, **kwargs):
         super(FusionTest, self).__init__(*args, **kwargs)
@@ -35,20 +36,27 @@ class FusionTest(PassTest):
         raise Exception("Not implemented.")
 
     def check_fusion_outputs(self,
-                              group_size,
-                              max_relative_error=1e-5,
-                              all_equal=False,
-                              equal_nan=False):
-      base_passes = ["AutoCast", "Decomposer", "TransToCustomCallPass"]
-      fusion_passes = ["OpFusionPass", "FusionMergePass"]
+                             group_size,
+                             max_relative_error=1e-5,
+                             all_equal=False,
+                             equal_nan=False):
+        base_passes = ["AutoCast", "Decomposer", "TransToCustomCallPass"]
+        fusion_passes = ["OpFusionPass", "FusionMergePass"]
 
-      real_group_size = self.get_pass_size(base_passes + fusion_passes)
-      logger.debug("The model has been fused into {} groups".format(real_group_size))
-      self.assertEqual(real_group_size, group_size, msg="The model should be fused into {} groups, but actually fused {} groups".format(group_size, real_group_size))
+        real_group_size = self.get_pass_size(base_passes + fusion_passes)
+        logger.debug(
+            "The model has been fused into {} groups".format(real_group_size))
+        self.assertEqual(
+            real_group_size,
+            group_size,
+            msg=
+            "The model should be fused into {} groups, but actually fused {} groups"
+            .format(group_size, real_group_size))
 
-      cinn_no_fusion_outputs = self.get_pass_outputs(base_passes)
-      cinn_fusion_outputs = self.get_pass_outputs(base_passes + fusion_passes)
+        cinn_no_fusion_outputs = self.get_pass_outputs(base_passes)
+        cinn_fusion_outputs = self.get_pass_outputs(base_passes +
+                                                    fusion_passes)
 
-      logger.debug("============ Check Outputs ============")
-      self.check_results(cinn_no_fusion_outputs, cinn_fusion_outputs,
-                          max_relative_error, all_equal, equal_nan)
+        logger.debug("============ Check Outputs ============")
+        self.check_results(cinn_no_fusion_outputs, cinn_fusion_outputs,
+                           max_relative_error, all_equal, equal_nan)

--- a/python/tests/fusion/fusion_test.py
+++ b/python/tests/fusion/fusion_test.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from tests.passes.pass_test import PassTest
+
+logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO').upper())
+logger = logging.getLogger(name="pass_test")
+
+class FusionTest(PassTest):
+    def __init__(self, *args, **kwargs):
+        super(FusionTest, self).__init__(*args, **kwargs)
+
+    def init_input_data(self):
+        """Set feed data
+        """
+        self.feed_data = dict()
+        logger.warn("No Input Data")
+
+    def build_program(self, builder, target):
+        """
+        """
+        raise Exception("Not implemented.")
+
+    def check_fusion_outputs(self,
+                              group_size,
+                              max_relative_error=1e-5,
+                              all_equal=False,
+                              equal_nan=False):
+      base_passes = ["AutoCast", "Decomposer", "TransToCustomCallPass"]
+      fusion_passes = ["OpFusionPass", "FusionMergePass"]
+
+      real_group_size = self.get_pass_size(base_passes + fusion_passes)
+      logger.debug("The model has been fused into {} groups".format(real_group_size))
+      self.assertEqual(real_group_size, group_size, msg="The model should be fused into {} groups, but actually fused {} groups".format(group_size, real_group_size))
+
+      cinn_no_fusion_outputs = self.get_pass_outputs(base_passes)
+      cinn_fusion_outputs = self.get_pass_outputs(base_passes + fusion_passes)
+
+      logger.debug("============ Check Outputs ============")
+      self.check_results(cinn_no_fusion_outputs, cinn_fusion_outputs,
+                          max_relative_error, all_equal, equal_nan)

--- a/python/tests/fusion/test_cast_broadcast_reduce_max.py
+++ b/python/tests/fusion/test_cast_broadcast_reduce_max.py
@@ -15,9 +15,12 @@
 import unittest
 from fusion_test import FusionTest
 
+
 class TestGroup1(FusionTest):
     def init_input_data(self):
-        self.feed_data = {'eager_in_tmp_8': self.random([32, 1, 1, 128], "float32")}
+        self.feed_data = {
+            'eager_in_tmp_8': self.random([32, 1, 1, 128], "float32")
+        }
 
     def build_program(self, builder, target):
         eager_in_tmp_8 = builder.create_input(
@@ -26,7 +29,8 @@ class TestGroup1(FusionTest):
 
         var_15 = builder.cast(eager_in_tmp_8, dtype="float16")
         # cast should not fused into reduce when the output need fetch
-        var_73 = builder.broadcast_to(var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
+        var_73 = builder.broadcast_to(
+            var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
         var_55 = builder.cast(var_73, dtype="float32")
         var_76 = builder.reduce_max(var_55, dim=[3], keep_dim=False)
 
@@ -38,7 +42,9 @@ class TestGroup1(FusionTest):
 
 class TestGroup2(FusionTest):
     def init_input_data(self):
-        self.feed_data = {'eager_in_tmp_8': self.random([32, 1, 1, 128], "float32")}
+        self.feed_data = {
+            'eager_in_tmp_8': self.random([32, 1, 1, 128], "float32")
+        }
 
     def build_program(self, builder, target):
         eager_in_tmp_8 = builder.create_input(
@@ -47,7 +53,8 @@ class TestGroup2(FusionTest):
 
         var_15 = builder.cast(eager_in_tmp_8, dtype="float16")
         # cast should  fused into reduce when the output not fetched
-        var_73 = builder.broadcast_to(var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
+        var_73 = builder.broadcast_to(
+            var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
         var_55 = builder.cast(var_73, dtype="float32")
         var_76 = builder.reduce_max(var_55, dim=[3], keep_dim=False)
 

--- a/python/tests/fusion/test_cast_broadcast_reduce_max.py
+++ b/python/tests/fusion/test_cast_broadcast_reduce_max.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from fusion_test import FusionTest
+
+class TestGroup1(FusionTest):
+    def init_input_data(self):
+        self.feed_data = {'eager_in_tmp_8': self.random([32, 1, 1, 128], "float32")}
+
+    def build_program(self, builder, target):
+        eager_in_tmp_8 = builder.create_input(
+            self.nptype2cinntype(self.feed_data['eager_in_tmp_8'].dtype),
+            self.feed_data['eager_in_tmp_8'].shape, "eager_in_tmp_8")
+
+        var_15 = builder.cast(eager_in_tmp_8, dtype="float16")
+        # cast should not fused into reduce when the output need fetch
+        var_73 = builder.broadcast_to(var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
+        var_55 = builder.cast(var_73, dtype="float32")
+        var_76 = builder.reduce_max(var_55, dim=[3], keep_dim=False)
+
+        return [eager_in_tmp_8], [var_15, var_76]
+
+    def test_check_results(self):
+        self.check_fusion_outputs(group_size=2)
+
+
+class TestGroup2(FusionTest):
+    def init_input_data(self):
+        self.feed_data = {'eager_in_tmp_8': self.random([32, 1, 1, 128], "float32")}
+
+    def build_program(self, builder, target):
+        eager_in_tmp_8 = builder.create_input(
+            self.nptype2cinntype(self.feed_data['eager_in_tmp_8'].dtype),
+            self.feed_data['eager_in_tmp_8'].shape, "eager_in_tmp_8")
+
+        var_15 = builder.cast(eager_in_tmp_8, dtype="float16")
+        # cast should  fused into reduce when the output not fetched
+        var_73 = builder.broadcast_to(var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
+        var_55 = builder.cast(var_73, dtype="float32")
+        var_76 = builder.reduce_max(var_55, dim=[3], keep_dim=False)
+
+        return [eager_in_tmp_8], [var_76]
+
+    def test_check_results(self):
+        self.check_fusion_outputs(group_size=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/passes/pass_test.py
+++ b/python/tests/passes/pass_test.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from cinn.frontend import NetBuilder, Variable
 from cinn.frontend import get_default_program_pass, get_default_graph_pass
 import logging
 import os
-from tests.ops.op_test import OpTest, OpTestTool
+from tests.ops.op_test import OpTest
 
 logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO').upper())
 logger = logging.getLogger(name="pass_test")
@@ -79,17 +78,14 @@ class PassTest(OpTest):
         logger.debug("After pass {}:\n{}".format(passes, str(pass_prog)))
         return op_num
 
-    def check_pass_outputs(self,
-                           pass_diff,
-                           test_passes,
-                           base_passes=[
-                               "AutoCast", "Decomposer",
-                               "TransToCustomCallPass", "OpFusionPass",
-                               "FusionMergePass"
-                           ],
-                           max_relative_error=1e-5,
-                           all_equal=False,
-                           equal_nan=False):
+    def check_pass_outputs(
+            self,
+            pass_diff,
+            test_passes,
+            base_passes=["AutoCast", "Decomposer", "TransToCustomCallPass"],
+            max_relative_error=1e-5,
+            all_equal=False,
+            equal_nan=False):
         base_pass_size = self.get_pass_size(base_passes)
         logger.debug(
             "Pass after base pass optimize has {} ops".format(base_pass_size))


### PR DESCRIPTION
1. 增加了passes参数为`vector<string>`类型的Optimize重载版本函数，同时替换了pybind中对应的实现。
2. 增加了fusion group测试机制，同时测试了如下子图的正确性（来自https://github.com/PaddlePaddle/CINN/pull/1386 ）：
```
eager_in_tmp_8 = builder.create_input(type="float32", shape=[32, 1, 1, 128], id_hint="eager_in_tmp_8")

var_15 = builder.cast(eager_in_tmp_8, dtype="float16")
var_73 = builder.broadcast_to(var_15, broadcast_axes=[0, 1, 2, 3], out_shape=[32, 12, 128, 128])
var_76 = builder.reduce_max(var_73, dim=[3], keep_dim=False)
```