### PR TITLE
Add test_all method to compatible with ci

### DIFF
--- a/python/tests/ops/op_test_helper.py
+++ b/python/tests/ops/op_test_helper.py
@@ -27,6 +27,12 @@ parser.add_argument(
 args = parser.parse_args()
 
 
+def run_all(test_classes: list):
+    for test_class in test_classes:
+        if not test_class.run():
+            sys.exit(1)
+
+
 class TestCaseHelper():
     """
     Helper class for constructing test cases.
@@ -94,7 +100,7 @@ class TestCaseHelper():
                 if self.__class__.__name__ == test_info[0]:
                     self.specify_test.append(test_info[1])
             if len(self.specify_test) is 0:
-                return
+                return True
         self._make_all_classes()
         test_suite = unittest.TestSuite()
         test_loader = unittest.TestLoader()
@@ -102,4 +108,4 @@ class TestCaseHelper():
             test_suite.addTests(test_loader.loadTestsFromTestCase(x))
         runner = unittest.TextTestRunner()
         res = runner.run(test_suite)
-        sys.exit(not res.wasSuccessful())
+        return res.wasSuccessful()

--- a/python/tests/ops/test_add_op_new.py
+++ b/python/tests/ops/test_add_op_new.py
@@ -15,7 +15,7 @@
 import unittest
 import numpy as np
 from op_test import OpTest, OpTestTool
-from op_test_helper import TestCaseHelper
+from op_test_helper import TestCaseHelper, run_all
 import paddle
 import cinn
 from cinn.frontend import *
@@ -255,5 +255,4 @@ class TestAddAllWithBroadcast(TestCaseHelper):
 
 
 if __name__ == "__main__":
-    TestAddAll().run()
-    TestAddAllWithBroadcast().run()
+    run_all(test_classes=[TestAddAll(), TestAddAllWithBroadcast()])


### PR DESCRIPTION
当前CI通过命令行指令返回值来判断单测是否运行成功，因此需要添加一个`run_all`函数，将当前单测有问题的测试用例命令返回值设置为1


与PR#1405重复，关闭此PR