### PR TITLE
[0D-Tensor] Polish 0D-Tensor unittest framework, tests +-*/ op

### DIFF
--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -189,7 +189,9 @@ class OpTest(unittest.TestCase):
                 .format(self._get_device(), i, expect.dtype, actual.dtype))
             self.assertEqual(
                 expect.shape,
-                actual.shape,
+                # NOTE: Paddle's 0D Tensor will be changed to 1D when calling expect_res[i].numpy(), hence we need to return (1, ) if actual.shape = ()
+                (
+                    1, ) if len(actual.shape) == 0 else actual.shape,
                 msg=
                 "[{}] The {}-th output shape different, which expect shape is {} but actual is {}."
                 .format(self._get_device(), i, expect.shape, actual.shape))

--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -180,6 +180,8 @@ class OpTest(unittest.TestCase):
             else:
                 expect = expect_res[i]
             actual = actual_res[i]
+            # NOTE: Paddle's 0D Tensor will be changed to 1D when calling `expect = expect_res[i].numpy()`, hence we need get expect_shape explicitly.
+            expect_shape = tuple(expect_res[i].shape)
 
             self.assertEqual(
                 expect.dtype,
@@ -188,10 +190,8 @@ class OpTest(unittest.TestCase):
                 "[{}] The {}-th output dtype different, which expect shape is {} but actual is {}."
                 .format(self._get_device(), i, expect.dtype, actual.dtype))
             self.assertEqual(
-                expect.shape,
-                # NOTE: Paddle's 0D Tensor will be changed to 1D when calling expect_res[i].numpy(), hence we need to return (1, ) if actual.shape = ()
-                (
-                    1, ) if len(actual.shape) == 0 else actual.shape,
+                expect_shape,
+                actual.shape,
                 msg=
                 "[{}] The {}-th output shape different, which expect shape is {} but actual is {}."
                 .format(self._get_device(), i, expect.shape, actual.shape))

--- a/python/tests/ops/op_test.py
+++ b/python/tests/ops/op_test.py
@@ -180,8 +180,6 @@ class OpTest(unittest.TestCase):
             else:
                 expect = expect_res[i]
             actual = actual_res[i]
-            # NOTE: Paddle's 0D Tensor will be changed to 1D when calling `expect = expect_res[i].numpy()`, hence we need get expect_shape explicitly.
-            expect_shape = tuple(expect_res[i].shape)
 
             self.assertEqual(
                 expect.dtype,
@@ -189,12 +187,15 @@ class OpTest(unittest.TestCase):
                 msg=
                 "[{}] The {}-th output dtype different, which expect shape is {} but actual is {}."
                 .format(self._get_device(), i, expect.dtype, actual.dtype))
-            self.assertEqual(
-                expect_shape,
-                actual.shape,
-                msg=
-                "[{}] The {}-th output shape different, which expect shape is {} but actual is {}."
-                .format(self._get_device(), i, expect.shape, actual.shape))
+            # NOTE: Paddle's 0D Tensor will be changed to 1D when calling tensor.numpy(),
+            # only check non-0D Tensor's shape here. 0D-Tensor's shape will be verified by `test_zero_dim_tensor.py`
+            if len(expect.shape) != 0 and len(actual.shape) != 0:
+                self.assertEqual(
+                    expect.shape,
+                    actual.shape,
+                    msg=
+                    "[{}] The {}-th output shape different, which expect shape is {} but actual is {}."
+                    .format(self._get_device(), i, expect.shape, actual.shape))
 
             should_all_equal = all_equal or (actual.dtype in [
                 np.dtype('bool'),

--- a/python/tests/ops/test_zero_dim_tensor.py
+++ b/python/tests/ops/test_zero_dim_tensor.py
@@ -17,17 +17,21 @@
 import unittest
 import numpy as np
 from op_test import OpTest, OpTestTool
-# import paddle
+import paddle
 import cinn
 from cinn.frontend import *
 from cinn.common import *
 
 
+##############################
+## Test ElementwiseAddGrad  ##
+##############################
 # 1) x is 0D, y is 0D
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestElementwiseAddOp(OpTest):
+class TestElementwiseAddGrad(OpTest):
     def setUp(self):
+        np.random.seed(2023)
         self.init_input()
 
     def init_input(self):
@@ -37,32 +41,21 @@ class TestElementwiseAddOp(OpTest):
             "dout": np.random.randint(-10, 10, []).astype("float32"),
         }
 
-    def assertShapeEqual(self, res):
-        out, x_grad, y_grad = res
-        self.assertEqual(out.shape, ())
-        self.assertEqual(x_grad.shape, ())
-        self.assertEqual(y_grad.shape, ())
-
     def build_paddle_program(self, target):
-        # x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        # y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
-        # out = paddle.add(x, y)
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
+        out = paddle.add(x, y)
 
-        # self.paddle_outputs = [out]
-        # self.paddle_grads = self.get_paddle_grads([out], [x, y],
-        #                                           [self.inputs["dout"]])
-
-        x, y, dout = self.inputs["x"], self.inputs["y"], self.inputs["dout"]
-        self.paddle_outputs = [x + y]
-        self.paddle_grads = [dout, dout]
+        self.paddle_outputs = [out]
+        self.paddle_grads = self.get_paddle_grads([out], [x, y],
+                                                  [self.inputs["dout"]])
 
     def build_cinn_program(self, target):
         builder = NetBuilder("add")
-        import sys
-        sys.stdout.flush()
         x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
         y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
-        out = builder.add(x, y)
+        # Test elementwise_add here, next unittest tests add, actually these two APIs are same.
+        out = builder.elementwise_add(x, y)
 
         dout = builder.create_input(
             Float(32), self.inputs["dout"].shape, "dout")
@@ -73,10 +66,13 @@ class TestElementwiseAddOp(OpTest):
             prog, target, [x, y, dout],
             [self.inputs["x"], self.inputs["y"], self.inputs["dout"]],
             [out, x_grad, y_grad])
-        self.assertShapeEqual(res)
 
-        self.cinn_outputs = [res[0]]
-        self.cinn_grads = [res[1], res[2]]
+        out, x_grad, y_grad = res
+        self.cinn_outputs = [out]
+        self.cinn_grads = [x_grad, y_grad]
+        self.assertEqual(out.shape, self.inputs["dout"].shape)
+        self.assertEqual(x_grad.shape, self.inputs["x"].shape)
+        self.assertEqual(y_grad.shape, self.inputs["y"].shape)
 
     def test_check_results(self):
         self.check_outputs_and_grads()
@@ -84,9 +80,7 @@ class TestElementwiseAddOp(OpTest):
 
 # 2) x is ND, y is 0D
 # NOTE: CINN only supports x's rank >= y's rank, hence no need to test next scenario: `3) x is 0D, y is ND`
-@OpTestTool.skip_if(not is_compiled_with_cuda(),
-                    "x86 test will be skipped due to timeout.")
-class TestElementwiseAddOp2(TestElementwiseAddOp):
+class TestElementwiseAddGrad1(TestElementwiseAddGrad):
     def init_input(self):
         self.inputs = {
             "x": np.random.randint(-10, 10, [3, 5]).astype("float32"),
@@ -94,16 +88,158 @@ class TestElementwiseAddOp2(TestElementwiseAddOp):
             "dout": np.random.randint(-10, 10, [3, 5]).astype("float32"),
         }
 
-    def build_paddle_program(self, target):
-        x, y, dout = self.inputs["x"], self.inputs["y"], self.inputs["dout"]
-        self.paddle_outputs = [x + y]
-        self.paddle_grads = [dout, np.sum(dout)]
 
-    def assertShapeEqual(self, res):
-        out, x_grad, y_grad = res
-        self.assertEqual(out.shape, (3, 5))
-        self.assertEqual(x_grad.shape, (3, 5))
-        self.assertEqual(y_grad.shape, ())
+#############################
+#### Test ElementwiseOp  ####
+#############################
+# 1) x is 0D, y is 0D
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestElementwiseOp(OpTest):
+    def setUp(self):
+        np.random.seed(2023)
+        self.init_input()
+
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, []).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = ()
+
+    def paddle_func(self, x, y):
+        return paddle.add(x, y)
+
+    def cinn_func(self, builder, x, y):
+        return builder.add(x, y)
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
+        out = self.paddle_func(x, y)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("elementwise_op")
+        x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
+        y = builder.create_input(Float(32), self.inputs["y"].shape, "y")
+        out = self.cinn_func(builder, x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.inputs["x"], self.inputs["y"]], [out])
+
+        self.cinn_outputs = res
+        self.assertEqual(res[0].shape, self.target_shape)
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestElementwiseAdd(TestElementwiseOp):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, [3, 5]).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = (3, 5)
+
+
+class TestElementwiseSub1(TestElementwiseOp):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, []).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = ()
+
+    def paddle_func(self, x, y):
+        return paddle.subtract(x, y)
+
+    def cinn_func(self, builder, x, y):
+        return builder.subtract(x, y)
+
+
+class TestElementwiseSub2(TestElementwiseSub1):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, [3, 5]).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = (3, 5)
+
+
+class TestElementwiseMul1(TestElementwiseOp):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, []).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = ()
+
+    def paddle_func(self, x, y):
+        return paddle.multiply(x, y)
+
+    def cinn_func(self, builder, x, y):
+        return builder.multiply(x, y)
+
+
+class TestElementwiseMul2(TestElementwiseMul1):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, [3, 5]).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = (3, 5)
+
+
+class TestElementwiseMul3(TestElementwiseOp):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, []).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = ()
+
+    def paddle_func(self, x, y):
+        return paddle.multiply(x, y)
+
+    def cinn_func(self, builder, x, y):
+        return builder.elementwise_mul(x, y)
+
+
+class TestElementwiseMul4(TestElementwiseMul3):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, [3, 5]).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = (3, 5)
+
+
+class TestElementwiseDiv1(TestElementwiseOp):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, []).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = ()
+
+    def paddle_func(self, x, y):
+        return paddle.divide(x, y)
+
+    def cinn_func(self, builder, x, y):
+        return builder.divide(x, y)
+
+
+class TestElementwiseDiv2(TestElementwiseDiv1):
+    def init_input(self):
+        self.inputs = {
+            "x": np.random.randint(-10, 10, [3, 5]).astype("float32"),
+            "y": np.random.randint(-10, 10, []).astype("float32"),
+        }
+        self.target_shape = (3, 5)
 
 
 if __name__ == "__main__":

--- a/python/tests/passes/test_expand_zero_dim_pass.py
+++ b/python/tests/passes/test_expand_zero_dim_pass.py
@@ -21,7 +21,7 @@ from cinn.common import *
 import numpy as np
 
 
-class TestAutoCastPass(PassTest):
+class TestExpandZeroDimPass(PassTest):
     def init_input_data(self):
         self.feed_data = {
             'x': np.random.randint(-10, 10, []).astype("float32")


### PR DESCRIPTION
[0D-Tensor] Polish 0D-Tensor unittest framework, tests +-*/ op

### Main change:
1. Reconstruct unittest framework of 0D-Tensor, elementwise binary op can reuse this framework.
2. Add sub, mul, div unittest.
3. Align CINN result with paddle instead of numpy.