### PR TITLE
[Fix Bug] Fix remainder bug when inputs int64

### DIFF
--- a/cinn/hlir/pe/broadcast.cc
+++ b/cinn/hlir/pe/broadcast.cc
@@ -249,7 +249,7 @@ HLIR_IMP_BC_PE(Subtract, return a - b;);
 HLIR_IMP_BC_PE(Multiply, return a * b;);
 HLIR_IMP_BC_PE(Divide, return a / b;);
 HLIR_IMP_BC_PE(FloorDivide, return lang::FloorDivide(a, b););
-HLIR_IMP_BC_PE(Remainder, return a.type().is_int() ? a % b : lang::Remainder(a, b););
+HLIR_IMP_BC_PE(Remainder, return lang::Remainder(a, b););
 HLIR_IMP_BC_PE(Mod, return lang::Mod(a, b););
 HLIR_IMP_BC_PE(Maximum, return ir::Max::Make(a, b););
 HLIR_IMP_BC_PE(Minimum, return ir::Min::Make(a, b););

--- a/python/tests/ops/test_remainder_op.py
+++ b/python/tests/ops/test_remainder_op.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, OpTestTool
+import paddle
+import paddle.nn.functional as F
+import cinn
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestRemainderOp(OpTest):
+    def setUp(self):
+        self.init_case()
+
+    def init_case(self):
+        self.inputs = {
+            "x": np.array([7]).astype('float32'),
+            "y": np.array([-3]).astype('float32')
+        }
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
+        y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
+
+        out = paddle.remainder(x, y)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("pow")
+        x = builder.create_input(
+            self.nptype2cinntype(self.inputs["x"].dtype),
+            self.inputs["x"].shape, "x")
+        y = builder.create_input(
+            self.nptype2cinntype(self.inputs["y"].dtype),
+            self.inputs["y"].shape, "y")
+        out = builder.remainder(x, y)
+
+        prog = builder.build()
+        res = self.get_cinn_output(prog, target, [x, y],
+                                   [self.inputs["x"], self.inputs["y"]], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads()
+
+
+class TestRemainderCase1(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "float32", 20, 100),
+            "y": self.random([32, 64], "float32", 1, 20),
+        }
+
+
+class TestRemainderCase2(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "int32", 20, 100),
+            "y": self.random([32, 64], "int32", 1, 20),
+        }
+
+
+class TestRemainderCase3(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "float32", 20, 100),
+            "y": self.random([32, 64], "float32", -20, -1),
+        }
+
+
+class TestRemainderCase4(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "int32", 20, 100),
+            "y": self.random([32, 64], "int32", -20, -1),
+        }
+
+
+class TestRemainderCase5(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "float32", -100, -20),
+            "y": self.random([32, 64], "float32", 1, 20),
+        }
+
+
+class TestRemainderCase6(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "float32", -100, -20),
+            "y": self.random([32, 64], "float32", -20, -1),
+        }
+
+
+class TestRemainderCase7(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "int32", -100, -20),
+            "y": self.random([32, 64], "int32", 1, 20),
+        }
+
+
+class TestRemainderCase8(TestRemainderOp):
+    def init_case(self):
+        self.inputs = {
+            "x": self.random([32, 64], "int32", -100, -20),
+            "y": self.random([32, 64], "int32", -20, -1),
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/ops/test_zero_dim_tensor.py
+++ b/python/tests/ops/test_zero_dim_tensor.py
@@ -240,8 +240,12 @@ create_unit_test(
     paddle.remainder,
     "builder.remainder",
     dtype="int64")
-# Some error with remainder Nd-0D, debug later
-# create_unit_test(TestElementwiseBinaryOp_NdTo0d, "remainder", paddle.remainder, "builder.remainder", dtype="int64")
+create_unit_test(
+    TestElementwiseBinaryOp_NdTo0d,
+    "remainder",
+    paddle.remainder,
+    "builder.remainder",
+    dtype="int64")
 create_unit_test(TestElementwiseBinaryOp_0DTo0D, "max", paddle.maximum,
                  "builder.max")
 create_unit_test(TestElementwiseBinaryOp_NdTo0d, "max", paddle.maximum,


### PR DESCRIPTION
[Fix Bug] Fix remainder bug when inputs int64

### Background
Given int64 input pair `x = -4, y = 6`, CINN outputs builder.remainder(x, y) = -4. However, PaddlePaddle outputs paddle.remainder(x, y) = 2.

This PR fixes CINN's remainder bug, making its output consistent with PaddlePaddle.