### PR TITLE
[CodeRefine]Polish CallExtern/Lowered Interface argument naming to avoid disambiguation

### DIFF
--- a/cinn/lang/compute.h
+++ b/cinn/lang/compute.h
@@ -85,12 +85,12 @@ struct ReturnType {
  *
  * TODO(Superjomn) Add a registry (symbol table?) to make return result inference automatically.
  *
- * @param target The name of the function to call.
+ * @param func_name The name of the function to call.
  * @param args The readonly arguments(while the mutable tensors are return result).
  * @param return_types The types of the return values.
  * @return Return one or more tensors as result.
  */
-std::vector<ir::Tensor> CallLowered(const std::string &target,
+std::vector<ir::Tensor> CallLowered(const std::string &func_name,
                                     const std::vector<Expr> &args,
                                     const std::vector<ReturnType> &return_types);
 
@@ -120,11 +120,11 @@ std::vector<ir::Tensor> CallLowered(const std::string &target,
  * }
  * \endcode
  *
- * @param target The name of the function to call.
+ * @param func_name The name of the function to call.
  * @param args The readonly arguments(while there should be only one tensor as result).
  * @param attrs The readonly attrs.
  */
-Expr CallExtern(const std::string &target,
+Expr CallExtern(const std::string &func_name,
                 const std::vector<Expr> &args,
                 const std::map<std::string, attr_t> &attrs = {});
 


### PR DESCRIPTION
### What's New ?

在研读 CINN 此模块代码时，发现 CallExtern/Lowered 两个接口的参数中使用了 target，一开始以为是Device相关的语义，深入看了函数实现发现是指：func_name，会让人产生困扰。

个人理解在AI编译器里，target 类似一个「关键字」，不应该包含其他含义，容易误解，故此处优化两个接口的参数命名，修改为 `func_name`，消解歧义、提升代码可读性。