### PR TITLE
Fixed TestCaseHelper would exit after running one test class

### DIFF
--- a/python/tests/ops/op_test_helper.py
+++ b/python/tests/ops/op_test_helper.py
@@ -102,4 +102,5 @@ class TestCaseHelper():
             test_suite.addTests(test_loader.loadTestsFromTestCase(x))
         runner = unittest.TextTestRunner()
         res = runner.run(test_suite)
-        sys.exit(not res.wasSuccessful())
+        if not res.wasSuccessful():
+            sys.exit(not res.wasSuccessful())

--- a/python/tests/ops/test_divide_op.py
+++ b/python/tests/ops/test_divide_op.py
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import numpy as np
-from op_test import OpTest, OpTestTool
-from op_test_helper import TestCaseHelper
 import paddle
-import paddle.nn.functional as F
-import cinn
 from cinn.frontend import *
 from cinn.common import *
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
@@ -36,30 +32,30 @@ class TestDivOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"],
             dtype=self.case["x_dtype"],
-            low=-10,
-            high=10)
+            low=self.case["x_low"],
+            high=self.case["x_high"])
         self.y_np = self.random(
             shape=self.case["y_shape"],
             dtype=self.case["y_dtype"],
-            low=1,
-            high=10)
+            low=self.case["y_low"],
+            high=self.case["y_high"])
+
+        # paddle.divide does not support zero division
+        if self.case["y_dtype"] is "int32" or self.case["y_dtype"] is "int64":
+            self.y_np[self.y_np == 0] = 1
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)
         y = paddle.to_tensor(self.y_np, stop_gradient=True)
-
         out = paddle.divide(x, y)
-
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
         builder = NetBuilder("div")
         x = builder.create_input(
-            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
-            "x")
+            self.nptype2cinntype(self.x_np.dtype), self.x_np.shape, "x")
         y = builder.create_input(
-            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
-            "y")
+            self.nptype2cinntype(self.y_np.dtype), self.y_np.shape, "y")
         out = builder.divide(x, y)
 
         prog = builder.build()
@@ -74,147 +70,209 @@ class TestDivOp(OpTest):
         self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
-class TestDivAll(TestCaseHelper):
+class TestDivOpBase(TestCaseHelper):
+
+    inputs = [
+        {
+            "x_shape": [32],
+            "y_shape": [32],
+        },
+        {
+            "x_shape": [32, 64],
+            "y_shape": [32, 64],
+        },
+        {
+            "x_shape": [2, 3, 4],
+            "y_shape": [2, 3, 4],
+        },
+        {
+            "x_shape": [16, 8, 4, 2],
+            "y_shape": [16, 8, 4, 2],
+        },
+        {
+            "x_shape": [16, 8, 4, 2, 1],
+            "y_shape": [16, 8, 4, 2, 1],
+        },
+    ]
+
+    dtypes = [
+        {
+            "x_dtype": "float32",
+            "y_dtype": "float32",
+        },
+    ]
+
+    attrs = [
+        {
+            "x_low": -10,
+            "x_high": 10,
+            "y_low": -10,
+            "y_high": 10
+        },
+    ]
+
     def init_attrs(self):
         self.class_name = "TestDivOpCase"
         self.cls = TestDivOp
-        self.inputs = [
-            {
-                "x_shape": [32],
-                "y_shape": [32],
-            },
-            {
-                "x_shape": [32, 64],
-                "y_shape": [32, 64],
-            },
-            {
-                "x_shape": [2, 3, 4],
-                "y_shape": [1, 1, 1],
-            },
-            {
-                "x_shape": [16, 8, 4, 2],
-                "y_shape": [16, 8, 4, 2],
-            },
-            {
-                "x_shape": [16, 8, 4, 2, 1],
-                "y_shape": [16, 8, 4, 2, 1],
-            },
-        ]
-        self.dtypes = [
-            {
-                "x_dtype": "int32",
-                "y_dtype": "int32",
-            },
-            {
-                "x_dtype": "int64",
-                "y_dtype": "int64",
-            },
-            {
-                "x_dtype": "float32",
-                "y_dtype": "float32",
-            },
-            {
-                "x_dtype": "float64",
-                "y_dtype": "float64",
-            },
-        ]
-        self.attrs = []
 
 
-class TestDivNegOp(OpTest):
-    def setUp(self):
-        print(f"\nRunning {self.__class__.__name__}: {self.case}")
-        self.init_case()
-
-    def init_case(self):
-        self.x_np = self.random(
-            shape=self.case["x_shape"],
-            dtype=self.case["x_dtype"],
-            low=-10,
-            high=10)
-        self.y_np = self.random(
-            shape=self.case["y_shape"],
-            dtype=self.case["y_dtype"],
-            low=-10,
-            high=-1)
-
-    def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.x_np, stop_gradient=True)
-        y = paddle.to_tensor(self.y_np, stop_gradient=True)
-
-        out = paddle.divide(x, y)
-
-        self.paddle_outputs = [out]
-
-    def build_cinn_program(self, target):
-        builder = NetBuilder("div")
-        x = builder.create_input(
-            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
-            "x")
-        y = builder.create_input(
-            self.nptype2cinntype(self.case["y_dtype"]), self.case["y_shape"],
-            "y")
-        out = builder.divide(x, y)
-
-        prog = builder.build()
-        res = self.get_cinn_output(prog, target, [x, y],
-                                   [self.x_np, self.y_np], [out])
-
-        self.cinn_outputs = [res[0]]
-
-    def test_check_results(self):
-        max_relative_error = self.case[
-            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
-        self.check_outputs_and_grads(max_relative_error=max_relative_error)
-
-
-class TestDivNegAll(TestCaseHelper):
+class TestDivOpShapeTest(TestDivOpBase):
     def init_attrs(self):
-        self.class_name = "TestDivNegOpCase"
-        self.cls = TestDivNegOp
-        self.inputs = [
+        self.class_name = "TestDivOpShapeTest"
+        self.cls = TestDivOp
+        self.inputs = [{
+            "x_shape": [32],
+            "y_shape": [32],
+        }, {
+            "x_shape": [32, 64],
+            "y_shape": [32, 64],
+        }, {
+            "x_shape": [2, 3, 4],
+            "y_shape": [2, 3, 4],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 1024],
+            "y_shape": [16, 8, 4, 1024],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+            "y_shape": [16, 8, 4, 2, 1],
+        }, {
+            "x_shape": [1, 1, 1, 1, 1],
+            "y_shape": [1, 1, 1, 1, 1],
+        }, {
+            "x_shape": [1],
+            "y_shape": [1],
+        }, {
+            "x_shape": [1024],
+            "y_shape": [1024],
+        }, {
+            "x_shape": [2048],
+            "y_shape": [2048],
+        }, {
+            "x_shape": [32768],
+            "y_shape": [32768],
+        }, {
+            "x_shape": [65536],
+            "y_shape": [65536],
+        }, {
+            "x_shape": [131072],
+            "y_shape": [131072],
+        }]
+
+
+class TestDivOpDtypeTest(TestDivOpBase):
+    def init_attrs(self):
+        self.class_name = "TestDivOpDtypeTest"
+        self.cls = TestDivOp
+        self.dtypes = [{
+            "x_dtype": "int32",
+            "y_dtype": "int32",
+        }, {
+            "x_dtype": "int64",
+            "y_dtype": "int64",
+        }, {
+            "x_dtype": "float32",
+            "y_dtype": "float32",
+        }, {
+            "x_dtype": "float64",
+            "y_dtype": "float64",
+        }]
+
+
+class TestDivOpPolarityTest(TestDivOpBase):
+    def init_attrs(self):
+        self.class_name = "TestDivOpPolarityTest"
+        self.cls = TestDivOp
+        self.attrs = [
             {
-                "x_shape": [32],
-                "y_shape": [32],
+                "x_low": -10,
+                "x_high": 10,
+                "y_low": -10,
+                "y_high": -1
             },
             {
-                "x_shape": [32, 64],
-                "y_shape": [32, 64],
-            },
-            {
-                "x_shape": [2, 3, 4],
-                "y_shape": [1, 5, 2],
-            },
-            {
-                "x_shape": [16, 8, 4, 2],
-                "y_shape": [16, 8, 4, 2],
-            },
-            {
-                "x_shape": [16, 8, 4, 2, 1],
-                "y_shape": [16, 8, 4, 2, 1],
+                "x_low": -10,
+                "x_high": 10,
+                "y_low": 1,
+                "y_high": 10
             },
         ]
-        self.dtypes = [
-            {
-                "x_dtype": "int32",
-                "y_dtype": "int32",
-            },
-            {
-                "x_dtype": "int64",
-                "y_dtype": "int64",
-            },
-            {
-                "x_dtype": "float32",
-                "y_dtype": "float32",
-            },
-            {
-                "x_dtype": "float64",
-                "y_dtype": "float64",
-            },
-        ]
-        self.attrs = []
+
+
+class TestDivOpBroadcastTest(TestDivOpBase):
+    def init_attrs(self):
+        self.class_name = "TestDivOpBroadcastTest"
+        self.cls = TestDivOp
+        self.inputs = [{
+            "x_shape": [32],
+            "y_shape": [1],
+        }, {
+            "x_shape": [1],
+            "y_shape": [32],
+        }, {
+            "x_shape": [1, 64],
+            "y_shape": [32, 1],
+        }, {
+            "x_shape": [1, 64],
+            "y_shape": [32, 64],
+        }, {
+            "x_shape": [32, 1],
+            "y_shape": [32, 64],
+        }, {
+            "x_shape": [1, 1],
+            "y_shape": [32, 64],
+        }, {
+            "x_shape": [1, 3, 4],
+            "y_shape": [2, 3, 4],
+        }, {
+            "x_shape": [1, 3, 1],
+            "y_shape": [2, 3, 4],
+        }, {
+            "x_shape": [1, 1, 1],
+            "y_shape": [2, 3, 4],
+        }, {
+            "x_shape": [2, 1, 1],
+            "y_shape": [1, 3, 4],
+        }, {
+            "x_shape": [1, 8, 4, 2],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 1, 1],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [1, 8, 1, 1],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [1, 1, 1, 1],
+            "y_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [1, 8, 1, 2],
+            "y_shape": [16, 1, 4, 1],
+        }, {
+            "x_shape": [1, 8, 4, 2, 32],
+            "y_shape": [16, 8, 4, 2, 32],
+        }, {
+            "x_shape": [16, 1, 1, 2, 32],
+            "y_shape": [16, 8, 4, 2, 32],
+        }, {
+            "x_shape": [16, 1, 4, 1, 1],
+            "y_shape": [16, 8, 4, 2, 32],
+        }, {
+            "x_shape": [1, 1, 1, 1, 32],
+            "y_shape": [16, 8, 4, 2, 32],
+        }, {
+            "x_shape": [1, 1, 1, 1, 1],
+            "y_shape": [16, 8, 4, 2, 32],
+        }, {
+            "x_shape": [16, 1, 4, 1, 32],
+            "y_shape": [1, 8, 1, 2, 1],
+        }]
 
 
 if __name__ == "__main__":
-    TestDivAll().run()
-    TestDivNegAll().run()
+    TestDivOpShapeTest().run()
+    TestDivOpDtypeTest().run()
+    TestDivOpPolarityTest().run()
+    TestDivOpBroadcastTest().run()

--- a/python/tests/ops/test_select_op.py
+++ b/python/tests/ops/test_select_op.py
@@ -29,7 +29,7 @@ class TestSelectOp(OpTest):
 
     def prepare_inputs(self):
         self.inputs = {
-            "Condition": self.random(self.case["shape"], "bool", 0, 2),
+            "Condition": self.random(self.case["shape"], "bool"),
             "X": self.random(self.case["shape"], self.case["dtype"]),
             "Y": self.random(self.case["shape"], self.case["dtype"])
         }
@@ -133,9 +133,6 @@ class TestSelectOpDtype(TestCaseHelper):
         ]
         self.dtypes = [
             {
-                "dtype": "float16"
-            },
-            {
                 "dtype": "float32"
             },
             {
@@ -147,28 +144,6 @@ class TestSelectOpDtype(TestCaseHelper):
             {
                 "dtype": "int64"
             },
-            {
-                "dtype": "uint16"
-            },
-            # Paddle does not support the following data type
-            # {
-            #     "dtype": "bool"
-            # },
-            # {
-            #     "dtype": "int8"
-            # },
-            # {
-            #     "dtype": "int16"
-            # },
-            # {
-            #     "dtype": "uint8"
-            # },
-            # {
-            #     "dtype": "uint32"
-            # },
-            # {
-            #     "dtype": "uint64"
-            # },
         ]
         self.attrs = []
 

--- a/python/tests/ops/test_slice_assign_op.py
+++ b/python/tests/ops/test_slice_assign_op.py
@@ -307,9 +307,6 @@ class TestSliceAssignOpDtypeTest(TestCaseHelper):
         ]
         self.dtypes = [
             {
-                "dtype": "float16"
-            },
-            {
                 "dtype": "float32"
             },
             {

--- a/python/tests/ops/test_slice_op.py
+++ b/python/tests/ops/test_slice_op.py
@@ -233,9 +233,6 @@ class TestSliceOpDtypeTest(TestCaseHelper):
         ]
         self.dtypes = [
             {
-                "dtype": "float16"
-            },
-            {
                 "dtype": "float32"
             },
             {


### PR DESCRIPTION
#1400 修复了其中一个类执行错误但是没有退出的问题：即使执行过程出错，echo $? 结果仍为 0，CI 检查不到错误。

这个 PR 修复了 #1400 存在提早退出测试的问题，在算子测试中可能执行多个 TestCaseHelper 测试类，下面的代码执行完TestSortOpShapeTest 就会退出，后续测试类没有执行。

```python
if __name__ == "__main__":
    TestSortOpShapeTest().run()
    TestSortOpDtypeTest().run()
    TestSortOpAxisTest().run()
    TestSortOpDescedingTest().run()
```

