### PR TITLE
Fix model convertor out of memory bug

### DIFF
--- a/cinn/frontend/paddle_model_convertor.cc
+++ b/cinn/frontend/paddle_model_convertor.cc
@@ -104,11 +104,24 @@ std::unordered_map<std::string, Variable> PaddleModelConvertor::GetFetchList(
   return fetch_list;
 }
 
-Program PaddleModelConvertor::LoadModel(const std::string& model_dir, bool is_combined) {
+Program PaddleModelConvertor::LoadModel(const std::string& model_dir,
+                                        bool is_combined,
+                                        const std::unordered_map<std::string, std::vector<int64_t>>& feed) {
   paddle::cpp::ProgramDesc program_desc;
   paddle::LoadModelPb(model_dir, "__model__", "", scope_.get(), &program_desc, is_combined, false, target_);
   CHECK_EQ(program_desc.BlocksSize(), 1) << "CINN can only support the model with a single block";
   auto* block_desc = program_desc.GetBlock<paddle::cpp::BlockDesc>(0);
+
+  // Set feeds shape
+  for (int i = 0; i < block_desc->VarsSize(); i++) {
+    auto* var_desc      = block_desc->GetVar<paddle::cpp::VarDesc>(i);
+    const auto var_name = var_desc->Name();
+    if (feed.count(var_name)) {
+      const auto& var_shape = feed.at(var_name);
+      VLOG(4) << "Update var " << var_name << "'s shape to: " << cinn::utils::Join(var_shape, ", ");
+      var_desc->SetShape(var_shape);
+    }
+  }
 
   OpMapperContext ctx(*scope_, target_, builder_.get(), &var_map_, &var_model_to_program_map_, &fetch_var_names_);
 

--- a/cinn/frontend/paddle_model_convertor.h
+++ b/cinn/frontend/paddle_model_convertor.h
@@ -66,7 +66,9 @@ class PaddleModelConvertor {
   Program operator()();
 
   // operator() accept the modle's directory, and return the fronted::Program object.
-  Program LoadModel(const std::string& model_dir, bool is_combined = false);
+  Program LoadModel(const std::string& model_dir,
+                    bool is_combined                                                  = false,
+                    const std::unordered_map<std::string, std::vector<int64_t>>& feed = {});
 
   // return the internal variable map
   const std::unordered_map<std::string, Variable>& var_map() const { return var_map_; }

--- a/cinn/pybind/frontend.cc
+++ b/cinn/pybind/frontend.cc
@@ -767,7 +767,11 @@ void BindFrontend(pybind11::module *m) {
            py::arg("builder") = nullptr,
            py::arg("scope")   = nullptr)
       .def("__call__", &PaddleModelConvertor::operator())
-      .def("load_model", &PaddleModelConvertor::LoadModel, py::arg("model_dir"), py::arg("is_combined") = false)
+      .def("load_model",
+           &PaddleModelConvertor::LoadModel,
+           py::arg("model_dir"),
+           py::arg("is_combined") = false,
+           py::arg("feed")        = std::unordered_map<std::string, std::vector<int64_t>>())
       .def("create_input", &PaddleModelConvertor::CreateInput, py::arg("dtype"), py::arg("shape"), py::arg("name"))
       .def("append_op",
            static_cast<void (PaddleModelConvertor::*)(const std::string &,

--- a/python/tests/test_paddle_model_convertor.py
+++ b/python/tests/test_paddle_model_convertor.py
@@ -192,7 +192,7 @@ class TestPaddleModel(OpMapperTest):
         for i in range(len(self.feed_names)):
             convertor.create_input(
                 dtype=self.paddleddtype2nptype(self.feed_dtypes[i]),
-                shape=self.feed_shapes[i],
+                shape=self.feed_data[self.feed_names[i]].shape,
                 name=self.feed_names[i])
             feed_with_param.append(self.feed_names[i])
 


### PR DESCRIPTION
1. 修复`ModelConvertor`在加载Paddle模型时，因输入`feed`的`shapes`中包含未知维度而引起显存大小计算错误，导致爆显存的问题