### PR TITLE
fix(lowering): Align the extent of reudce's fusion operator loop

### DIFF
--- a/cinn/hlir/framework/op_lowering_util.cc
+++ b/cinn/hlir/framework/op_lowering_util.cc
@@ -686,6 +686,18 @@ void LoopAssignReduceWithLast(ir::IRSchedule& ir_sch,
   if (lane > max_num_threads) {
     // last reduce axis size > 1024
     if (index == static_cast<int>(axes.size()) - 1) {
+      int tail         = max_num_threads;
+      bool check_bound = true;
+      for (; tail >= max_num_threads / 2; --tail) {
+        if (lane % tail == 0) {
+          check_bound = false;
+          break;
+        }
+      }
+      if (check_bound) {
+        lane = ((lane + max_num_threads - 1) / max_num_threads) * max_num_threads;
+        ir_sch.Split(block_name, axes[index], {lane});
+      }
       int idx = max_num_threads;
       do {
         if (lane % idx == 0) {


### PR DESCRIPTION
Take the warp reduce policy as an example. If the dimension of the reduce op is not divisible by 32, the reduce loop is extended for the extent that it is divisible by 32.

```python
    var_7062 = builder.broadcast_to(var_2931, broadcast_axes=[0, 1, 2, 3], out_shape=[128, 12, 197, 197])
    var_2937 = builder.reduce_sum(var_7062, dim=[3], keep_dim=True)
    var_7063 = builder.broadcast_to(var_2937, broadcast_axes=[0, 1, 2, 3], out_shape=[128, 12, 197, 197])
```

In the preceding example, the shape of the reduce axis is 197, and the obtained ir of cinn is as follows: `reduce_k extent * threadIdx.x extent=224` in ir. 

In the current lowering process, there are bugs in the lowering process that do not align the for loop  between other operators and reduce operators.
```c++
          thread_bind[blockIdx.x] for (i_j_fused_k_fused, 0, 151296)
          {
            thread_bind[threadIdx.y] for (i_j_fused_k_fused_0, 0, 2)
            {
              thread_bind[threadIdx.x] for (b, 0, 32)
              {
               .......
                serial for (reduce_k_0, 0, 7)
                {
                  ScheduleBlock(var_9_internal)
                  {
                    .......
                    var_9_internal[0] = cinn_max(var_9_internal[0], select(((i4_1 + (i5 * 32)) < 197), var_8[i0_8, i1_8, i2_7, ((i4_1 + (i5 * 32)) / 1)], -3.40282347e+38f))

                  }
                }
              }
            }
          }

```

In the preceding example, the cinn ir obtained for broadcast not aligned with reduce is as follows. `flat_i_2 extent` is 197 and is not divisible by 32.
```cpp
      serial for (flat_i, 0, 128)
      {
        serial for (flat_i_0, 0, 12)
        {
          serial for (flat_i_1, 0, 197)
          {
            serial for (flat_i_2, 0, 197)
            {
              ScheduleBlock(var_16)
              {
                _flat_i = axis.bind(((465708 * flat_i) + ((38809 * flat_i_0) + ((197 * flat_i_1) + flat_i_2))))
                var_16[_flat_i] = float16(var_15[_flat_i])
              }
            }
          }
        }
      }

```

The cinn ir of broadcast extended after 224 like reduce is as follows. `if ` is used to ensure that the calculation logic is the same as before.
```cpp
      serial for (flat_i, 0, 128)
      {
        serial for (flat_i_0, 0, 12)
        {
          serial for (flat_i_1, 0, 197)
          {
            serial for (flat_i_2, 0, 224)
            {
              if ((flat_i_2 < 197)) {
                {
                  ScheduleBlock(var_16)
                  {
                    _flat_i = axis.bind(((465708 * flat_i) + ((38809 * flat_i_0) + ((197 * flat_i_1) + flat_i_2))))
                    var_16[_flat_i] = float16(var_15[_flat_i])
                  }
                }
              }
            }
          }
        }
      }
```