### PR TITLE
Add unitest for is_inf/is_finite/is_nan

### DIFF
--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -35,7 +35,7 @@ class TestIsFiniteOp(OpTest):
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
         index = np.random.randint(0, len(self.x_np))
-        inf_data = np.zeros(self.x_np[index].shape, dtype="float") + np.inf
+        inf_data = np.where(self.x_np[index] > 0.5, np.inf, np.nan)
         self.x_np[index] = inf_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):

--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -92,12 +92,6 @@ class TestIsFiniteOpDtype(TestCaseHelper):
             "x_shape": [32, 64],
         }]
         self.dtypes = [{
-            "x_dtype": "bool",
-        }, {
-            "x_dtype": "int8",
-        }, {
-            "x_dtype": "int16",
-        }, {
             "x_dtype": "int32",
         }, {
             "x_dtype": "int64",

--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -34,8 +34,8 @@ class TestIsFiniteOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        nan_data = np.zeros(self.x_np[0].shape, dtype="float") + np.nan
-        self.x_np[0] = nan_data.astype(self.case["x_dtype"])
+        inf_data = np.zeros(self.x_np[0].shape, dtype="float") + np.inf
+        self.x_np[0] = inf_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -34,8 +34,9 @@ class TestIsFiniteOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        inf_data = np.zeros(self.x_np[0].shape, dtype="float") + np.inf
-        self.x_np[0] = inf_data.astype(self.case["x_dtype"])
+        index = np.random.randint(0, len(self.x_np))
+        inf_data = np.zeros(self.x_np[index].shape, dtype="float") + np.inf
+        self.x_np[index] = inf_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -34,7 +34,8 @@ class TestIsFiniteOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        self.x_np[0] = np.inf
+        nan_data = np.zeros(self.x_np[0].shape, dtype="float") + np.nan
+        self.x_np[0] = nan_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -32,10 +32,13 @@ class TestIsFiniteOp(OpTest):
 
     def prepare_inputs(self):
         self.x_np = self.random(
-            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-100,
+            high=100)
 
         index = np.random.randint(0, len(self.x_np))
-        inf_data = np.where(self.x_np[index] > 0.5, np.inf, np.nan)
+        inf_data = np.where(self.x_np[index] > 0, np.inf, np.nan)
         self.x_np[index] = inf_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):

--- a/python/tests/ops/test_is_finite_op.py
+++ b/python/tests/ops/test_is_finite_op.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import unittest
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestIsFiniteOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+
+        self.x_np[0] = np.inf
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = paddle.isfinite(x)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("is_finite")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.is_finite(x)
+
+        prog = builder.build()
+
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads(all_equal=True)
+
+
+class TestIsFiniteOpShape(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestIsFiniteOpShape"
+        self.cls = TestIsFiniteOp
+        self.inputs = [{
+            "x_shape": [1],
+        }, {
+            "x_shape": [1024],
+        }, {
+            "x_shape": [1, 2048],
+        }, {
+            "x_shape": [1, 1, 1],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
+        self.attrs = []
+
+
+class TestIsFiniteOpDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestIsFiniteOpDtype"
+        self.cls = TestIsFiniteOp
+        self.inputs = [{
+            "x_shape": [32, 64],
+        }]
+        self.dtypes = [{
+            "x_dtype": "bool",
+        }, {
+            "x_dtype": "int8",
+        }, {
+            "x_dtype": "int16",
+        }, {
+            "x_dtype": "int32",
+        }, {
+            "x_dtype": "int64",
+        }, {
+            "x_dtype": "float16",
+            "max_relative_error": 1e-3
+        }, {
+            "x_dtype": "float32",
+        }, {
+            "x_dtype": "float64",
+        }]
+        self.attrs = []
+
+
+if __name__ == "__main__":
+    TestIsFiniteOpShape().run()
+    TestIsFiniteOpDtype().run()

--- a/python/tests/ops/test_is_inf_op.py
+++ b/python/tests/ops/test_is_inf_op.py
@@ -92,12 +92,6 @@ class TestIsInfOpDtype(TestCaseHelper):
             "x_shape": [32, 64],
         }]
         self.dtypes = [{
-            "x_dtype": "bool",
-        }, {
-            "x_dtype": "int8",
-        }, {
-            "x_dtype": "int16",
-        }, {
             "x_dtype": "int32",
         }, {
             "x_dtype": "int64",

--- a/python/tests/ops/test_is_inf_op.py
+++ b/python/tests/ops/test_is_inf_op.py
@@ -34,8 +34,9 @@ class TestIsInfOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        inf_data = np.zeros(self.x_np[0].shape, dtype="float") + np.inf
-        self.x_np[0] = inf_data.astype(self.case["x_dtype"])
+        index = np.random.randint(0, len(self.x_np))
+        inf_data = np.zeros(self.x_np[index].shape, dtype="float") + np.inf
+        self.x_np[index] = inf_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_inf_op.py
+++ b/python/tests/ops/test_is_inf_op.py
@@ -32,7 +32,10 @@ class TestIsInfOp(OpTest):
 
     def prepare_inputs(self):
         self.x_np = self.random(
-            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-100,
+            high=100)
 
         index = np.random.randint(0, len(self.x_np))
         inf_data = np.zeros(self.x_np[index].shape, dtype="float") + np.inf

--- a/python/tests/ops/test_is_inf_op.py
+++ b/python/tests/ops/test_is_inf_op.py
@@ -34,7 +34,8 @@ class TestIsInfOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        self.x_np[0] = np.inf
+        nan_data = np.zeros(self.x_np[0].shape, dtype="float") + np.nan
+        self.x_np[0] = nan_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_inf_op.py
+++ b/python/tests/ops/test_is_inf_op.py
@@ -34,8 +34,8 @@ class TestIsInfOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        nan_data = np.zeros(self.x_np[0].shape, dtype="float") + np.nan
-        self.x_np[0] = nan_data.astype(self.case["x_dtype"])
+        inf_data = np.zeros(self.x_np[0].shape, dtype="float") + np.inf
+        self.x_np[0] = inf_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_inf_op.py
+++ b/python/tests/ops/test_is_inf_op.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import unittest
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestIsInfOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+
+        self.x_np[0] = np.inf
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = paddle.isinf(x)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("is_inf")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.is_inf(x)
+
+        prog = builder.build()
+
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads(all_equal=True)
+
+
+class TestIsInfOpShape(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestIsInfOpShape"
+        self.cls = TestIsInfOp
+        self.inputs = [{
+            "x_shape": [1],
+        }, {
+            "x_shape": [1024],
+        }, {
+            "x_shape": [1, 2048],
+        }, {
+            "x_shape": [1, 1, 1],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
+        self.attrs = []
+
+
+class TestIsInfOpDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestIsInfOpDtype"
+        self.cls = TestIsInfOp
+        self.inputs = [{
+            "x_shape": [32, 64],
+        }]
+        self.dtypes = [{
+            "x_dtype": "bool",
+        }, {
+            "x_dtype": "int8",
+        }, {
+            "x_dtype": "int16",
+        }, {
+            "x_dtype": "int32",
+        }, {
+            "x_dtype": "int64",
+        }, {
+            "x_dtype": "float16",
+            "max_relative_error": 1e-3
+        }, {
+            "x_dtype": "float32",
+        }, {
+            "x_dtype": "float64",
+        }]
+        self.attrs = []
+
+
+if __name__ == "__main__":
+    TestIsInfOpShape().run()
+    TestIsInfOpDtype().run()

--- a/python/tests/ops/test_is_nan_op.py
+++ b/python/tests/ops/test_is_nan_op.py
@@ -34,8 +34,9 @@ class TestIsNanOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        nan_data = np.zeros(self.x_np[0].shape, dtype="float") + np.nan
-        self.x_np[0] = nan_data.astype(self.case["x_dtype"])
+        index = np.random.randint(0, len(self.x_np))
+        nan_data = np.zeros(self.x_np[index].shape, dtype="float") + np.nan
+        self.x_np[index] = nan_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_nan_op.py
+++ b/python/tests/ops/test_is_nan_op.py
@@ -92,12 +92,6 @@ class TestIsNanOpDtype(TestCaseHelper):
             "x_shape": [32, 64],
         }]
         self.dtypes = [{
-            "x_dtype": "bool",
-        }, {
-            "x_dtype": "int8",
-        }, {
-            "x_dtype": "int16",
-        }, {
             "x_dtype": "int32",
         }, {
             "x_dtype": "int64",

--- a/python/tests/ops/test_is_nan_op.py
+++ b/python/tests/ops/test_is_nan_op.py
@@ -32,7 +32,10 @@ class TestIsNanOp(OpTest):
 
     def prepare_inputs(self):
         self.x_np = self.random(
-            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+            shape=self.case["x_shape"],
+            dtype=self.case["x_dtype"],
+            low=-100,
+            high=100)
 
         index = np.random.randint(0, len(self.x_np))
         nan_data = np.zeros(self.x_np[index].shape, dtype="float") + np.nan

--- a/python/tests/ops/test_is_nan_op.py
+++ b/python/tests/ops/test_is_nan_op.py
@@ -34,7 +34,8 @@ class TestIsNanOp(OpTest):
         self.x_np = self.random(
             shape=self.case["x_shape"], dtype=self.case["x_dtype"])
 
-        self.x_np[0] = np.nan
+        nan_data = np.zeros(self.x_np[0].shape, dtype="float") + np.nan
+        self.x_np[0] = nan_data.astype(self.case["x_dtype"])
 
     def build_paddle_program(self, target):
         x = paddle.to_tensor(self.x_np, stop_gradient=True)

--- a/python/tests/ops/test_is_nan_op.py
+++ b/python/tests/ops/test_is_nan_op.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import unittest
+from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
+import paddle
+from cinn.frontend import *
+from cinn.common import *
+
+
+@OpTestTool.skip_if(not is_compiled_with_cuda(),
+                    "x86 test will be skipped due to timeout.")
+class TestIsNanOp(OpTest):
+    def setUp(self):
+        print(f"\nRunning {self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
+
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"], dtype=self.case["x_dtype"])
+
+        self.x_np[0] = np.nan
+
+    def build_paddle_program(self, target):
+        x = paddle.to_tensor(self.x_np, stop_gradient=True)
+        out = paddle.isnan(x)
+
+        self.paddle_outputs = [out]
+
+    def build_cinn_program(self, target):
+        builder = NetBuilder("is_nan")
+        x = builder.create_input(
+            self.nptype2cinntype(self.case["x_dtype"]), self.case["x_shape"],
+            "x")
+        out = builder.is_nan(x)
+
+        prog = builder.build()
+
+        res = self.get_cinn_output(prog, target, [x], [self.x_np], [out])
+
+        self.cinn_outputs = [res[0]]
+
+    def test_check_results(self):
+        self.check_outputs_and_grads(all_equal=True)
+
+
+class TestIsNanOpShape(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestIsNanOpShape"
+        self.cls = TestIsNanOp
+        self.inputs = [{
+            "x_shape": [1],
+        }, {
+            "x_shape": [1024],
+        }, {
+            "x_shape": [1, 2048],
+        }, {
+            "x_shape": [1, 1, 1],
+        }, {
+            "x_shape": [32, 64],
+        }, {
+            "x_shape": [16, 8, 4, 2],
+        }, {
+            "x_shape": [16, 8, 4, 2, 1],
+        }]
+        self.dtypes = [{
+            "x_dtype": "float32",
+        }]
+        self.attrs = []
+
+
+class TestIsNanOpDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestIsNanOpDtype"
+        self.cls = TestIsNanOp
+        self.inputs = [{
+            "x_shape": [32, 64],
+        }]
+        self.dtypes = [{
+            "x_dtype": "bool",
+        }, {
+            "x_dtype": "int8",
+        }, {
+            "x_dtype": "int16",
+        }, {
+            "x_dtype": "int32",
+        }, {
+            "x_dtype": "int64",
+        }, {
+            "x_dtype": "float16",
+            "max_relative_error": 1e-3
+        }, {
+            "x_dtype": "float32",
+        }, {
+            "x_dtype": "float64",
+        }]
+        self.attrs = []
+
+
+if __name__ == "__main__":
+    TestIsNanOpShape().run()
+    TestIsNanOpDtype().run()


### PR DESCRIPTION
 ## 描述
 From #1378
 
 为 `is_inf/is_finite/is_nan` 算子增加新的测试用例
 
序号 | 算子 | 单测文件
-- | -- | -- 
110 | is_nan/isnan | test_is_nan_op.py
111 | is_finite/isfinite | test_is_finite_op.py 
112 | is_inf/isinf | test_is_inf_op.py

 ### 算子类型
 * [x]  ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
 * [ ]  Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
 * [ ]  Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
 * [ ]  Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
 * [ ]  OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
 * [ ]  kNonFusible：无法融合的算子
 
 ## Test Cases Checklist
 ### 张量维度
 * [x]  1D 张量
 * [x]  2D 张量
 * [x]  3D 张量
 * [x]  4D 张量
 * [x]  5D 张量
 
 #### special shape
 挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。
 
 * [x]  其中一个维度为 1
 * [x]  其中一个维度小于 1024
 * [x]  其中一个维度大于 1024
 * [x]  向量的所有维度都是 1
 
 ### 张量数据类型
 * [x]  int32
 * [x]  int64
 * [x]  float16
 * [x]  float32
 * [x]  float64
 
 ### 广播
 * [ ]  这个算子是否支持广播？
 * [ ]  广播的测试样例