### PR TITLE
feat(reduction): support two dimensions warp reduce

### DIFF
--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -11,13 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "cinn/common/target.h"
+#ifdef CINN_WITH_CUDA
+#include <cuda_runtime_api.h>
+#include <driver_types.h>
+#endif
 
 #include <glog/logging.h>
 
 #include <sstream>
 
+#include "cinn/common/target.h"
 #include "cinn/runtime/cinn_runtime.h"
 
 #ifdef CINN_WITH_CUDA
@@ -52,6 +55,24 @@ int Target::runtime_arch() const {
 int Target::max_num_threads() const {
   CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max number of threads.";
   return 1024;
+}
+
+int Target::get_multi_processor_count() const {
+  CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get multi processor count";
+  int num_sm = 0;
+#ifdef CINN_WITH_CUDA
+  cudaDeviceGetAttribute(&num_sm, cudaDeviceAttr::cudaDevAttrMultiProcessorCount, 0);
+#endif
+  return num_sm;
+}
+
+int Target::get_max_threads_per_sm() const {
+  CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max threads per stream processor";
+  int max_thread = 0;
+#ifdef CINN_WITH_CUDA
+  cudaDeviceGetAttribute(&max_thread, cudaDeviceAttr::cudaDevAttrMaxThreadsPerMultiProcessor, 0);
+#endif
+  return max_thread;
 }
 
 std::vector<Target::Lib> Target::get_target_libs() const { return libs; }

--- a/cinn/common/target.cc
+++ b/cinn/common/target.cc
@@ -75,6 +75,15 @@ int Target::get_max_threads_per_sm() const {
   return max_thread;
 }
 
+int Target::get_max_blocks_per_sm() const {
+  CHECK(arch == Arch::NVGPU) << "The target is not NVGPU! Cannot get max blocks per stream processor";
+  int max_blocks = 1;
+#ifdef CINN_WITH_CUDA
+  cudaDeviceGetAttribute(&max_blocks, cudaDeviceAttr::cudaDevAttrMaxBlocksPerMultiprocessor, 0);
+#endif
+  return max_blocks;
+}
+
 std::vector<Target::Lib> Target::get_target_libs() const { return libs; }
 
 int Target::get_target_bits() const {

--- a/cinn/common/target.h
+++ b/cinn/common/target.h
@@ -84,6 +84,8 @@ struct Target {
 
   int get_max_threads_per_sm() const;
 
+  int get_max_blocks_per_sm() const;
+
   int get_target_bits() const;
 
   std::vector<Lib> get_target_libs() const;

--- a/cinn/common/target.h
+++ b/cinn/common/target.h
@@ -80,6 +80,10 @@ struct Target {
 
   int max_num_threads() const;
 
+  int get_multi_processor_count() const;
+
+  int get_max_threads_per_sm() const;
+
   int get_target_bits() const;
 
   std::vector<Lib> get_target_libs() const;

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -117,7 +117,14 @@ Variable NetBuilder::Reduce(const std::string& op_type, const Variable& x, const
       return Reshape(x, new_shape);
     }
   }
-  return CustomInstr(op_type, {x}, {{"dim", dim}, {"keep_dim", keep_dim}}).front();
+  // Convert the negative dim to a positive number
+  std::vector<int> reduce_dim(dim.begin(), dim.end());
+  for (int i = 0; i < dim.size(); i++) {
+    if (reduce_dim[i] < 0) {
+      reduce_dim[i] = x->shape.size() + reduce_dim[i];
+    }
+  }
+  return CustomInstr(op_type, {x}, {{"dim", reduce_dim}, {"keep_dim", keep_dim}}).front();
 }
 
 #define NETBUILDER_UNARY_OP_DEF(func_name__, op_type__) \

--- a/cinn/hlir/framework/op_lowering_test.cc
+++ b/cinn/hlir/framework/op_lowering_test.cc
@@ -1194,6 +1194,75 @@ TEST(OP_LOWERING, Reduce_Fusion_Test_21) {
 }
 */
 
+TEST(OpFusionPass, Block_Reduce_Fuse_Broadcast) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold - 10;
+  int w                     = 256;
+  NetBuilder net_builder("Block_Reduce_Fuse_Broadcast");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.ReduceSum(A, {1}, true);
+    auto C = net_builder.BroadcastTo(B, {h, w}, {0, 1});
+  }
+
+  Compile(net_builder);
+}
+
+TEST(OpFusionPass, Block_Reduce_Fuse_Elementwise) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold - 10;
+  int w                     = 256;
+  NetBuilder net_builder("Block_Reduce_Fuse_Elementwise");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {h}, "B");
+    auto C = net_builder.ReduceSum(A, {1}, true);
+    auto D = net_builder.Add(B, C);
+  }
+
+  Compile(net_builder);
+}
+TEST(OpFusionPass, Warp_Reduce_Fuse_Broadcast) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold + 10;
+  int w                     = 256;
+  NetBuilder net_builder("Warp_Reduce_Fuse_Broadcast");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.ReduceSum(A, {1}, true);
+    auto C = net_builder.BroadcastTo(B, {h, w}, {0, 1});
+  }
+
+  Compile(net_builder);
+}
+
+TEST(OpFusionPass, Warp_Reduce_Fuse_Elementwise) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+  int h                     = warp_reduce_threshold + 10;
+  int w                     = 256;
+  NetBuilder net_builder("Warp_Reduce_Fuse_Elementwise");
+  // create model
+  {
+    auto A = net_builder.CreateInput(Float(32), {h, w}, "A");
+    auto B = net_builder.CreateInput(Float(32), {h}, "B");
+    auto C = net_builder.ReduceSum(A, {1}, true);
+    auto D = net_builder.Add(B, C);
+  }
+
+  Compile(net_builder);
+}
+
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -648,10 +648,25 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
                               const std::vector<int>& inshape,
                               const std::vector<int>& axes,
                               const common::Target& target) {
+  // If the number of current device SM is smaller than the number of SM
+  // required by Warp Reduce, the performance of Warp Reduce is better.
+  // Otherwise, use Block Reduce.
+  auto max_num_threads       = common::DefaultNVGPUTarget().max_num_threads();
+  int need_reduce_last_count = 1;
+  for (int i = 0; i < inshape.size(); i++) {
+    if (find(axes.begin(), axes.end(), i) == axes.end()) {
+      need_reduce_last_count *= inshape[i];
+    }
+  }
+  int warp_reduce_need_sm_count = ceil((need_reduce_last_count * 32) / float(target.get_max_threads_per_sm()));
+  // Set Num_max_threads to 32 is Warp Reduce
+  if (target.get_multi_processor_count() < warp_reduce_need_sm_count) {
+    max_num_threads = 32;
+  }
   // find first reduce and second reduce axis.
-  int lane             = 1;
-  int index            = static_cast<int>(axes.size()) - 1;
-  auto max_num_threads = target.max_num_threads();
+  int lane  = 1;
+  int index = static_cast<int>(axes.size()) - 1;
+
   for (; index >= 0; --index) {
     if (index + 1 < axes.size() && axes[index] != axes[index + 1] - 1) {
       break;

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -530,6 +530,15 @@ void LoopOrderAssignReduce(ir::IRSchedule& ir_sch,
   for (int idx = 0; idx < index - 1; ++idx) {
     ir_sch.Fuse(block_name, {0, 1});
   }
+  loops               = ir_sch.GetLoops(block_name);
+  auto grid_dim_x     = loops[0].As<ir::For>()->extent.as_int32();
+  auto block_dim_x    = loops[1].As<ir::For>()->extent.as_int32();
+  int sm_max_block    = 64;
+  int new_block_dim_x = -1;
+  if (block_dim_x < sm_max_block && block_dim_x * grid_dim_x > 64) {
+    new_block_dim_x = ceil(sm_max_block / float(block_dim_x));
+    ir_sch.Split(loops[0], {-1, new_block_dim_x});
+  }
 }
 
 void LoopAssignReduceWithoutLast(ir::IRSchedule& ir_sch,

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -530,14 +530,13 @@ void LoopOrderAssignReduce(ir::IRSchedule& ir_sch,
   for (int idx = 0; idx < index - 1; ++idx) {
     ir_sch.Fuse(block_name, {0, 1});
   }
-  loops            = ir_sch.GetLoops(block_name);
-  auto grid_dim_x  = loops[0].As<ir::For>()->extent.as_int32();
-  auto block_dim_x = loops[1].As<ir::For>()->extent.as_int32();
-  int sm_max_block = common::DefaultNVGPUTarget().get_max_blocks_per_sm();
+
   // The current one-dimensional reduce does not make full use of SM.
   // This case is optimized into a two-dimensional.
-  if (block_dim_x < sm_max_block && block_dim_x * grid_dim_x > sm_max_block) {
-    int block_dim_y = ceil(sm_max_block / float(block_dim_x));
+  loops            = ir_sch.GetLoops(block_name);
+  auto block_dim_x = loops[1].As<ir::For>()->extent.as_int32();
+  int block_dim_y  = block_dim_x <= 32 ? 2 : 1;
+  if (block_dim_y != 1) {
     ir_sch.Split(loops[0], {-1, block_dim_y});
   }
 }

--- a/cinn/hlir/op/reduction_test.cc
+++ b/cinn/hlir/op/reduction_test.cc
@@ -509,6 +509,53 @@ TEST(Operator, Operator_Reduction_Case_11) {
   GenReduceCode(shape, dim, "Operator_Reduction_Case_11");
 }
 
+TEST(Operator, Operator_Reduction_Case_Warp_Reduce) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {warp_reduce_threshold + 10, 256};
+  std::vector<int> dim   = {1};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Warp_Reduce");
+  CHECK(res.second.find("threadIdx.x < 32") != std::string::npos);
+}
+
+TEST(Operator, Operator_Reduction_Case_Block_Reduce) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {warp_reduce_threshold - 10, 33};
+  std::vector<int> dim   = {1};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Block_Reduce");
+  CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
+}
+
+TEST(Operator, Operator_Reduction_Case_Warp_Reduce_Case_1) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {(warp_reduce_threshold + 32) / 2, 2, 10, 256};
+  std::vector<int> dim   = {2, 3};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Warp_Reduce_Case_1");
+  CHECK(res.second.find("threadIdx.x < 32") != std::string::npos);
+}
+
+TEST(Operator, Operator_Reduction_Case_Block_Reduce_Case_1) {
+  int sm_count              = common::DefaultNVGPUTarget().get_multi_processor_count();
+  int max_threads_per_sm    = common::DefaultNVGPUTarget().get_max_threads_per_sm();
+  int warp_reduce_threshold = sm_count * max_threads_per_sm / 32;
+
+  std::vector<int> shape = {(warp_reduce_threshold - 32) / 2, 2, 10, 33};
+  std::vector<int> dim   = {2, 3};
+
+  auto res = GenReduceCode(shape, dim, "Operator_Reduction_Case_Block_Reduce_Case_2");
+  CHECK(res.second.find("threadIdx.x < 32") == std::string::npos);
+}
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -853,16 +853,12 @@ void IRCudaTwoStepReduceSchedule(ir::IRSchedule &ir_sch,
   auto tmp_out_block = ir_sch.GetBlock(tmp_out->name);
   ir_sch.SetBuffer(tmp_out_block, "local", true);
 
-  auto internal_loops = ir_sch.GetLoops(internal->name);
-  auto grid_dim_x     = internal_loops[0].As<ir::For>()->extent.as_int32();
-  auto block_dim_x    = internal_loops[1].As<ir::For>()->extent.as_int32();
-  int block_dim_y     = 1;
-  int sm_max_block    = common::DefaultNVGPUTarget().get_max_blocks_per_sm();
   // The current one-dimensional reduce does not make full use of SM.
   // This case is optimized into a two-dimensional.
-  if (block_dim_x < sm_max_block && block_dim_x * grid_dim_x > sm_max_block) {
-    block_dim_y = ceil(sm_max_block / float(block_dim_x));
-  }
+  auto internal_loops = ir_sch.GetLoops(internal->name);
+  auto block_dim_x    = internal_loops[1].As<ir::For>()->extent.as_int32();
+  int block_dim_y     = block_dim_x <= 32 ? 2 : 1;
+
   for (auto &tensor : {internal, tmp_out, out}) {
     auto loops = ir_sch.GetLoops(tensor->name);
     if (loops.size() == 1) {

--- a/cinn/hlir/pe/ir_schedule_pe.cc
+++ b/cinn/hlir/pe/ir_schedule_pe.cc
@@ -852,14 +852,30 @@ void IRCudaTwoStepReduceSchedule(ir::IRSchedule &ir_sch,
   auto tmp_out_block = ir_sch.GetBlock(tmp_out->name);
   ir_sch.SetBuffer(tmp_out_block, "local", true);
 
+  auto internal_loops = ir_sch.GetLoops(internal->name);
+  auto grid_dim_x     = internal_loops[0].As<ir::For>()->extent.as_int32();
+  auto block_dim_x    = internal_loops[1].As<ir::For>()->extent.as_int32();
+  int sm_max_block    = 64;
+  int new_block_dim_x = -1;
+  if (block_dim_x < sm_max_block && block_dim_x * grid_dim_x > 64) {
+    new_block_dim_x = ceil(sm_max_block / float(block_dim_x));
+  }
   for (auto &tensor : {internal, tmp_out, out}) {
     auto loops = ir_sch.GetLoops(tensor->name);
     if (loops.size() == 1) {
       ir_sch.Split(loops[0], {-1, 1});
       loops = ir_sch.GetLoops(tensor->name);
     }
-    ir_sch.Bind(loops[0], "blockIdx.x");
-    ir_sch.Bind(loops[1], "threadIdx.x");
+    if (new_block_dim_x != -1) {
+      ir_sch.Split(loops[0], {-1, new_block_dim_x});
+      loops = ir_sch.GetLoops(tensor->name);
+      ir_sch.Bind(loops[0], "blockIdx.x");
+      ir_sch.Bind(loops[1], "threadIdx.y");
+      ir_sch.Bind(loops[2], "threadIdx.x");
+    } else {
+      ir_sch.Bind(loops[0], "blockIdx.x");
+      ir_sch.Bind(loops[1], "threadIdx.x");
+    }
   }
   VLOG(3) << "After IRCudaTwoStepReduceSchedule : " << ir_sch.GetModule().GetExprs().at(0);
   // ir_sch.SimpleComputeAt(ir_sch.GetBlock(tmp_out->name), ir_sch.GetLoops(out->name)[0]);

--- a/cinn/hlir/pe/reduction.cc
+++ b/cinn/hlir/pe/reduction.cc
@@ -673,10 +673,25 @@ std::vector<ir::Tensor> TwoStepBlockReduceInternal(const ir::Tensor& A,
                                                    BlockReduceFunc block_reduce_func,
                                                    ir::Expr initial) {
   CHECK(!WithoutLastDimInReduce(A->shape, axes)) << "Can't find last axis in reduce!";
+  // If the number of current device SM is smaller than the number of SM
+  // required by Warp Reduce, the performance of Warp Reduce is better.
+  // Otherwise, use Block Reduce.
+  auto max_num_threads       = common::DefaultNVGPUTarget().max_num_threads();
+  int need_reduce_last_count = 1;
+  for (int i = 0; i < A->shape.size(); i++) {
+    if (find(axes.begin(), axes.end(), i) == axes.end()) {
+      need_reduce_last_count *= A->shape[i].as_int32();
+    }
+  }
+  int warp_reduce_need_sm_count =
+      ceil((need_reduce_last_count * 32) / float(common::DefaultNVGPUTarget().get_max_threads_per_sm()));
+  // Set Num_max_threads to 32 is Warp Reduce
+  if (common::DefaultNVGPUTarget().get_multi_processor_count() < warp_reduce_need_sm_count) {
+    max_num_threads = 32;
+  }
 
-  int lane             = A->shape[axes.back()].as_int32();
-  int index            = static_cast<int>(axes.size()) - 2;
-  auto max_num_threads = common::DefaultNVGPUTarget().max_num_threads();
+  int lane  = A->shape[axes.back()].as_int32();
+  int index = static_cast<int>(axes.size()) - 2;
   for (; index >= 0; --index) {
     if (lane >= max_num_threads / 2) {
       break;

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -170,6 +170,14 @@ void CudaSyncThreadsDropIfThenElse(Expr *expr) {
   Mutator()(expr);
 }
 
+class RestructureVarNodes : public ir::IRMutator<> {
+ public:
+  void operator()(ir::Expr *expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::_Var_ *var, Expr *op) override { *op = IRCopy(*op); }
+};
+
 class ReplaceIndexToBindExpr : public ir::IRMutator<> {
  public:
   void operator()(ir::Expr *expr) { ir::IRMutator<>::Visit(expr, expr); }
@@ -180,15 +188,13 @@ class ReplaceIndexToBindExpr : public ir::IRMutator<> {
     CHECK(schedule_block_realize->schedule_block.As<ir::ScheduleBlock>());
     std::vector<ir::Expr> iter_values = schedule_block_realize->iter_values;
     ir::Expr body                     = schedule_block_realize->schedule_block.As<ir::ScheduleBlock>()->body;
-    ir::Expr body_copy                = IRCopy(body);
     std::vector<ir::Var> iter_vars    = schedule_block_realize->schedule_block.As<ir::ScheduleBlock>()->iter_vars;
 
     CHECK_EQ(iter_values.size(), iter_vars.size());
     for (int idx = 0; idx < iter_values.size(); ++idx) {
-      ReplaceVarWithExpr(&body_copy, iter_vars[idx], iter_values[idx]);
+      ReplaceVarWithExpr(&body, iter_vars[idx], iter_values[idx]);
     }
-    ir::IRMutator<>::Visit(&body_copy, &body_copy);
-    schedule_block_realize->schedule_block.As<ir::ScheduleBlock>()->body = body_copy;
+    ir::IRMutator<>::Visit(&body, &body);
   }
 };
 
@@ -603,6 +609,11 @@ class ReplaceVarToZero : public ir::IRMutator<> {
 
 void OptimizeExprGPU(Expr *expr) {
   VLOG(2) << "Before Optimize Expr:\n" << *expr;
+
+  // copy var nodes to prevent one modification leading to multiple changes
+  RestructureVarNodes restructure_var_nodes;
+  restructure_var_nodes(expr);
+
   // replace var to bind expr
   ReplaceIndexToBindExpr replace_index_to_bind_expr;
   replace_index_to_bind_expr(expr);

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -498,10 +498,11 @@ class ResizeBufferSizeVisitor : public ir::IRMutator<> {
 
     load->tensor.as_tensor_ref()->shape = load->tensor.as_tensor_ref()->buffer->shape;
 
+    // For the moment, align the load tensor indices with the tensor shape using the trick method.
+    // A better way would be to modify the FlattenLoop Schedule.
     int cnt = load->indices.size() - load->tensor.as_tensor_ref()->shape.size();
     for (int i = 0; i < cnt; i++) {
-      auto &xx = load->indices;
-      xx.erase(xx.begin());
+      load->indices.erase(load->indices.begin());
     }
     ir::IRMutator<>::Visit(op, expr);
   }

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -497,6 +497,12 @@ class ResizeBufferSizeVisitor : public ir::IRMutator<> {
     }
 
     load->tensor.as_tensor_ref()->shape = load->tensor.as_tensor_ref()->buffer->shape;
+
+    int cnt = load->indices.size() - load->tensor.as_tensor_ref()->shape.size();
+    for (int i = 0; i < cnt; i++) {
+      auto &xx = load->indices;
+      xx.erase(xx.begin());
+    }
     ir::IRMutator<>::Visit(op, expr);
   }
 


### PR DESCRIPTION
CINN provides two strategies for reduce implementation: 
block reduce and warp reduce. block reduce used by default.

The performance of block reduce is not necessarily optimal. 
Theoretically, when the number of SM on the device is less than the number of SM required by warp reduce, warp reduce has better performance advantage. This has also been confirmed in the A100 experiment.

The experimental data of a100 is as follows: 8192 is the number of sm required by warp reduce. It can be seen that when the data scale keeps increasing, warp reduce has better performance advantage。
```bash
# N is the number of non-reduce element
# C is the scale of reduce 
# block_reduce, warp_reduce indicates the time of the corresponding policy, in ms
N, C, block_reduce, warp_reduce, faster
802, 256, 0.015062, 0.015410, block
902, 256, 0.015327, 0.015592, block
1002, 256, 0.015331, 0.015186, warp
1102, 256, 0.015242, 0.014902, warp
...
...
7096, 256, 0.025904, 0.022672, warp
8096, 256, 0.027820, 0.024762, warp
9096, 256, 0.027624, 0.024254, warp
10096, 256, 0.030151, 0.025956, warp
11096, 256, 0.031304, 0.027315, warp
```

The codegen for block-reduce is as follows. The value of BlockDim.x is 128, which is the same as the number of reduces
```cuda
__global__
void __launch_bounds__(128) fn_reduce_sum_0_cast_1_3_kernel(const float* __restrict__ eager_tmp_0, float16* __restrict__ var_3)
{
  float _var_7_temp_buffer [ 1 ];
  float _var_7_tmp_temp_buffer [ 1 ];
  float* var_7 = _var_7_temp_buffer;
  float* var_7_tmp = _var_7_tmp_temp_buffer;
  if (((int)blockIdx.x < 196608)) {
  {
    if (((int)threadIdx.x < 128)) {
      var_7_tmp[0] = cinn_block_reduce_sum_fp32_internal(eager_tmp_0[((128 * (int)blockIdx.x) + (int)threadIdx.x)]);
    };
    if (((int)threadIdx.x < 1)) {
    {
      var_7[0] = var_7_tmp[0];
      var_3[((int)blockIdx.x + (int)threadIdx.x)] = ((float16)(var_7[0]));
    }
    };
  }
  };
}

```
The codegen for warp-reduce is as follows, The value of BlockDim.x is 32, which is  the same as the number of threads in a warp. 
```cuda
__global__
void __launch_bounds__(64) fn_reduce_sum_0_cast_1_0_kernel(const float* __restrict__ eager_tmp_0, float16* __restrict__ var_3)
{
  float _var_8_internal_temp_buffer [ 1 ];
  float _var_8_temp_buffer [ 1 ];
  float _var_8_tmp_temp_buffer [ 1 ];
  float* var_8 = _var_8_temp_buffer;
  float* var_8_internal = _var_8_internal_temp_buffer;
  float* var_8_internal__reduce_init = _var_8_internal_temp_buffer;
  float* var_8_tmp = _var_8_tmp_temp_buffer;
  if (((int)blockIdx.x < 98304)) {
    if (((int)threadIdx.y < 2)) {
    {
      if (((int)threadIdx.x < 32)) {
      {
        var_8_internal__reduce_init[0] = 0.00000000f;
        for (int32_t kk = 0; kk < 4; kk += 1) {
          var_8_internal[0] = (var_8_internal[0] + eager_tmp_0[((256 * (int)blockIdx.x) + ((32 * kk) + ((128 * (int)threadIdx.y) + (int)threadIdx.x)))]);
        };
        var_8_tmp[0] = cinn_block_reduce_sum_fp32_internal(var_8_internal[0]);
      }
      };
      if (((int)threadIdx.x < 1)) {
      {
        var_8[0] = var_8_tmp[0];
        var_3[((2 * (int)blockIdx.x) + (int)threadIdx.y)] = ((float16)(var_8[0]));
      }
      };
    }
    };
  };
}
```
