### PR TITLE
Add Op UnitTest for gelu

### DIFF
--- a/python/tests/ops/test_gelu_op.py
+++ b/python/tests/ops/test_gelu_op.py
@@ -62,8 +62,6 @@ class TestGeluOp(OpTest):
         self.cinn_outputs = forward_res
 
     def test_check_results(self):
-        self.build_paddle_program(self.target)
-        self.build_cinn_program(self.target)
         self.check_outputs_and_grads()
 
 


### PR DESCRIPTION
## 描述
From #1378
为 gelu 算子增加单测文件

## 算子类型

- [X]  ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ]  Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ]  Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [ ]  Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ]  OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [ ]  kNonFusible：无法融合的算子


## OpMapper
否

## Test Cases Checklist
张量维度

- [x]  1D 张量
- [x]  2D 张量
- [x]  3D 张量
- [x]  4D 张量

special shape
挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x]  其中一个维度为 1
- [x]  其中一个维度小于 1024
- [ ]  其中一个维度大于 1024
- [ ]  向量的所有维度都是 1

## 张量数据类型
- [ ]  bool
- [ ]  int8
- [ ]  int16
- [ ]  int32
- [ ]  int64
- [x]  float16
- [x]  float32
- [x]  float64

## 广播

- [ ]  这个算子是否支持广播？
- [ ]  广播的测试样例

## 算子属性
算子属性的测试用例。

- [x]  属性：属性类型-可取值
- [x]  dtype