### PR TITLE
Add Op UnitTest for Sqrt

### DIFF
--- a/python/tests/ops/test_sqrt_op.py
+++ b/python/tests/ops/test_sqrt_op.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestSqrtOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=0.01,
+            high=10000)
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = paddle.sqrt(x)
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("unary_elementwise_test")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.sqrt(x)
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestSqrtOpShape(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestUnaryOpCase"
+        self.cls = TestSqrtOp
+        self.inputs = [{
+            "x_shape": [1],
+        }, {
+            "x_shape": [1024],
+        }, {
+            "x_shape": [1, 2048],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
+        self.attrs = []
+
+
+class TestSqrtOpDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestUnaryOpCase"
+        self.cls = TestSqrtOp
+        self.inputs = [{
+            "x_shape": [32, 64],
+        }]
+        self.dtypes = [
+            {
+                "x_dtype": "float16",
+                "max_relative_error": 1e-3
+            },
+            {
+                "x_dtype": "float32",
+            },
+            {
+                "x_dtype": "float64",
+            },
+        ]
+        self.attrs = []
+
+
+if __name__ == "__main__":
+    TestSqrtOpShape().run()
+    TestSqrtOpDtype().run()


### PR DESCRIPTION
 ## 描述
 From #1378
 
 为 `sqrt` 算子增加新的测试用例
 
序号 | 算子 | 单测文件
-- | -- | -- 
80 | sqrt | test_sqrt_op.py


 ### 算子类型
 * [x]  ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
 * [ ]  Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
 * [ ]  Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
 * [ ]  Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
 * [ ]  OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
 * [ ]  kNonFusible：无法融合的算子
 
 ## Test Cases Checklist
 ### 张量维度
 * [x]  1D 张量
 * [x]  2D 张量
 * [x]  3D 张量
 * [x]  4D 张量
 * [x]  5D 张量
 
 #### special shape
 挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。
 
 * [x]  其中一个维度为 1
 * [x]  其中一个维度小于 1024
 * [x]  其中一个维度大于 1024
 * [x]  向量的所有维度都是 1
 
 ### 张量数据类型
 * [x]  float16
 * [x]  float32
 * [x]  float64
 
 ### 广播
 * [ ]  这个算子是否支持广播？
 * [ ]  广播的测试样例

[used AI Studio]