### PR TITLE
[0D-Tensor] InferShapeForReshape support 0D-Tensor

### DIFF
--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -715,7 +715,6 @@ std::vector<std::vector<int>> InferShapeForReshape(const std::vector<std::vector
   for (auto i : inputs_shape[0]) {
     tensor_size *= i;
   }
-  CHECK(!output_shape.empty()) << "infer_shape for reshape turns out to be empty. Please check\n";
   int flag_index = -1;
   for (int i = 0; i < output_shape.size(); i++) {
     if (output_shape[i] > 0) {


### PR DESCRIPTION
[0D-Tensor] InferShapeForReshape support 0D-Tensor

Target: 
1. Tests current CI have no error with the `develop` version Paddle
2. InferShapeForReshape removes 0D-Tensor judgement, https://github.com/PaddlePaddle/Paddle/pull/53955 will be supported after this PR merges.