### PR TITLE
[Perf]Add FLAGS for profiler to easily enable nvtx event for Nsight

### DIFF
--- a/cinn/hlir/framework/instruction.cc
+++ b/cinn/hlir/framework/instruction.cc
@@ -129,13 +129,13 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
   VLOG(2) << "Run function " << function_name_;
 
   {
-    utils::RecordEvent record_args("PrepareArgs", cinn::utils::EventType::kInstruction);
+    utils::RecordEvent record_args("UpdateArgsCache", cinn::utils::EventType::kInstruction);
     if (!use_cache || args_cached_.size() != size()) {
       UpdateArgsCache(name2podargs);
     }
   }
 
-  utils::ProfilerRangePush("Compute");
+  utils::RecordEvent record_args("Instruction::Run", cinn::utils::EventType::kInstruction);
 #if defined(CINN_WITH_CUDA) && !defined(CINN_WITH_CUDNN)
   if (function_name_ == "cublas_gemm" && target_.arch == Target::Arch::NVGPU) {
     auto& pod_args = args_cached_[0];
@@ -264,7 +264,6 @@ void Instruction::Run(const std::map<std::string, cinn_pod_value_t>* name2podarg
   }
   VLOG(3) << "Done Runing extern function " << function_name_;
 #endif
-  utils::ProfilerRangePop();
 
   if (!cinn::runtime::CheckStringFlagFalse(FLAGS_cinn_self_check_accuracy)) {
     CheckResults(name2podargs, stream);

--- a/cinn/runtime/cuda/cuda_module.cc
+++ b/cinn/runtime/cuda/cuda_module.cc
@@ -25,6 +25,7 @@
 
 #include "cinn/backends/cuda_util.h"
 #include "cinn/runtime/cuda/cuda_util.h"
+#include "cinn/utils/profiler.h"
 
 namespace cinn {
 namespace runtime {
@@ -58,6 +59,7 @@ void CUDAModule::LaunchKernel(int device_id,
           << ", share_memory_size:" << share_memory_size;
   auto function = GetFunction(device_id, func_name);
   CHECK(function);
+  cinn::utils::RecordEvent record_run("cuLaunchKernel", cinn::utils::EventType::kInstruction);
   CUDA_DRIVER_CALL(cuLaunchKernel(function,
                                   gridDim.x,
                                   gridDim.y,
@@ -73,6 +75,7 @@ void CUDAModule::LaunchKernel(int device_id,
 
 CUfunction CUDAModule::GetFunction(int device_id, const std::string& func_name) {
   VLOG(5) << "GetFuncion : " << func_name << " with device_id : " << device_id;
+  cinn::utils::RecordEvent record_run("cuLaunchKernel", cinn::utils::EventType::kOrdinary);
   if (!module_per_card_[device_id]) {
     std::lock_guard<std::mutex> lock(mutex_);
     // Compilation with parameters

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -35,6 +35,7 @@
 #include "cinn/runtime/cuda/cublas_util.h"
 #include "cinn/runtime/custom_function.h"
 #include "cinn/runtime/flags.h"
+#include "cinn/utils/profiler.h"
 #include "cinn/utils/timer.h"
 
 namespace cinn {
@@ -88,26 +89,33 @@ void cinn_call_cuda_kernel(void *kernel_fn,
           << block_x << ", " << block_y << ", " << block_z << "}, num_args=" << num_args << ", stream=" << stream;
 
   std::vector<void *> kernel_args;
-  kernel_args.reserve(num_args);
-  cinn_pod_value_t *args = static_cast<cinn_pod_value_t *>(v_args);
-  for (int idx = 0; idx < num_args; ++idx) {
-    if (args[idx].type_code() == ::cinn_type_code<cinn_buffer_t *>()) {
-      kernel_args.emplace_back(&((cinn_buffer_t *)(args[idx]))->memory);
-    } else {
-      kernel_args.emplace_back(args[idx].data_addr());
+  {
+    cinn::utils::RecordEvent record_run("prepare_args", cinn::utils::EventType::kInstruction);
+    kernel_args.reserve(num_args);
+    cinn_pod_value_t *args = static_cast<cinn_pod_value_t *>(v_args);
+    for (int idx = 0; idx < num_args; ++idx) {
+      if (args[idx].type_code() == ::cinn_type_code<cinn_buffer_t *>()) {
+        kernel_args.emplace_back(&((cinn_buffer_t *)(args[idx]))->memory);
+      } else {
+        kernel_args.emplace_back(args[idx].data_addr());
+      }
     }
   }
-  CUDA_DRIVER_CALL(cuLaunchKernel(static_cast<CUfunction>(kernel_fn),
-                                  grid_x,
-                                  grid_y,
-                                  grid_z,
-                                  block_x,
-                                  block_y,
-                                  block_z,
-                                  0,  // share memory
-                                  static_cast<CUstream>(stream),
-                                  kernel_args.data(),
-                                  nullptr))
+
+  {
+    cinn::utils::RecordEvent record_run("cuLaunchKernel", cinn::utils::EventType::kInstruction);
+    CUDA_DRIVER_CALL(cuLaunchKernel(static_cast<CUfunction>(kernel_fn),
+                                    grid_x,
+                                    grid_y,
+                                    grid_z,
+                                    block_x,
+                                    block_y,
+                                    block_z,
+                                    0,  // share memory
+                                    static_cast<CUstream>(stream),
+                                    kernel_args.data(),
+                                    nullptr))
+  }
 }
 
 void cinn_call_cublas(void *v_args,
@@ -126,6 +134,7 @@ void cinn_call_cublas(void *v_args,
                       int b3,
                       int b4,
                       void *stream) {
+  cinn::utils::RecordEvent record_run("cinn_call_cublas", cinn::utils::EventType::kInstruction);
   CHECK_EQ(num_args, 3);
   cublasHandle_t &cuhandle = CublasHandle::GetInstance().GetCublasHandle();
   cinn_pod_value_t *args   = static_cast<cinn_pod_value_t *>(v_args);
@@ -173,6 +182,7 @@ void cinn_call_cublas(void *v_args,
 
   if (a1 * a2 * b1 * b2 == 1) {
     VLOG(3) << "call cublasGemm for a1 * a2 * b1 * b2 == 1";
+    cinn::utils::RecordEvent record_run("Call cublasGemm", cinn::utils::EventType::kInstruction);
     CUBLAS_CALL(
         cublasGemm(cuda_dtype, cuhandle, trans_op_l, trans_op_r, m, n, k, alpha, lhs, ldl, rhs, ldr, beta, C, ldc));
   } else if (a1 * b1 == 1) {
@@ -180,6 +190,7 @@ void cinn_call_cublas(void *v_args,
     if (b2 == 1 && trans_op_r == CUBLAS_OP_N) {
       // In case of [1, bs, M, K] * [1, 1, K, N]
       VLOG(3) << "call cublasGemm for a1 * b1 = 1, b2 = 1, trans_op_r:" << trans_op_r;
+      cinn::utils::RecordEvent record_run("Call cublasGemm", cinn::utils::EventType::kInstruction);
       CUBLAS_CALL(cublasGemm(
           cuda_dtype, cuhandle, trans_op_l, trans_op_r, m, a2 * n, k, alpha, lhs, ldl, A, ldr, beta, C, ldc));
     } else {
@@ -188,6 +199,7 @@ void cinn_call_cublas(void *v_args,
       int batch    = std::max(a2, b2);
       VLOG(3) << "call cublasGemmStridedBatched with a1*b1 = 1, stride_l = " << stride_l << ", stride_r = " << stride_r
               << ", batch = " << batch;
+      cinn::utils::RecordEvent record_run("Call cublasGemmStridedBatched", cinn::utils::EventType::kInstruction);
       CUBLAS_CALL(cublasGemmStridedBatched(cuda_dtype,
                                            cuhandle,
                                            trans_op_l,
@@ -221,6 +233,7 @@ void cinn_call_cublas(void *v_args,
       // (N, L) * (1, 1) , (1, 1) * (N, L)
       VLOG(3) << "call cublasGemmStridedBatched for stride_l = " << stride_l << ", stride_r = " << stride_r
               << ", batch = " << std::max(l1, r1) * std::max(l2, r2);
+      cinn::utils::RecordEvent record_run("Call cublasGemmStridedBatched", cinn::utils::EventType::kInstruction);
       CUBLAS_CALL(cublasGemmStridedBatched(cuda_dtype,
                                            cuhandle,
                                            trans_op_l,
@@ -241,6 +254,7 @@ void cinn_call_cublas(void *v_args,
                                            m * n,
                                            std::max(l1, r1) * std::max(l2, r2)));
     } else {
+      cinn::utils::RecordEvent record_run("Call cublasGemmBatched", cinn::utils::EventType::kInstruction);
       // (N, L) / (N, 1) / (1, L)
       int bstride_l = (l1 != 1 && l2 != 1) ? (l2 * m * k) : ((l1 != 1) ? m * k : 0);
       // (N, L) / (N, 1) / (1, L)

--- a/cinn/runtime/flags.cc
+++ b/cinn/runtime/flags.cc
@@ -123,6 +123,11 @@ DEFINE_bool(verbose_function_register,
             BoolFromEnv("FLAGS_verbose_function_register", false),
             "Whether to verbose function regist log. This will only work if CINN build with flag -DWITH_DEBUG=ON.");
 
+DEFINE_int32(
+    cinn_profiler_state,
+    Int32FromEnv("FLAGS_cinn_profiler_state", -1),
+    "Specify the ProfilerState by Int in CINN, 0 for kDisabled, 1 for kCPU, 2 for kCUDA, 3 for kAll, default 0.");
+
 namespace cinn {
 namespace runtime {
 

--- a/cinn/utils/profiler.cc
+++ b/cinn/utils/profiler.cc
@@ -14,6 +14,8 @@
 
 #include "cinn/utils/profiler.h"
 
+#include <gflags/gflags.h>
+
 #ifdef CINN_WITH_NVTX
 #include <nvToolsExt.h>
 #endif
@@ -23,13 +25,35 @@
 
 #include "cinn/backends/cuda_util.h"
 #endif
-
 #include <chrono>
+
+DECLARE_int32(cinn_profiler_state);
 
 namespace cinn {
 namespace utils {
 
 ProfilerState ProfilerHelper::g_state = ProfilerState::kDisabled;
+
+void ProfilerHelper::UpdateState() {
+  if (FLAGS_cinn_profiler_state < 0) return;
+
+  switch (FLAGS_cinn_profiler_state) {
+    case 0:
+      g_state = ProfilerState::kDisabled;
+      break;
+    case 1:
+      g_state = ProfilerState::kCPU;
+      break;
+    case 2:
+      g_state = ProfilerState::kCUDA;
+      break;
+    case 3:
+      g_state = ProfilerState::kAll;
+      break;
+    default:
+      LOG(WARNING) << "Unsupport FLAGS_cinn_profiler_state = " << FLAGS_cinn_profiler_state << ", and will do nothing.";
+  }
+}
 
 RecordEvent::RecordEvent(const std::string& name, EventType type) {
   if (!ProfilerHelper::IsEnable()) return;

--- a/cinn/utils/profiler.h
+++ b/cinn/utils/profiler.h
@@ -22,6 +22,7 @@
 #endif
 
 #include "cinn/utils/event.h"
+#include "glog/logging.h"
 
 namespace cinn {
 namespace utils {
@@ -41,15 +42,22 @@ class ProfilerHelper {
   static void EnableCPU() { g_state = ProfilerState::kCPU; }
   static void EnableCUDA() { g_state = ProfilerState::kCUDA; }
 
-  static bool IsEnable() { return ProfilerHelper::g_state != ProfilerState::kDisabled; }
+  static bool IsEnable() {
+    UpdateState();
+    return ProfilerHelper::g_state != ProfilerState::kDisabled;
+  }
 
   static bool IsEnableCPU() {
+    UpdateState();
     return ProfilerHelper::g_state == ProfilerState::kAll || ProfilerHelper::g_state == ProfilerState::kCPU;
   }
 
   static bool IsEnableCUDA() {
+    UpdateState();
     return ProfilerHelper::g_state == ProfilerState::kAll || ProfilerHelper::g_state == ProfilerState::kCUDA;
   }
+
+  static void UpdateState();
 };
 
 class RecordEvent {


### PR DESCRIPTION
## what's New ?

1. 移除了`Instruction::Run` 函数中的默认的`utils::ProfilerRangePush/Pop`，调整为可选触发
2. 在`cinn_call_cuda_kernel ` 和 `cinn_call_cublas ` 关键位置添加RecordEvent
3. 新增 `FLAGS_cinn_profiler_state` 灵活控制，之前虽然在CINN的python pybind了API，但在Paddle主框架里无法使用CINN前端，添加FLAGS提升易用性体验

用法：
```bash
FLAGS_cinn_profiler_state=2 nsys profile -o test ctest -R test_cuda_module
```