### PR TITLE
fix(fuse): fix elementwise fuse reduce

### DIFF
--- a/cinn/hlir/pass/fusion_merge_pass.cc
+++ b/cinn/hlir/pass/fusion_merge_pass.cc
@@ -917,7 +917,7 @@ class FusionMergePassHelper : public FusionHelperBase {
                                       // element-wise and injective op must be horizontal relation.
                                       {OpPatternKind::kInjective, is_same_size},
                                       // element-wise and reduce op must be horizontal relation.
-                                      {OpPatternKind::kReduction, is_same_size}};
+                                      {OpPatternKind::kReduction, honrizontal_elementwise_fuse_reduce}};
       // vertical
       relation.vertical_relation = {{OpPatternKind::kElementWise, is_same_size},
                                     // element-wise and broadcast can be vertical/horizontal relation.
@@ -976,7 +976,7 @@ class FusionMergePassHelper : public FusionHelperBase {
       auto& relation = fusion_relation_map_[OpPatternKind::kReduction];
       // horizontal
       relation.horizontal_relation = {// reduce and element-wise op must be horizontal relation.
-                                      {OpPatternKind::kElementWise, is_same_size},
+                                      {OpPatternKind::kElementWise, honrizontal_elementwise_fuse_reduce},
                                       // reduce and broadcast op must be horizontal relation.
                                       {OpPatternKind::kBroadcast, is_same_size},
                                       // reduce and injective op must be horizontal relation.


### PR DESCRIPTION
Fix a case of type elementwise-fuse-reduce during group fusion:
<img width="385" alt="fc9cb83b21d6bce76ed9ea74210b82db" src="https://github.com/PaddlePaddle/CINN/assets/62832681/cb81c8d6-1b0d-4a9b-81de-b65202f5602c">

The first group is ElementWise, and the second group is Reduce. However, there is no reduce node in the consumers connected to the first group, and the reduce nodes are all above. At this time, it is possible that the output shape of the reduce node is different from the shape of the elementwise group and cannot be fused. This PR increases the fusion of this situation.