### PR TITLE
fix paddle test: arg_min/arg_max/flip/strided_slice

### DIFF
--- a/cinn/frontend/op_mappers/paddle/arg_min_max.cc
+++ b/cinn/frontend/op_mappers/paddle/arg_min_max.cc
@@ -44,7 +44,7 @@ void ArgOpMapperHelper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext
   auto out_name = op_desc.Output("Out").front();
 
   auto x    = ctx.GetVar(x_name);
-  auto axis = utils::GetAttrOrDefault<int32_t>(op_desc, "axis", -1);
+  auto axis = utils::GetAttrOrDefault<int64_t>(op_desc, "axis", -1);
   CHECK(op_desc.HasAttr("axis")) << "Argmax/Argmin op should has attribute \"axis\"! Please check.";
 
   auto keepdims = utils::GetAttrOrDefault<bool>(op_desc, "keepdims", false);

--- a/cinn/frontend/op_mappers/paddle/flip.cc
+++ b/cinn/frontend/op_mappers/paddle/flip.cc
@@ -28,7 +28,13 @@ void FlipOpMapper(const paddle::cpp::OpDesc& op_desc, const OpMapperContext& ctx
   auto axes = utils::GetAttrOrDefault<std::vector<int>>(op_desc, "axis", std::vector<int>{});
   VLOG(4) << "out_name = flip(" << x_name << ", axis=[" << cinn::utils::Join(axes, ", ") << "])";
 
-  auto x   = ctx.GetVar(x_name);
+  auto x           = ctx.GetVar(x_name);
+  const auto& ndim = x->shape.size();
+  for (auto& axis : axes) {
+    if (axis < 0) {
+      axis += ndim;
+    }
+  }
   auto out = ctx.Builder()->Flip(x, axes);
 
   ctx.AddVar(out_name, out);

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -1446,14 +1446,14 @@ std::vector<std::vector<int>> InferShapeForSlice(const std::vector<std::vector<i
   for (int i = 0; i < axes.size(); i++) {
     if (ends[i] < 0) {
       ends[i] = output_shape[axes[i]] + ends[i];
-    }
-    if (starts[i] < 0) {
-      starts[i] = output_shape[axes[i]] + starts[i];
-    }
-    if (ends[i] > output_shape[axes[i]]) {
+    } else if (ends[i] > output_shape[axes[i]]) {
       ends[i] = output_shape[axes[i]];
     }
-    if (starts[i] > output_shape[axes[i]]) {
+    if (starts[i] < -output_shape[axes[i]]) {
+      starts[i] = 0;
+    } else if (starts[i] < 0) {
+      starts[i] = output_shape[axes[i]] + starts[i];
+    } else if (starts[i] > output_shape[axes[i]]) {
       starts[i] = output_shape[axes[i]] - 1;
     }
 

--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -915,10 +915,11 @@ ir::Tensor Slice(const ir::Tensor& A,
   }
   std::vector<int> new_starts(starts);
   for (int i = 0; i < axes.size(); i++) {
-    if (new_starts[i] < 0) {
+    if (new_starts[i] < -input_shape[axes[i]]) {
+      new_starts[i] = 0;
+    } else if (new_starts[i] < 0) {
       new_starts[i] = input_shape[axes[i]] + new_starts[i];
-    }
-    if (new_starts[i] > input_shape[axes[i]]) {
+    } else if (new_starts[i] > input_shape[axes[i]]) {
       new_starts[i] = input_shape[axes[i]] - 1;
     }
   }

--- a/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -685,11 +685,14 @@ CINN_NVGPU_LT_NUM(fp32, float)
 CINN_NVGPU_LT_NUM(fp64, double)
 CINN_NVGPU_LT_NUM(int32, int)
 CINN_NVGPU_LT_NUM(int64, long long int)
+#ifdef CINN_CUDA_FP16
+CINN_NVGPU_LT_NUM(fp16, float16)
+#endif
 
 #undef CINN_NVGPU_LT_NUM
 
-#define CINN_NVGPU_GT_NUM(TYPE_SUFFIX, TYPE)                                                  \
-  __device__ inline int cinn_nvgpu_gt_num_##TYPE_SUFFIX(                                      \
+#define CINN_NVGPU_GT_NUM(TYPE_SUFFIX, TYPE)                                                 \
+  __device__ inline int cinn_nvgpu_gt_num_##TYPE_SUFFIX(                                     \
       const TYPE *buf, const int size, const TYPE num, const int offset, const int stride) { \
     int out = 0;                                                                             \
     for (int i = (size - 1) * stride + offset; i >= offset; i -= stride) {                   \
@@ -702,11 +705,14 @@ CINN_NVGPU_GT_NUM(fp32, float)
 CINN_NVGPU_GT_NUM(fp64, double)
 CINN_NVGPU_GT_NUM(int32, int)
 CINN_NVGPU_GT_NUM(int64, long long int)
+#ifdef CINN_CUDA_FP16
+CINN_NVGPU_GT_NUM(fp16, float16)
+#endif
 
 #undef CINN_NVGPU_GT_NUM
 
-#define CINN_NVGPU_INDEX_ADD(TYPE_SUFFIX, TYPE)                                \
-  __device__ inline TYPE cinn_nvgpu_index_add_##TYPE_SUFFIX(const TYPE x,      \
+#define CINN_NVGPU_INDEX_ADD(TYPE_SUFFIX, TYPE)                               \
+  __device__ inline TYPE cinn_nvgpu_index_add_##TYPE_SUFFIX(const TYPE x,     \
                                             const int axis_indice,            \
                                             const TYPE *__restrict__ y,       \
                                             const int offset,                 \

--- a/cinn/runtime/cuda/cuda_instrinsics_float16.cc
+++ b/cinn/runtime/cuda/cuda_instrinsics_float16.cc
@@ -76,7 +76,35 @@ CINN_REGISTER_HELPER(cuda_intrinsics_float16) {
 
 #undef REGISTER_EXTERN_FUNC_1_IN_1_FP16_OUT_BOOL
 
-#define _REGISTER_CINN_NVGPU_INDEX_ADD(TYPE_SUFFIX, TYPE)                        \
+#define REGISTER_CINN_NVGPU_GT_NUM(TYPE_SUFFIX, TYPE)                            \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_gt_num_##TYPE_SUFFIX, target)    \
+      .SetRetType<int>()                                                         \
+      .AddInputType<cinn_buffer_t *>()                                           \
+      .AddInputType<int>()                                                       \
+      .AddInputType<TYPE>()                                                      \
+      .AddInputType<int>()                                                       \
+      .AddInputType<int>()                                                       \
+      .End();
+
+  REGISTER_CINN_NVGPU_GT_NUM(fp16, float16);
+
+#undef REGISTER_CINN_NVGPU_GT_NUM
+
+#define REGISTER_CINN_NVGPU_LT_NUM(TYPE_SUFFIX, TYPE)                            \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_lt_num_##TYPE_SUFFIX, target)    \
+      .SetRetType<int>()                                                         \
+      .AddInputType<cinn_buffer_t *>()                                           \
+      .AddInputType<int>()                                                       \
+      .AddInputType<TYPE>()                                                      \
+      .AddInputType<int>()                                                       \
+      .AddInputType<int>()                                                       \
+      .End();
+
+  REGISTER_CINN_NVGPU_LT_NUM(fp16, float16);
+
+#undef REGISTER_CINN_NVGPU_LT_NUM
+
+#define REGISTER_CINN_NVGPU_INDEX_ADD(TYPE_SUFFIX, TYPE)                         \
   REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_index_add_##TYPE_SUFFIX, target) \
       .SetRetType<TYPE>()                                                        \
       .AddInputType<TYPE>()                                                      \
@@ -88,9 +116,9 @@ CINN_REGISTER_HELPER(cuda_intrinsics_float16) {
       .AddInputType<int>()                                                       \
       .End();
 
-  _REGISTER_CINN_NVGPU_INDEX_ADD(fp16, float16);
+  REGISTER_CINN_NVGPU_INDEX_ADD(fp16, float16);
 
-#undef _REGISTER_CINN_NVGPU_INDEX_ADD
+#undef REGISTER_CINN_NVGPU_INDEX_ADD
 
   return true;
 }

--- a/cinn/runtime/cuda/cuda_instrinsics_float16.cc
+++ b/cinn/runtime/cuda/cuda_instrinsics_float16.cc
@@ -76,28 +76,28 @@ CINN_REGISTER_HELPER(cuda_intrinsics_float16) {
 
 #undef REGISTER_EXTERN_FUNC_1_IN_1_FP16_OUT_BOOL
 
-#define REGISTER_CINN_NVGPU_GT_NUM(TYPE_SUFFIX, TYPE)                            \
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_gt_num_##TYPE_SUFFIX, target)    \
-      .SetRetType<int>()                                                         \
-      .AddInputType<cinn_buffer_t *>()                                           \
-      .AddInputType<int>()                                                       \
-      .AddInputType<TYPE>()                                                      \
-      .AddInputType<int>()                                                       \
-      .AddInputType<int>()                                                       \
+#define REGISTER_CINN_NVGPU_GT_NUM(TYPE_SUFFIX, TYPE)                         \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_gt_num_##TYPE_SUFFIX, target) \
+      .SetRetType<int>()                                                      \
+      .AddInputType<cinn_buffer_t *>()                                        \
+      .AddInputType<int>()                                                    \
+      .AddInputType<TYPE>()                                                   \
+      .AddInputType<int>()                                                    \
+      .AddInputType<int>()                                                    \
       .End();
 
   REGISTER_CINN_NVGPU_GT_NUM(fp16, float16);
 
 #undef REGISTER_CINN_NVGPU_GT_NUM
 
-#define REGISTER_CINN_NVGPU_LT_NUM(TYPE_SUFFIX, TYPE)                            \
-  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_lt_num_##TYPE_SUFFIX, target)    \
-      .SetRetType<int>()                                                         \
-      .AddInputType<cinn_buffer_t *>()                                           \
-      .AddInputType<int>()                                                       \
-      .AddInputType<TYPE>()                                                      \
-      .AddInputType<int>()                                                       \
-      .AddInputType<int>()                                                       \
+#define REGISTER_CINN_NVGPU_LT_NUM(TYPE_SUFFIX, TYPE)                         \
+  REGISTER_FACKED_EXTERN_FUNC_HELPER(cinn_nvgpu_lt_num_##TYPE_SUFFIX, target) \
+      .SetRetType<int>()                                                      \
+      .AddInputType<cinn_buffer_t *>()                                        \
+      .AddInputType<int>()                                                    \
+      .AddInputType<TYPE>()                                                   \
+      .AddInputType<int>()                                                    \
+      .AddInputType<int>()                                                    \
       .End();
 
   REGISTER_CINN_NVGPU_LT_NUM(fp16, float16);


### PR DESCRIPTION
- arg\_min/arg\_max: 修复 axis 类型不对齐的问题；添加 fp16 的支持
- flip: 在 mapper 中将 axis 的值设置为正值；
- strided_slice: 修改 shape infer 使其与 paddle 对齐