### PR TITLE
Keep norm_grad dtype same as input dtype

### DIFF
--- a/cinn/frontend/op_mappers/paddle/norm.cc
+++ b/cinn/frontend/op_mappers/paddle/norm.cc
@@ -94,8 +94,9 @@ void NormOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   ctx.AddVarModelToProgram(out_name, y->id);
 
   if (!norm_name.empty()) {
-    ctx.AddVar(norm_name, std_square_sum);
-    ctx.AddVarModelToProgram(norm_name, std_square_sum->id);
+    auto norm_grad = ctx.Builder()->Cast(std_square_sum, common::Type2Str(in_type));
+    ctx.AddVar(norm_name, norm_grad);
+    ctx.AddVarModelToProgram(norm_name, norm_grad->id);
   }
 }
 

--- a/python/tests/op_mappers/test_norm_op.py
+++ b/python/tests/op_mappers/test_norm_op.py
@@ -61,5 +61,10 @@ class TestNormTestMode(TestNormOp):
         return {"Norm"}
 
 
+class TestNormFP16(TestNormOp):
+    def init_input_data(self):
+        self.feed_data = {'x': self.random([32, 64], "float16")}
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
如题，当前`norm`的算子映射没有转换梯度的数据类型，现通过添加`cast`进行数据类型转换