### PR TITLE
Op conv2d, softmax support fp64

### DIFF
--- a/cinn/frontend/decomposer/activation.cc
+++ b/cinn/frontend/decomposer/activation.cc
@@ -88,6 +88,11 @@ void softmax(const Instruction& instr, const DecomposerContext& context) {
     }
   }
 
+  // When the rank of x is 1, broadcast axes will be empty, so we need to insert last dim as broadcast axis.
+  if (b_axes.empty()) {
+    b_axes.emplace_back(-1);
+  }
+
   auto mode = instr.GetAttrs<std::string>("mode");
   if (mode == "fast") {
     // x_sum = sum(exp(x))

--- a/cinn/hlir/pass/custom_call_pass.cc
+++ b/cinn/hlir/pass/custom_call_pass.cc
@@ -44,7 +44,7 @@ class GraphAlterHelper {
         auto&& op_name = node->op()->name;
         // a op with external_api registered and not excluded explicitly will be selected
         if (!IsExcluded(op_name) && ExternalApiRegistry::Global()->Has(op_name, target)) {
-          VLOG(4) << "Op:" << op_name << " will not use custom_call";
+          VLOG(4) << "Op:" << op_name << " will use custom_call";
           return true;
         }
       }

--- a/cinn/runtime/cuda/cuda_util.cc
+++ b/cinn/runtime/cuda/cuda_util.cc
@@ -551,7 +551,7 @@ cudnnDataType_t get_cudnn_compute_dtype(cudnnDataType_t data_type) {
     case CUDNN_DATA_DOUBLE:
       return CUDNN_DATA_DOUBLE;
     default:
-      LOG(FATAL) << "unsupported cudnn data type, only support float16/bfloat16 and float32 now!";
+      LOG(FATAL) << "unsupported cudnn data type, only support float16/bfloat16/float32/float64 now!";
   }
   return CUDNN_DATA_FLOAT;
 }

--- a/python/tests/ops/test_conv2d_op.py
+++ b/python/tests/ops/test_conv2d_op.py
@@ -22,149 +22,103 @@ from cinn.frontend import *
 from cinn.common import *
 from cinn.runtime import *
 from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
 
 set_cinn_cudnn_deterministic(True)
-paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
+paddle.fluid.set_flags({'FLAGS_cudnn_deterministic': 1})
 
 
 @OpTestTool.skip_if(not is_compiled_with_cuda(),
                     "x86 test will be skipped due to timeout.")
-class TestConv2dNCHW(OpTest):
+class TestConv2dOp(OpTest):
     def setUp(self):
-        self.init_case()
+        # print(f"\n{self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
 
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([3, 16, 32, 32], "float32"),
-            "weight": self.random([16, 16, 3, 3], "float32"),
-            "dy": self.random([3, 16, 30, 30], "float32")
-        }
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"], dtype=self.case["dtype"])
+        self.w_np = self.random(
+            shape=self.case["w_shape"], dtype=self.case["dtype"])
+        self.dy_np = self.random(
+            shape=self.case["dy_shape"], dtype=self.case["dtype"])
 
     def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        weight = paddle.to_tensor(self.inputs["weight"], stop_gradient=False)
-
-        y = paddle.nn.functional.conv2d(x, weight, data_format='NCHW')
-
-        self.paddle_outputs = [y.numpy()]
-        self.paddle_grads = self.get_paddle_grads([y], [x, weight],
-                                                  [self.inputs["dy"]])
-
-    def build_cinn_program(self, target):
-        builder = NetBuilder("conv2d")
-        x = builder.create_input(
-            self.nptype2cinntype(self.inputs["x"].dtype),
-            self.inputs["x"].shape, "x")
-        weight = builder.create_input(
-            self.nptype2cinntype(self.inputs["weight"].dtype),
-            self.inputs["weight"].shape, "weight")
-        dy = builder.create_input(
-            self.nptype2cinntype(self.inputs["dy"].dtype),
-            self.inputs["dy"].shape, "dy")
-
-        y = builder.conv2d(x, weight, data_format='NCHW')
-
-        x_grad = builder.conv(
+        x = paddle.to_tensor(self.x_np, stop_gradient=False)
+        weight = paddle.to_tensor(self.w_np, stop_gradient=False)
+        y = paddle.nn.functional.conv2d(
+            x,
             weight,
-            dy,
-            data_format='NCHW',
-            conv_type="backward_data",
-            output_shape=x.shape())
-        weight_grad = builder.conv(
-            x,
-            dy,
-            data_format='NCHW',
-            conv_type="backward_filter",
-            output_shape=weight.shape())
-
-        prog = builder.build()
-
-        res = self.get_cinn_output(
-            prog,
-            target, [x, weight, dy],
-            [self.inputs["x"], self.inputs["weight"], self.inputs["dy"]],
-            [y, x_grad, weight_grad],
-            passes=[])
-
-        self.cinn_outputs = [res[0]]
-        self.cinn_grads = [res[1], res[2]]
-
-    def test_check_results(self):
-        self.check_outputs_and_grads()
-
-
-class TestConv2dNCHWFP16(TestConv2dNCHW):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([3, 16, 32, 32], "float16"),
-            "weight": self.random([16, 16, 3, 3], "float16"),
-            "dy": self.random([3, 16, 30, 30], "float16")
-        }
-
-    def test_check_results(self):
-        self.check_outputs_and_grads(max_relative_error=1e-3)
-
-
-@OpTestTool.skip_if(not is_compiled_with_cudnn(),
-                    "conv2d NHWC only support cudnn now.")
-class TestConv2dNHWC(OpTest):
-    def setUp(self):
-        self.init_case()
-
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([3, 32, 32, 16], "float32"),
-            "weight": self.random([16, 16, 3, 3], "float32"),
-            "dy": self.random([3, 30, 30, 16], "float32")
-        }
-
-    def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        weight = paddle.to_tensor(self.inputs["weight"], stop_gradient=False)
-
-        y = paddle.nn.functional.conv2d(x, weight, data_format='NHWC')
-
-        self.paddle_outputs = [y.numpy()]
+            stride=self.case["stride"],
+            padding=self.case["padding"],
+            dilation=self.case["dilation"],
+            groups=self.case["groups"],
+            data_format=self.case["data_format"])
+        self.paddle_outputs = [y]
         self.paddle_grads = self.get_paddle_grads([y], [x, weight],
-                                                  [self.inputs["dy"]])
+                                                  [self.dy_np])
 
     def build_cinn_program(self, target):
         builder = NetBuilder("conv2d")
         x = builder.create_input(
-            self.nptype2cinntype(self.inputs["x"].dtype),
-            self.inputs["x"].shape, "x")
+            self.nptype2cinntype(self.case["dtype"]), self.case["x_shape"],
+            "x")
         weight = builder.create_input(
-            self.nptype2cinntype(self.inputs["weight"].dtype),
-            self.inputs["weight"].shape, "weight")
+            self.nptype2cinntype(self.case["dtype"]), self.case["w_shape"],
+            "weight")
         dy = builder.create_input(
-            self.nptype2cinntype(self.inputs["dy"].dtype),
-            self.inputs["dy"].shape, "dy")
+            self.nptype2cinntype(self.case["dtype"]), self.case["dy_shape"],
+            "dy")
 
-        w_t = builder.transpose(weight, [0, 2, 3, 1])
-
-        y = builder.conv2d(x, w_t, data_format='NHWC')
-
-        x_grad = builder.conv(
-            w_t,
-            dy,
-            data_format='NHWC',
-            conv_type="backward_data",
-            output_shape=x.shape())
-        w_grad = builder.conv(
-            x,
-            dy,
-            data_format='NHWC',
-            conv_type="backward_filter",
-            output_shape=w_t.shape())
-
-        weight_grad = builder.transpose(w_grad, [0, 3, 1, 2])
+        if self.case["data_format"] == "NCHW":
+            y = builder.conv2d(
+                x,
+                weight,
+                strides=self.case["stride"],
+                paddings=self.case["padding"],
+                dilations=self.case["dilation"],
+                groups=self.case["groups"],
+                data_format=self.case["data_format"])
+            x_grad = builder.conv(
+                weight,
+                dy,
+                data_format=self.case["data_format"],
+                conv_type="backward_data",
+                output_shape=x.shape())
+            weight_grad = builder.conv(
+                x,
+                dy,
+                data_format=self.case["data_format"],
+                conv_type="backward_filter",
+                output_shape=weight.shape())
+        elif self.case["data_format"] == "NHWC":
+            weight_t = builder.transpose(weight, [0, 2, 3, 1])
+            y = builder.conv2d(
+                x,
+                weight_t,
+                strides=self.case["stride"],
+                paddings=self.case["padding"],
+                dilations=self.case["dilation"],
+                groups=self.case["groups"],
+                data_format=self.case["data_format"])
+            x_grad = builder.conv(
+                weight_t,
+                dy,
+                data_format=self.case["data_format"],
+                conv_type="backward_data",
+                output_shape=x.shape())
+            w_grad = builder.conv(
+                x,
+                dy,
+                data_format=self.case["data_format"],
+                conv_type="backward_filter",
+                output_shape=weight_t.shape())
+            weight_grad = builder.transpose(w_grad, [0, 3, 1, 2])
 
         prog = builder.build()
-
         res = self.get_cinn_output(
             prog,
-            target, [x, weight, dy],
-            [self.inputs["x"], self.inputs["weight"], self.inputs["dy"]],
+            target, [x, weight, dy], [self.x_np, self.w_np, self.dy_np],
             [y, x_grad, weight_grad],
             passes=[])
 
@@ -172,20 +126,85 @@ class TestConv2dNHWC(OpTest):
         self.cinn_grads = [res[1], res[2]]
 
     def test_check_results(self):
-        self.check_outputs_and_grads()
+        max_relative_error = self.case[
+            "max_relative_error"] if "max_relative_error" in self.case else 1e-5
+        self.check_outputs_and_grads(max_relative_error=max_relative_error)
 
 
-class TestConv2dNHWCFP16(TestConv2dNHWC):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([3, 32, 32, 16], "float16"),
-            "weight": self.random([16, 16, 3, 3], "float16"),
-            "dy": self.random([3, 30, 30, 16], "float16")
-        }
+class TestConv2dOpAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestConv2dCase"
+        self.cls = TestConv2dOp
+        self.inputs = [
+            {
+                "x_shape": [3, 16, 32, 32],
+                "w_shape": [16, 16, 3, 3],
+                "dy_shape": [3, 16, 30, 30],
+                "data_format": "NCHW",
+            },
+            {
+                "x_shape": [3, 16, 64, 64],
+                "w_shape": [16, 16, 3, 3],
+                "dy_shape": [3, 16, 62, 62],
+                "data_format": "NCHW",
+            },
+            {
+                "x_shape": [3, 32, 32, 16],
+                "w_shape": [16, 16, 3, 3],
+                "dy_shape": [3, 30, 30, 16],
+                "data_format": "NHWC",
+            },
+            {
+                "x_shape": [3, 64, 64, 16],
+                "w_shape": [16, 16, 3, 3],
+                "dy_shape": [3, 62, 62, 16],
+                "data_format": "NHWC",
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "float16",
+                "max_relative_error": 1e-3,
+            },
+            {
+                "dtype": "float32",
+            },
+        ]
+        self.attrs = [
+            {
+                "stride": [1, 1],
+                "padding": [0, 0],
+                "dilation": [1, 1],
+                "groups": 1,
+            },
+        ]
 
-    def test_check_results(self):
-        self.check_outputs_and_grads(max_relative_error=1e-3)
+
+# Cause Conv2d backward_fliter mode do not support NHWC
+class TestConv2dOpFP64(TestConv2dOpAll):
+    def init_attrs(self):
+        super().init_attrs()
+        self.inputs = [
+            {
+                "x_shape": [3, 16, 32, 32],
+                "w_shape": [16, 16, 3, 3],
+                "dy_shape": [3, 16, 30, 30],
+                "data_format": "NCHW",
+            },
+            {
+                "x_shape": [3, 16, 64, 64],
+                "w_shape": [16, 16, 3, 3],
+                "dy_shape": [3, 16, 62, 62],
+                "data_format": "NCHW",
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "float64",
+            },
+        ]
 
 
 if __name__ == "__main__":
-    unittest.main()
+    TestConv2dOpAll().run()
+    TestConv2dOpFP64().run()

--- a/python/tests/ops/test_softmax_op.py
+++ b/python/tests/ops/test_softmax_op.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.nn.functional as F
+from cinn.frontend import *
+from cinn.common import *
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestSoftmaxOp(OpTest):
+    def setUp(self):
+        # print(f"\n{self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(self.case["shape"], self.case["dtype"])
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = F.softmax(x, axis=self.case["axis"])
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("softmax")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["dtype"]), self.case["shape"], "x")
+        out = builder.softmax(x, axes=[self.case["axis"]])
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+        self.cinn_outputs = res
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestSoftmaxAll(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestSoftmaxCase"
+        self.cls = TestSoftmaxOp
+        self.inputs = [
+            {
+                "shape": [1],
+                "axis": 0,
+            },
+            {
+                "shape": [1024],
+                "axis": -1,
+            },
+            {
+                "shape": [512, 256],
+                "axis": 0,
+            },
+            {
+                "shape": [128, 64, 32],
+                "axis": 1,
+            },
+            {
+                "shape": [16, 8, 4, 2],
+                "axis": 2,
+            },
+            {
+                "shape": [16, 8, 4, 2, 1],
+                "axis": 2,
+            },
+            {
+                "shape": [1, 1, 1, 1, 1],
+                "axis": 2,
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "float32",
+            },
+            {
+                "dtype": "float64",
+            },
+        ]
+        self.attrs = []
+
+
+if __name__ == "__main__":
+    TestSoftmaxAll().run()


### PR DESCRIPTION
1. 调用cudnn库的`conv2d, softmax`算子支持`float64`类型
3. 修复了`softmax`算子在输入张量的秩为1的情况下，广播维度的错误
4. 重写了`conv2d`的单测
5. 补充了缺失的`softmax`单测