### PR TITLE
[Perf]Polish PassPrinter default behavior

### DIFF
--- a/cinn/hlir/framework/visualize_helper.cc
+++ b/cinn/hlir/framework/visualize_helper.cc
@@ -57,11 +57,11 @@ bool PassPrinter::Begin(const std::unordered_set<std::string>& fetch_ids) {
 }
 
 bool PassPrinter::PassBegin(const std::string& pass_name, const frontend::Program& program) {
-  const auto& program_info = utils::GetStreamCnt(program);
   if (save_path_.empty()) {
-    VLOG(3) << "Before " << pass_name << " Pass:\n" << program_info;
     return false;
   }
+  const auto& program_info = utils::GetStreamCnt(program);
+  VLOG(3) << "Before " << pass_name << " Pass:\n" << program_info;
   const std::string& file_path =
       utils::StringFormat("%s/pass_%d_%s_before.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
   WriteToFile(file_path, program_info);
@@ -69,11 +69,11 @@ bool PassPrinter::PassBegin(const std::string& pass_name, const frontend::Progra
 }
 
 bool PassPrinter::PassEnd(const std::string& pass_name, const frontend::Program& program) {
-  const auto& program_info = utils::GetStreamCnt(program);
   if (save_path_.empty()) {
-    VLOG(3) << "After " << pass_name << " Pass:\n" << program_info;
     return false;
   }
+  const auto& program_info = utils::GetStreamCnt(program);
+  VLOG(3) << "After " << pass_name << " Pass:\n" << program_info;
   const std::string& file_path =
       utils::StringFormat("%s/pass_%d_%s_after.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
   WriteToFile(file_path, program_info);
@@ -83,11 +83,11 @@ bool PassPrinter::PassEnd(const std::string& pass_name, const frontend::Program&
 }
 
 bool PassPrinter::PassBegin(const std::string& pass_name, Graph* g) {
-  const auto& graph_info = g->DebugGroupedGraph(fetch_ids_);
   if (save_path_.empty()) {
-    VLOG(3) << "Before " << pass_name << " Pass:\n" << graph_info;
     return false;
   }
+  const auto& graph_info = g->DebugGroupedGraph(fetch_ids_);
+  VLOG(3) << "Before " << pass_name << " Pass:\n" << graph_info;
   const std::string& file_path =
       utils::StringFormat("%s/pass_%d_%s_before.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
   WriteToFile(file_path, graph_info);
@@ -100,11 +100,12 @@ bool PassPrinter::PassBegin(const std::string& pass_name, Graph* g) {
 }
 
 bool PassPrinter::PassEnd(const std::string& pass_name, Graph* g) {
-  const auto& graph_info = g->DebugGroupedGraph(fetch_ids_);
   if (save_path_.empty()) {
-    VLOG(3) << "After " << pass_name << " Pass:\n" << graph_info;
     return false;
   }
+  const auto& graph_info = g->DebugGroupedGraph(fetch_ids_);
+  VLOG(3) << "After " << pass_name << " Pass:\n" << graph_info;
+
   const std::string& file_path =
       utils::StringFormat("%s/pass_%d_%s_after.txt", save_path_.c_str(), pass_id_, pass_name.c_str());
   WriteToFile(file_path, graph_info);


### PR DESCRIPTION
### What's New?

优化了 PassPrinter 中接口的默认打印行为，当未开启FLAGS时，各个接口直接返回，减少冷启动编译时的HOST端开销。

从pprof火焰图里可以看出，这部分开销还是比较大：

<img width="2988" alt="image" src="https://github.com/PaddlePaddle/CINN/assets/9301846/7b1e383f-bba5-4351-875d-d7c1f447de59">
