### PR TITLE
modify eular_beam bug

### DIFF
--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -707,7 +707,7 @@ bool CanbeInline(Node* node,
       return false;
     }
   }
-  
+
   if (IsConstOp(node)) {
     return true;
   }

--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -700,15 +700,16 @@ bool CanbeInline(Node* node,
   if (group->output_nodes.count(node)) {
     return false;
   }
-  if (IsConstOp(node)) {
-    return true;
-  }
 
   auto& op_pattern_dict = Operator::GetAttrs<OpPatternKind>("OpPattern");
   for (auto consumer : consumers) {
     if (op_pattern_dict[consumer->op()] == framework::kReduction) {
       return false;
     }
+  }
+  
+  if (IsConstOp(node)) {
+    return true;
   }
 
   if (op_pattern_dict[node->op()] == framework::kReduction) {


### PR DESCRIPTION
修复eular_beam 模型遇到的子图融合错误
<img width="586" alt="6ee152757f1b49b0a0931742589e8222" src="https://github.com/PaddlePaddle/CINN/assets/100397923/e84a1d39-9cc6-402a-88e0-bc1e7b1ba30c">
报错ast如下：
<img width="932" alt="c4436d1caa976b0a6b2202813587a6a1" src="https://github.com/PaddlePaddle/CINN/assets/100397923/e3b8b45a-907b-4b4e-b3c5-b28f2251bb1f">
报错原因：途中两个想要inline 的代码indices 的维度不同。
本质原因：与reduce直接相连的节点，不能inline；此子图不应该被判断进行computeinline优化，