### PR TITLE
fix test_paddle_model_convertor cannot run directly bug

### DIFF
--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -208,10 +208,9 @@ void BindFrontend(pybind11::module *m) {
 
             // Keep compile option same as paddle
             hlir::framework::GraphCompiler::CompileOptions options;
-            options.with_instantiate_variables = true;
-            auto gc_fetch_ids                  = fetch_ids;
-            const auto &result                 = gc.Build(options, std::move(gc_fetch_ids));
-            const auto &program                = result.runtime_program;
+            auto gc_fetch_ids   = fetch_ids;
+            const auto &result  = gc.Build(options, std::move(gc_fetch_ids));
+            const auto &program = result.runtime_program;
 
             for (size_t i = 0; i < tensor_inputs.size(); i++) {
               auto in_tensor = scope->GetTensor(tensor_inputs[i]->id);

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -208,9 +208,11 @@ void BindFrontend(pybind11::module *m) {
 
             // Keep compile option same as paddle
             hlir::framework::GraphCompiler::CompileOptions options;
-            auto gc_fetch_ids   = fetch_ids;
-            const auto &result  = gc.Build(options, std::move(gc_fetch_ids));
-            const auto &program = result.runtime_program;
+            options.with_instantiate_variables = true;
+            options.remove_unused_variables    = false;
+            auto gc_fetch_ids                  = fetch_ids;
+            const auto &result                 = gc.Build(options, std::move(gc_fetch_ids));
+            const auto &program                = result.runtime_program;
 
             for (size_t i = 0; i < tensor_inputs.size(); i++) {
               auto in_tensor = scope->GetTensor(tensor_inputs[i]->id);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -130,7 +130,7 @@ ADD_TEST(NAME test_cinn_real_squeezenet
 
 ADD_TEST(NAME test_paddle_model_convertor
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
-    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_paddle_model_convertor.py "--path ${CMAKE_BINARY_DIR}/thirds/resnet_model"
+    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_paddle_model_convertor.py --path "${CMAKE_BINARY_DIR}/thirds/resnet_model"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -129,6 +129,12 @@ ADD_TEST(NAME test_cinn_real_squeezenet
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
+ADD_TEST(NAME test_paddle_model_convertor
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
+    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_paddle_model_convertor.py "${CMAKE_BINARY_DIR}/thirds/resnet_model" "${WITH_CUDA}"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
+
 #ADD_TEST(NAME test_cinn_real_facedet
 #    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_facedet.py "${CMAKE_BINARY_DIR}/thirds/FaceDet" "${WITH_CUDA}"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -127,11 +127,10 @@ ADD_TEST(NAME test_cinn_real_squeezenet
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
     python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_squeezenet.py "${CMAKE_BINARY_DIR}/thirds/SqueezeNet" "${WITH_CUDA}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-endif()
 
 ADD_TEST(NAME test_paddle_model_convertor
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}/python:$ENV{PYTHONPATH}
-    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_paddle_model_convertor.py "${CMAKE_BINARY_DIR}/thirds/resnet_model" "${WITH_CUDA}"
+    python3 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_paddle_model_convertor.py "--path ${CMAKE_BINARY_DIR}/thirds/resnet_model"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 

--- a/python/tests/op_mappers/op_mapper_test.py
+++ b/python/tests/op_mappers/op_mapper_test.py
@@ -17,9 +17,6 @@
 from ast import arg
 import os
 import logging
-from typing import Any
-import unittest
-import numpy as np
 
 import paddle
 from paddle.fluid.framework import Variable as PaddleVariable

--- a/python/tests/ops/test_cast_op.py
+++ b/python/tests/ops/test_cast_op.py
@@ -61,7 +61,7 @@ class TestCastOp(OpTest):
         self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
-class TestCastAll(TestCaseHelper):
+class TestCastShape(TestCaseHelper):
     def init_attrs(self):
         self.class_name = "TestCastOpCase"
         self.cls = TestCastOp
@@ -79,6 +79,21 @@ class TestCastAll(TestCaseHelper):
                 "x_shape": [16, 8, 4, 2],
             },
         ]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
+        self.attrs = [{
+            "d_dtype": "float64",
+        }]
+
+
+class TestCastDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestCastOpCase"
+        self.cls = TestCastOp
+        self.inputs = [{
+            "x_shape": [32, 64],
+        }]
         self.dtypes = [
             {
                 "x_dtype": "bool",
@@ -136,4 +151,5 @@ class TestCastAll(TestCaseHelper):
 
 
 if __name__ == "__main__":
-    TestCastAll().run()
+    TestCastShape().run()
+    TestCastDtype().run()

--- a/python/tests/ops/test_scale_op.py
+++ b/python/tests/ops/test_scale_op.py
@@ -57,7 +57,7 @@ class TestScaleOp(OpTest):
         self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
-class TestScaleAll(TestCaseHelper):
+class TestScaleShape(TestCaseHelper):
     def init_attrs(self):
         self.class_name = "TestScaleOpCase"
         self.cls = TestScaleOp
@@ -73,6 +73,19 @@ class TestScaleAll(TestCaseHelper):
             "x_shape": [16, 8, 4, 2],
         }, {
             "x_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
+        self.attrs = [{"scale": -0.1, "bias": 10, "bias_after_scale": False}]
+
+
+class TestScaleDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestScaleOpCase"
+        self.cls = TestScaleOp
+        self.inputs = [{
+            "x_shape": [32, 64],
         }]
         self.dtypes = [
             # {
@@ -102,6 +115,19 @@ class TestScaleAll(TestCaseHelper):
                 "x_dtype": "float64",
             },
         ]
+        self.attrs = [{"scale": -0.1, "bias": 10, "bias_after_scale": False}]
+
+
+class TestScaleAttr(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestScaleOpCase"
+        self.cls = TestScaleOp
+        self.inputs = [{
+            "x_shape": [32, 64],
+        }]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
         self.attrs = [{
             "scale": 0,
             "bias": 0,
@@ -138,4 +164,6 @@ class TestScaleAll(TestCaseHelper):
 
 
 if __name__ == "__main__":
-    TestScaleAll().run()
+    TestScaleShape().run()
+    TestScaleDtype().run()
+    TestScaleAttr().run()

--- a/python/tests/test_paddle_model_convertor.py
+++ b/python/tests/test_paddle_model_convertor.py
@@ -17,17 +17,47 @@
 import os, sys
 import numpy as np
 import unittest
-import logging
-from ops.op_test import OpTestTool
-from op_mappers.op_mapper_test import OpMapperTest
+import logging, argparse
+
 import paddle
 from paddle.fluid.framework import core
+
 from cinn.frontend import PaddleModelConvertor
 from cinn.common import is_compiled_with_cuda, DefaultNVGPUTarget
 from cinn.runtime import seed as cinn_seed
+from ops.op_test import OpTestTool
+from op_mappers.op_mapper_test import OpMapperTest
 
 logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO').upper())
 logger = logging.getLogger(name="paddle_model_convertor")
+
+parser = argparse.ArgumentParser(
+    description='Load Paddle Model File and Running at CINN')
+parser.add_argument(
+    "--path",
+    help="The path to load the paddle model",
+    type=str,
+    required=True)
+parser.add_argument(
+    "-m",
+    "--model_filename",
+    help="The filename of model file, default \"__model__\"",
+    type=str,
+    default="__model__")
+parser.add_argument(
+    "-p",
+    "--params_filename",
+    help=
+    "The filename of model parameter file, default None, in which each parameter will saved in each file",
+    type=str,
+    default=None)
+parser.add_argument(
+    "-cuda",
+    "--enable_cuda",
+    help="Whether enable CUDA, default True",
+    type=bool,
+    default=True)
+args = parser.parse_args()
 
 np.random.seed(1234)
 paddle.seed(1234)
@@ -54,25 +84,26 @@ paddle.enable_static()
 # ```
 # Second load and run model like:
 # ```
-# python test_paddle_model.py "./stack" ON
+# python test_paddle_model_convertor.py --path build/thirds/resnet_model -m "__model__" -p "params"
 # ```
-
-# The second argument(ON/OFF): wether to use GPU
-enable_gpu = sys.argv.pop()
-# The first argument(PATH_TO_MODEL): the inference model directory path
-model_dir = sys.argv.pop()
 
 
 class TestPaddleModel(OpMapperTest):
     def setUp(self):
-        if enable_gpu == 'ON':
+        if args.enable_cuda:
             self.target = DefaultNVGPUTarget()
             self.place = paddle.CUDAPlace(0)
         else:
             self.target = DefaultHostTarget()
             self.place = paddle.CPUPlace()
 
-        self.model_dir = model_dir
+        self.model_dir = args.path
+        self.model_filename = args.model_filename
+        self.params_filename = args.params_filename
+
+        logger.info(
+            "Run Model From \"{}\", which model filename is \"{}\", and parameter filename is \"{}\""
+            .format(self.model_dir, self.model_filename, self.params_filename))
 
         self.load_paddle_program()
         self.init_case()
@@ -112,9 +143,19 @@ class TestPaddleModel(OpMapperTest):
 
         [self.inference_program, self.feed_names,
          self.fetch_targets] = paddle.fluid.io.load_inference_model(
-             dirname=self.model_dir, executor=self.exe)
+             dirname=self.model_dir,
+             executor=self.exe,
+             model_filename=self.model_filename,
+             params_filename=self.params_filename)
+
+        self.param_vars = paddle.load(
+            self.model_dir,
+            model_filename=self.model_filename,
+            params_filename=self.params_filename,
+            return_numpy=True)
 
         logger.debug(msg="Program:\n{}".format(self.inference_program))
+        logger.debug(msg="Param List: {}".format(self.param_vars.keys()))
         logger.debug(msg="Feed List: {}".format(self.feed_names))
         logger.debug(msg="Fetch List: {}".format(
             [var.name for var in self.fetch_targets]))
@@ -122,24 +163,10 @@ class TestPaddleModel(OpMapperTest):
         self.feed_shapes = []
         self.feed_dtypes = []
 
-        self.param_vars = []
-        param_names = set()
         for var in self.inference_program.list_vars():
             if var.name in self.feed_names:
                 self.feed_shapes.append(var.shape)
                 self.feed_dtypes.append(var.dtype)
-
-            if var.persistable and var.desc.type(
-            ) == core.VarDesc.VarType.LOD_TENSOR:
-                self.param_vars.append(var)
-                param_names.add(var.name)
-
-        for param in self.inference_program.all_parameters():
-            if param.name not in param_names:
-                self.param_vars.append(param)
-                param_names.add(param.name)
-
-        logger.debug(msg="Param List: {}".format(param_names))
 
         self.assertEqual(
             len(self.feed_names),
@@ -147,21 +174,12 @@ class TestPaddleModel(OpMapperTest):
             msg="Cannot found some feed var in program!")
 
     def build_paddle_program(self, target):
-        fetch_with_param = self.fetch_targets + self.param_vars
-        output_with_param = self.exe.run(
+        self.paddle_outputs = self.exe.run(
             self.inference_program,
             feed=self.feed_data,
-            fetch_list=fetch_with_param,
+            fetch_list=self.fetch_targets,
             return_numpy=True)
-
-        self.paddle_outputs = output_with_param[:len(self.fetch_targets)]
         logger.debug("Paddle Result:\n{}".format(self.paddle_outputs))
-
-        self.parameter_datas = dict()
-        for i in range(len(self.param_vars)):
-            self.parameter_datas[self.param_vars[i].name] = output_with_param[
-                len(self.fetch_targets) + i]
-        logger.debug("Paddle Parameter:\n{}".format(self.parameter_datas))
 
     def build_cinn_program(self, target):
         self.assertEqual(
@@ -179,12 +197,12 @@ class TestPaddleModel(OpMapperTest):
                 name=self.feed_names[i])
             feed_with_param.append(self.feed_names[i])
 
-        for param in self.param_vars:
+        for param_name, param_value in self.param_vars.items():
             convertor.create_input(
-                dtype=self.paddleddtype2nptype(param.dtype),
-                shape=param.shape,
-                name=param.name)
-            feed_with_param.append(param.name)
+                dtype=str(param_value.dtype),
+                shape=param_value.shape,
+                name=param_name)
+            feed_with_param.append(param_name)
 
         for op in self.inference_program.global_block().ops:
             if op.desc.type() == "feed" or op.desc.type() == "fetch":
@@ -225,10 +243,10 @@ class TestPaddleModel(OpMapperTest):
             else:
                 self.assertIn(
                     name,
-                    self.parameter_datas,
+                    self.param_vars,
                     msg=
                     "The input variable should in feed list or parameter list")
-                cinn_feed_datas.append(self.parameter_datas[name])
+                cinn_feed_datas.append(self.param_vars[name])
 
         # get cinn output list
         fetch_names = {var.name for var in self.fetch_targets}
@@ -246,4 +264,6 @@ class TestPaddleModel(OpMapperTest):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    tester = unittest.defaultTestLoader.loadTestsFromTestCase(TestPaddleModel)
+    test_runer = unittest.TextTestRunner()
+    res = test_runer.run(tester)

--- a/python/tests/test_paddle_model_convertor.py
+++ b/python/tests/test_paddle_model_convertor.py
@@ -14,14 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import unittest
+import os, sys
 import numpy as np
-from ops.op_test import OpTest, OpTestTool
+import unittest
+import logging
+from ops.op_test import OpTestTool
+from op_mappers.op_mapper_test import OpMapperTest
 import paddle
-import cinn
-from cinn.frontend import *
-from cinn.common import *
+from paddle.fluid.framework import core
+from cinn.frontend import PaddleModelConvertor
+from cinn.common import is_compiled_with_cuda, DefaultNVGPUTarget
+from cinn.runtime import seed as cinn_seed
+
+logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'INFO').upper())
+logger = logging.getLogger(name="paddle_model_convertor")
+
+np.random.seed(1234)
+paddle.seed(1234)
+cinn_seed(1234)
 
 paddle.enable_static()
 
@@ -53,9 +63,9 @@ enable_gpu = sys.argv.pop()
 model_dir = sys.argv.pop()
 
 
-class TestPaddleModel(OpTest):
+class TestPaddleModel(OpMapperTest):
     def setUp(self):
-        if enable_gpu == "ON":
+        if enable_gpu == 'ON':
             self.target = DefaultNVGPUTarget()
             self.place = paddle.CUDAPlace(0)
         else:
@@ -68,22 +78,15 @@ class TestPaddleModel(OpTest):
         self.init_case()
 
     @staticmethod
-    def dtype_paddle2str(dtype):
-        if dtype == paddle.float32:
-            return "float32"
-        elif dtype == paddle.int32:
-            return "int32"
-        elif dtype == paddle.int64:
-            return "int64"
-        elif dtype == paddle.bool:
-            return "bool"
-        else:
-            raise Exception("CINN only support float/int/bool! But here " +
-                            str(dtype))
-
-    @staticmethod
     def eliminate_unkown_shape(shape):
         return [1 if dim == -1 else dim for dim in shape]
+
+    def get_paddle_op_attrs(self, op):
+        attr_map = {}
+        for n in op.attr_names:
+            attr_map[n] = op.attr(n)
+
+        return attr_map
 
     def init_case(self):
         self.feed_data = dict()
@@ -94,9 +97,9 @@ class TestPaddleModel(OpTest):
                 self.feed_data,
                 msg="Repeat feed name: " + self.feed_names[i])
 
-            dtype = self.dtype_paddle2str(self.feed_dtypes[i])
+            dtype = self.paddleddtype2nptype(self.feed_dtypes[i])
             # random int type data should not limited to [0, 1]
-            high = 1 if dtype != "int32" else self.feed_shapes[i][0]
+            high = 1 if ("int" not in dtype) else self.feed_shapes[i][0]
 
             # the paddle's feed list need dict not list
             self.feed_data[self.feed_names[i]] = self.random(
@@ -111,12 +114,32 @@ class TestPaddleModel(OpTest):
          self.fetch_targets] = paddle.fluid.io.load_inference_model(
              dirname=self.model_dir, executor=self.exe)
 
+        logger.debug(msg="Program:\n{}".format(self.inference_program))
+        logger.debug(msg="Feed List: {}".format(self.feed_names))
+        logger.debug(msg="Fetch List: {}".format(
+            [var.name for var in self.fetch_targets]))
+
         self.feed_shapes = []
         self.feed_dtypes = []
+
+        self.param_vars = []
+        param_names = set()
         for var in self.inference_program.list_vars():
             if var.name in self.feed_names:
                 self.feed_shapes.append(var.shape)
                 self.feed_dtypes.append(var.dtype)
+
+            if var.persistable and var.desc.type(
+            ) == core.VarDesc.VarType.LOD_TENSOR:
+                self.param_vars.append(var)
+                param_names.add(var.name)
+
+        for param in self.inference_program.all_parameters():
+            if param.name not in param_names:
+                self.param_vars.append(param)
+                param_names.add(param.name)
+
+        logger.debug(msg="Param List: {}".format(param_names))
 
         self.assertEqual(
             len(self.feed_names),
@@ -124,20 +147,60 @@ class TestPaddleModel(OpTest):
             msg="Cannot found some feed var in program!")
 
     def build_paddle_program(self, target):
-        self.paddle_outputs = self.exe.run(
+        fetch_with_param = self.fetch_targets + self.param_vars
+        output_with_param = self.exe.run(
             self.inference_program,
             feed=self.feed_data,
-            fetch_list=self.fetch_targets)
+            fetch_list=fetch_with_param,
+            return_numpy=True)
+
+        self.paddle_outputs = output_with_param[:len(self.fetch_targets)]
+        logger.debug("Paddle Result:\n{}".format(self.paddle_outputs))
+
+        self.parameter_datas = dict()
+        for i in range(len(self.param_vars)):
+            self.parameter_datas[self.param_vars[i].name] = output_with_param[
+                len(self.fetch_targets) + i]
+        logger.debug("Paddle Parameter:\n{}".format(self.parameter_datas))
 
     def build_cinn_program(self, target):
+        self.assertEqual(
+            1,
+            self.inference_program.num_blocks,
+            msg="CINN only support single block now")
+
+        feed_with_param = list()
+
         convertor = PaddleModelConvertor(target)
-        convertor.load_model(self.model_dir)
+        for i in range(len(self.feed_names)):
+            convertor.create_input(
+                dtype=self.paddleddtype2nptype(self.feed_dtypes[i]),
+                shape=self.feed_shapes[i],
+                name=self.feed_names[i])
+            feed_with_param.append(self.feed_names[i])
+
+        for param in self.param_vars:
+            convertor.create_input(
+                dtype=self.paddleddtype2nptype(param.dtype),
+                shape=param.shape,
+                name=param.name)
+            feed_with_param.append(param.name)
+
+        for op in self.inference_program.global_block().ops:
+            if op.desc.type() == "feed" or op.desc.type() == "fetch":
+                continue
+            convertor.append_op(op.desc.type(), op.desc.inputs(),
+                                op.desc.outputs(),
+                                self.get_paddle_op_attrs(op))
+
         prog = convertor()
 
         # get cinn input list
         inputs = prog.get_inputs()
+        logger.debug("CINN Input List: {}".format(
+            [var.name() for var in inputs]))
         self.assertEqual(
-            len(self.feed_names),
+            len(feed_with_param),
             len(inputs),
             msg="The paddle's input list not equal to cinn's input list!")
 
@@ -146,28 +209,40 @@ class TestPaddleModel(OpTest):
 
         cinn_inputs = []
         cinn_feed_datas = []
-        for name in self.feed_names:
+        for name in feed_with_param:
             cinn_name = convertor.get_cinn_name(name)
 
-            self.assertTrue(
-                cinn_name in input_dict,
+            self.assertIn(
+                cinn_name,
+                input_dict,
                 msg="Cannot find variable " + cinn_name +
                 " in cinn program's input, which are " + str(
                     input_dict.items()))
             cinn_inputs.append(input_dict[cinn_name])
-            cinn_feed_datas.append(self.feed_data[name])
+
+            if name in self.feed_data:
+                cinn_feed_datas.append(self.feed_data[name])
+            else:
+                self.assertIn(
+                    name,
+                    self.parameter_datas,
+                    msg=
+                    "The input variable should in feed list or parameter list")
+                cinn_feed_datas.append(self.parameter_datas[name])
 
         # get cinn output list
-        output_dict = convertor.get_fetch_list()
+        fetch_names = {var.name for var in self.fetch_targets}
+        output_dict = convertor.get_fetch_list(fetch_names)
         cinn_output = [output_dict[var.name] for var in self.fetch_targets]
 
         # run and get result
-        self.cinn_outputs = self.get_cinn_output(prog, target, cinn_inputs,
-                                                 cinn_feed_datas, cinn_output,
-                                                 list())
+        self.cinn_outputs = self.get_cinn_output(
+            prog, target, cinn_inputs, cinn_feed_datas, cinn_output, passes=[])
+
+        logger.debug("CINN Result:\n{}".format(self.cinn_outputs))
 
     def test_check_results(self):
-        self.check_outputs_and_grads()
+        self.check_outputs_and_grads(max_relative_error=1e-2)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_paddle_model_convertor.py
+++ b/python/tests/test_paddle_model_convertor.py
@@ -267,3 +267,4 @@ if __name__ == "__main__":
     tester = unittest.defaultTestLoader.loadTestsFromTestCase(TestPaddleModel)
     test_runer = unittest.TextTestRunner()
     res = test_runer.run(tester)
+    sys.exit(not res.wasSuccessful())


### PR DESCRIPTION
As title. 修复了`test_paddle_model_convertor.py`直接跑会挂的BUG