### PR TITLE
Op gather support N-D index

### DIFF
--- a/cinn/auto_schedule/tests/performance_comparison_test.cc
+++ b/cinn/auto_schedule/tests/performance_comparison_test.cc
@@ -293,8 +293,8 @@ TEST_F(PerformanceTester, LookupTable) {
 TEST_F(PerformanceTester, Gather) {
   int axis = 3;
 
-  Evaluate(tests::OpBuilder("gather").Build({{"operand", {10, 12, 128, 512}}, {"index", {128}, common::Int(32)}},
-                                            {{"axis", axis}}));
+  Evaluate(tests::OpBuilder("gather").Build(
+      {{"operand", {10, 12, 128, 512}}, {"index", {1, 1, 1, 128}, common::Int(32)}}, {{"axis", axis}}));
 }
 
 // paddle model test

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -14,7 +14,6 @@
 
 #include "cinn/frontend/net_builder.h"
 
-#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cinn/frontend/net_builder.cc
+++ b/cinn/frontend/net_builder.cc
@@ -14,6 +14,7 @@
 
 #include "cinn/frontend/net_builder.h"
 
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -389,7 +390,23 @@ Variable NetBuilder::Select(const Variable& condition, const Variable& true_valu
 }
 
 Variable NetBuilder::Gather(const Variable& operand, const Variable& index, int axis) {
-  return CustomInstr("gather", {operand, index}, {{"axis", axis}}).front();
+  size_t x_ndim = operand->shape.size();
+  if (axis < 0) {
+    axis += static_cast<int>(x_ndim);
+  }
+  CHECK_LT(axis, x_ndim) << "Axis must be in [" << -x_ndim << ", " << x_ndim - 1 << ").";
+  Variable transformed_index = index;
+  // If we got 1-D Tensor, the first step is reshape, in order to keep operand.rank == index.rank
+  if (index->shape.size() == 1) {
+    std::vector<int> index_reshape(x_ndim, 1);
+    index_reshape[axis] = index->shape[0];
+    transformed_index   = Reshape(index, index_reshape);
+  }
+  // Then we need to broadcast transformed index
+  auto broadcast_shape  = operand->shape;
+  broadcast_shape[axis] = transformed_index->shape[axis];
+  transformed_index     = BroadcastTo(transformed_index, broadcast_shape);
+  return CustomInstr("gather", {operand, transformed_index}, {{"axis", axis}}).front();
 }
 
 Variable NetBuilder::ScatterAssign(const Variable& operand, const Variable& updates, const Variable& index, int axis) {

--- a/cinn/hlir/op/transform.cc
+++ b/cinn/hlir/op/transform.cc
@@ -28,7 +28,6 @@
 #include "cinn/hlir/pe/transform.h"
 #include "cinn/ir/ir_printer.h"
 #include "cinn/utils/string.h"
-#include "glog/logging.h"
 
 DECLARE_bool(cinn_ir_schedule);
 

--- a/cinn/hlir/pe/transform.cc
+++ b/cinn/hlir/pe/transform.cc
@@ -1047,7 +1047,7 @@ ir::Tensor Gather(const ir::Tensor& x,
                   const std::vector<Expr>& output_shape,
                   int axis,
                   const std::string& name) {
-  CHECK_EQ(1, static_cast<int>(index->shape.size())) << "The index should be a 1-D Tensor.";
+  CHECK_EQ(x->shape.size(), index->shape.size()) << "The rank of x and index must be same.";
   // The implementation details are explained below.
   // If output_shape = [2, 4, 3] and axis = 0, `Compute` can be translated as the following code:
   // {
@@ -1057,7 +1057,7 @@ ir::Tensor Gather(const ir::Tensor& x,
   //     {
   //       for (k, 0, 3)
   //       {
-  //         index_select_output[i, j, k] = X[int32(Index[i]), j, k]
+  //         index_select_output[i, j, k] = X[int32(Index[i, j, k]), j, k]
   //       }
   //     }
   //   }
@@ -1071,7 +1071,7 @@ ir::Tensor Gather(const ir::Tensor& x,
         // The element type of index maybe int64, but the index type is limited to int32 in CINN.
         // See the below link for more details:
         // https://github.com/PaddlePaddle/CINN/blob/85ab4981a38926dc5c1dbf672762cec335d2b857/cinn/ir/ir.cc#L477
-        transformed_indice[axis] = ir::Cast::Make(common::Int(32), index(indice[axis]));
+        transformed_indice[axis] = ir::Cast::Make(common::Int(32), index(indice));
         return x(transformed_indice);
       },
       name);

--- a/python/tests/op_mappers/test_take_along_axis_op.py
+++ b/python/tests/op_mappers/test_take_along_axis_op.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_mapper_test import OpMapperTest
+import paddle
+
+
+def infer_broadcast_shape(arr, indices, axis):
+    # This function is used in take/put_along_axis
+    broadcast_shape_list = list(arr.shape)
+    broadcast_shape_list[axis] = list(indices.shape)[axis]
+    broadcast_shape = tuple(broadcast_shape_list)
+    for i in range(len(arr.shape)):
+        if arr.shape[i] < indices.shape[i]:
+            # if indices matrix has larger size than arr matrix, do not broadcast.
+            return None
+    return broadcast_shape
+
+
+class TestTakeAlongAxisOp(OpMapperTest):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 1, 1, 5], 'int32', 0, 5),
+        }
+        self.axis = 0
+
+    def set_op_type(self):
+        return "take_along_axis"
+
+    def set_op_inputs(self):
+        broadcast_shape = infer_broadcast_shape(
+            self.feed_data['x'], self.feed_data['index'], self.axis)
+        if not broadcast_shape:
+            broadcast_shape = self.feed_data['index'].shape
+        self.feed_data['index'] = np.broadcast_to(self.feed_data['index'],
+                                                  broadcast_shape).copy()
+        broadcast_shape_list = list(broadcast_shape)
+        broadcast_shape_list[self.axis] = list(
+            self.feed_data['x'].shape)[self.axis]
+        broadcast_shape = tuple(broadcast_shape_list)
+        self.feed_data['x'] = np.broadcast_to(self.feed_data['x'],
+                                              broadcast_shape).copy()
+        x = paddle.static.data(
+            name='x',
+            shape=self.feed_data['x'].shape,
+            dtype=self.feed_data['x'].dtype)
+        index = paddle.static.data(
+            name='index',
+            shape=self.feed_data['index'].shape,
+            dtype=self.feed_data['index'].dtype)
+        return {'Input': [x], 'Index': [index]}
+
+    def set_op_attrs(self):
+        return {'Axis': self.axis}
+
+    def set_op_outputs(self):
+        return {'Result': [str(self.feed_data['x'].dtype)]}
+
+    def test_check_results(self):
+        self.check_outputs_and_grads(all_equal=True)
+
+
+class TestTakeAlongAxisCase1(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 1, 1, 5], 'int32', 0, 5),
+        }
+        self.axis = 1
+
+
+class TestTakeAlongAxisCase2(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 1, 1, 5], 'int32', 0, 5),
+        }
+        self.axis = 2
+
+
+class TestTakeAlongAxisCase3(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 1, 1, 5], 'int32', 0, 5),
+        }
+        self.axis = 3
+
+
+class TestTakeAlongAxisCase4(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([5, 1, 1, 1], 'int32', 0, 5),
+        }
+        self.axis = 0
+
+
+class TestTakeAlongAxisCase5(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 5, 1, 1], 'int32', 0, 5),
+        }
+        self.axis = 0
+
+
+class TestTakeAlongAxisCase6(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 1, 5, 1], 'int32', 0, 5),
+        }
+        self.axis = 0
+
+
+class TestTakeAlongAxisCase7(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float32'),
+            'index': self.random([1, 1, 1, 5], 'int64', 0, 5),
+        }
+        self.axis = 0
+
+
+class TestTakeAlongAxisCase8(TestTakeAlongAxisOp):
+    def init_input_data(self):
+        self.feed_data = {
+            'x': self.random([5, 5, 5, 5], 'float64'),
+            'index': self.random([1, 1, 1, 5], 'int64', 0, 5),
+        }
+        self.axis = 0
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. 原`gather`中，`index`只支持1-D Tensor，因此无法将`take_along_axis`直接映射到`gather`上
2. 此PR扩展了CINN中的`gather`，使参数`index`支持N-D Tensor，同时也保留对原1-D Tensor的兼容