### PR TITLE
Add Op UnitTest for reciprocal

### DIFF
--- a/python/tests/ops/test_reciprocal_op.py
+++ b/python/tests/ops/test_reciprocal_op.py
@@ -12,22 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cinn
-import numpy as np
-import paddle
 import unittest
-
+import numpy as np
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+import cinn
 from cinn.frontend import *
 from cinn.common import *
-from op_test import OpTest, OpTestTool
 
 
 class TestReciprocalOp(OpTest):
     def setUp(self):
-        self.init_case()
+        self.prepare_inputs()
 
-    def init_case(self):
-        self.inputs = {"x": np.random.random([32]).astype("float32")}
+    def prepare_inputs(self):
+        self.inputs = {
+            "x":
+            np.random.random(self.case["x_shape"]).astype(self.case["x_dtype"])
+        }
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.inputs["x"], stop_gradient=True)
@@ -36,7 +39,9 @@ class TestReciprocalOp(OpTest):
 
     def build_cinn_program(self, target):
         builder = NetBuilder("reciprocal_test")
-        x = builder.create_input(Float(32), self.inputs["x"].shape, "x")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
         out = builder.reciprocal(x)
 
         prog = builder.build()
@@ -48,20 +53,46 @@ class TestReciprocalOp(OpTest):
         self.check_outputs_and_grads()
 
 
-class TestReciprocalCase1(TestReciprocalOp):
-    def init_case(self):
-        self.inputs = {"x": np.random.random([32]).astype("float32")}
-
-
-class TestReciprocalCase2(TestReciprocalOp):
-    def init_case(self):
-        self.inputs = {"x": np.random.random([10]).astype("float32")}
-
-
-class TestReciprocalCase3(TestReciprocalOp):
-    def init_case(self):
-        self.inputs = {"x": np.random.random([1, 10]).astype("float32")}
+class TestReciprocalShape(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestReciprocalOp"
+        self.cls = TestReciprocalOp
+        self.inputs = [
+            {
+                "x_shape": [1024]
+            },
+            {
+                "x_shape": [512, 256]
+            },
+            {
+                "x_shape": [128, 64, 32]
+            },
+            {
+                "x_shape": [16, 8, 4, 2]
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1]
+            },
+            {
+                "x_shape": [1]
+            },
+            {
+                "x_shape": [1, 1, 1, 1, 1]
+            },
+        ]
+        self.dtypes = [
+            {
+                "x_dtype": "float64"
+            },
+            {
+                "x_dtype": "float32"
+            },
+            {
+                "x_dtype": "float16"
+            },
+        ]
+        self.attrs = []
 
 
 if __name__ == "__main__":
-    unittest.main()
+    TestReciprocalShape().run()


### PR DESCRIPTION
## 描述
From #1378
为 reciprocal 算子增加单测文件

## 算子类型

- [X]  ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ]  Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ]  Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [ ]  Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ]  OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [ ]  kNonFusible：无法融合的算子


## OpMapper
否

## Test Cases Checklist
张量维度

- [x]  1D 张量
- [x]  2D 张量
- [x]  3D 张量
- [x]  4D 张量

special shape
挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x]  其中一个维度为 1
- [x]  其中一个维度小于 1024
- [ ]  其中一个维度大于 1024
- [ ]  向量的所有维度都是 1

## 张量数据类型
- [ ]  bool
- [ ]  int8
- [ ]  int16
- [ ]  int32
- [ ]  int64
- [x]  float16
- [x]  float32
- [x]  float64

## 广播

- [ ]  这个算子是否支持广播？
- [ ]  广播的测试样例

## 算子属性
算子属性的测试用例。

- [x]  属性：属性类型-可取值
- [x]  dtype