### PR TITLE
fix(ir): fix ir copy of var node

### DIFF
--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -181,6 +181,8 @@ class RestructureVarNodes : public ir::IRMutator<> {
       indices_copied.push_back(IRCopy(indice));
     }
     op->As<ir::Load>()->indices = indices_copied;
+
+    IRMutator::Visit(load, op);
   }
 
   void Visit(const ir::Store *store, Expr *op) override {
@@ -189,6 +191,8 @@ class RestructureVarNodes : public ir::IRMutator<> {
       indices_copied.push_back(IRCopy(indice));
     }
     op->As<ir::Store>()->indices = indices_copied;
+
+    IRMutator::Visit(store, op);
   }
 };
 

--- a/cinn/optim/transform_gpu_forloop.cc
+++ b/cinn/optim/transform_gpu_forloop.cc
@@ -175,7 +175,21 @@ class RestructureVarNodes : public ir::IRMutator<> {
   void operator()(ir::Expr *expr) { ir::IRMutator<>::Visit(expr, expr); }
 
  private:
-  void Visit(const ir::_Var_ *var, Expr *op) override { *op = IRCopy(*op); }
+  void Visit(const ir::Load *load, Expr *op) override {
+    std::vector<ir::Expr> indices_copied;
+    for (const ir::Expr &indice : load->indices) {
+      indices_copied.push_back(IRCopy(indice));
+    }
+    op->As<ir::Load>()->indices = indices_copied;
+  }
+
+  void Visit(const ir::Store *store, Expr *op) override {
+    std::vector<ir::Expr> indices_copied;
+    for (const ir::Expr &indice : store->indices) {
+      indices_copied.push_back(IRCopy(indice));
+    }
+    op->As<ir::Store>()->indices = indices_copied;
+  }
 };
 
 class ReplaceIndexToBindExpr : public ir::IRMutator<> {


### PR DESCRIPTION
Copy the indices under the store and load nodes, so that the var node points to different objects. Fixed the bug where one modification caused multiple changes during ReplaceIndexToBindExpr.