### PR TITLE
fix cas SimplifyFracOp no update after CasSimplify bug

### DIFF
--- a/cinn/common/cas.cc
+++ b/cinn/common/cas.cc
@@ -1858,6 +1858,10 @@ Expr CasSimplifyMutator::SimplifyFracOp(Expr expr) {
   auto a     = CasSimplify(node->a(), var_intervals);
   auto b     = CasSimplify(node->b(), var_intervals);
 
+  // update frac op node
+  expr = ir::FracOp::Make(a, b);
+  node = expr.As<FracOp>();
+
   auto* ap = a.As<Product>();
   auto* bp = b.As<Product>();
   auto* as = a.As<Sum>();

--- a/cinn/common/cas_test.cc
+++ b/cinn/common/cas_test.cc
@@ -420,5 +420,13 @@ TEST(CAS, cond) {
   }
 }
 
+TEST(CAS, SimplifyFracOp) {
+  Expr frac = Expr(1) / Expr(7) / Expr(6) / Expr(5) / Expr(4);
+  EXPECT_EQ(GetStreamCnt(AutoSimplify(frac)), "0");
+
+  Expr frac_f = Expr(20.0f) / Expr(2.0f) / Expr(1.0f) / Expr(5.0f);
+  EXPECT_EQ(GetStreamCnt(AutoSimplify(frac_f)), "2.00000000f");
+}
+
 }  // namespace common
 }  // namespace cinn


### PR DESCRIPTION
As title. 修复了cas中`SimplifyFracOp`优化除法两参数后，未能及时更新expr的BUG