### PR TITLE
Refactor op test on remainder, uniform and gaussian

### DIFF
--- a/python/tests/ops/test_remainder_op.py
+++ b/python/tests/ops/test_remainder_op.py
@@ -14,11 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import numpy as np
 from op_test import OpTest, OpTestTool
+from op_test_helper import TestCaseHelper
 import paddle
-import paddle.nn.functional as F
 import cinn
 from cinn.frontend import *
 from cinn.common import *
@@ -28,105 +27,172 @@ from cinn.common import *
                     "x86 test will be skipped due to timeout.")
 class TestRemainderOp(OpTest):
     def setUp(self):
-        self.init_case()
+        # print(f"\n{self.__class__.__name__}: {self.case}")
+        self.prepare_inputs()
 
-    def init_case(self):
-        self.inputs = {
-            "x": np.array([7]).astype('float32'),
-            "y": np.array([-3]).astype('float32')
-        }
+    def prepare_inputs(self):
+        self.x_np = self.random(
+            shape=self.case["x_shape"],
+            dtype=self.case["dtype"],
+            low=self.case["x_low"],
+            high=self.case["x_high"])
+        self.y_np = self.random(
+            shape=self.case["y_shape"],
+            dtype=self.case["dtype"],
+            low=self.case["y_low"],
+            high=self.case["y_high"])
+        self.y_np = np.where(self.y_np == 0, 1, self.y_np)
 
     def build_paddle_program(self, target):
-        x = paddle.to_tensor(self.inputs["x"], stop_gradient=False)
-        y = paddle.to_tensor(self.inputs["y"], stop_gradient=False)
-
+        x = paddle.to_tensor(self.x_np, stop_gradient=False)
+        y = paddle.to_tensor(self.y_np, stop_gradient=False)
         out = paddle.remainder(x, y)
-
         self.paddle_outputs = [out]
 
     def build_cinn_program(self, target):
-        builder = NetBuilder("pow")
+        builder = NetBuilder("remainder")
         x = builder.create_input(
-            self.nptype2cinntype(self.inputs["x"].dtype),
-            self.inputs["x"].shape, "x")
+            self.nptype2cinntype(self.x_np.dtype), self.x_np.shape, "x")
         y = builder.create_input(
-            self.nptype2cinntype(self.inputs["y"].dtype),
-            self.inputs["y"].shape, "y")
+            self.nptype2cinntype(self.y_np.dtype), self.y_np.shape, "y")
         out = builder.remainder(x, y)
-
         prog = builder.build()
         res = self.get_cinn_output(prog, target, [x, y],
-                                   [self.inputs["x"], self.inputs["y"]], [out])
-
-        self.cinn_outputs = [res[0]]
+                                   [self.x_np, self.y_np], [out])
+        self.cinn_outputs = res
 
     def test_check_results(self):
         self.check_outputs_and_grads()
 
 
-class TestRemainderCase1(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "float32", 20, 100),
-            "y": self.random([32, 64], "float32", 1, 20),
-        }
+class TestRemainderOpShape(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestRemainderOpCase"
+        self.cls = TestRemainderOp
+        self.inputs = [
+            {
+                "x_shape": [1],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [1024],
+                "y_shape": [1024],
+            },
+            {
+                "x_shape": [512, 256],
+                "y_shape": [512, 256],
+            },
+            {
+                "x_shape": [128, 64, 32],
+                "y_shape": [128, 64, 32],
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 8, 4, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 8, 4, 2, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "int32",
+            },
+        ]
+        self.attrs = [
+            {
+                "x_low": -10,
+                "x_high": 10,
+                "y_low": -10,
+                "y_high": 10,
+            },
+        ]
 
 
-class TestRemainderCase2(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "int32", 20, 100),
-            "y": self.random([32, 64], "int32", 1, 20),
-        }
+class TestRemainderOpDtype(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestRemainderOpCase"
+        self.cls = TestRemainderOp
+        self.inputs = [
+            {
+                "x_shape": [1024],
+                "y_shape": [1024],
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "int32",
+            },
+            {
+                "dtype": "int64",
+            },
+            {
+                "dtype": "float16",
+            },
+            {
+                "dtype": "float32",
+            },
+            {
+                "dtype": "float64",
+            },
+        ]
+        self.attrs = [
+            {
+                "x_low": -10,
+                "x_high": 10,
+                "y_low": -10,
+                "y_high": 10,
+            },
+        ]
 
 
-class TestRemainderCase3(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "float32", 20, 100),
-            "y": self.random([32, 64], "float32", -20, -1),
-        }
-
-
-class TestRemainderCase4(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "int32", 20, 100),
-            "y": self.random([32, 64], "int32", -20, -1),
-        }
-
-
-class TestRemainderCase5(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "float32", -100, -20),
-            "y": self.random([32, 64], "float32", 1, 20),
-        }
-
-
-class TestRemainderCase6(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "float32", -100, -20),
-            "y": self.random([32, 64], "float32", -20, -1),
-        }
-
-
-class TestRemainderCase7(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "int32", -100, -20),
-            "y": self.random([32, 64], "int32", 1, 20),
-        }
-
-
-class TestRemainderCase8(TestRemainderOp):
-    def init_case(self):
-        self.inputs = {
-            "x": self.random([32, 64], "int32", -100, -20),
-            "y": self.random([32, 64], "int32", -20, -1),
-        }
+class TestRemainderOpBroadcast(TestCaseHelper):
+    def init_attrs(self):
+        self.class_name = "TestRemainderOpCase"
+        self.cls = TestRemainderOp
+        self.inputs = [
+            {
+                "x_shape": [1],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [1024],
+                "y_shape": [1],
+            },
+            {
+                "x_shape": [512, 256],
+                "y_shape": [1, 256],
+            },
+            {
+                "x_shape": [128, 64, 32],
+                "y_shape": [128, 1, 32],
+            },
+            {
+                "x_shape": [16, 8, 4, 2],
+                "y_shape": [16, 1, 1, 2],
+            },
+            {
+                "x_shape": [16, 8, 4, 2, 1],
+                "y_shape": [16, 1, 1, 1, 1],
+            },
+        ]
+        self.dtypes = [
+            {
+                "dtype": "int32",
+            },
+        ]
+        self.attrs = [
+            {
+                "x_low": -10,
+                "x_high": 10,
+                "y_low": -10,
+                "y_high": 10,
+            },
+        ]
 
 
 if __name__ == "__main__":
-    unittest.main()
+    TestRemainderOpShape().run()
+    TestRemainderOpDtype().run()
+    TestRemainderOpBroadcast().run()


### PR DESCRIPTION
使用新单测重写了`remainder, uniform_random, gaussian_random`的单测

## Remainder

序号 | 算子名 | 单测文件 | 
-- | -- | -- | 
10 | remainder | test_remainder_op.py | 

### 算子类型

- [x] ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ] Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ] Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [ ] Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ] OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [ ] kNonFusible：无法融合的算子

### OpMapper

- [ ] 该算子是否 OpMapper? 如果是，请贴出在 Paddle 中对应的 OpMaker 代码路径。（给出 Github 链接更好）

## Test Cases Checklist

### 张量维度

- [x] 1D 张量
- [x] 2D 张量
- [x] 3D 张量
- [x] 4D 张量

#### special shape

挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x] 其中一个维度为 1
- [x] 其中一个维度小于 1024
- [ ] 其中一个维度大于 1024
- [x] 向量的所有维度都是 1

### 张量数据类型

- [x] int32
- [x] int64
- [x] float16
- [x] float32
- [x] float64

### 广播

- [x] 这个算子是否支持广播？
- [x] 广播的测试样例

### 算子属性

算子属性的测试用例。

- [ ] 属性：属性类型-可取值
- [x] 使用 OpTestHelper 测试上述属性的笛卡尔积组合

### 备注

- 无

## Uniform_random & Gaussian_random

序号 | 算子名 | 单测文件 | 
-- | -- | -- | 
41 | gaussian_random | test_gaussian_random_op.py | 
114 | uniform_random | test_ uniform_random_op.py | 

### 算子类型

- [ ] ElementWise：输入张量索引和输出张量索引之间存在一对一的对应关系
- [ ] Broadcast：输入张量索引和输出张量索引之间存在一对多的对应关系
- [ ] Injective：单射算子，可以将一个输出 axis 映射到一个输入 axis
- [ ] Reduction：输入张量索引和输出张量索引之间存在多对一的对应关系
- [ ] OutFusible：复杂算子，仍然可以将一对一的算子融合到其输出中。
- [x] kNonFusible：无法融合的算子

### OpMapper

- [ ] 该算子是否 OpMapper? 如果是，请贴出在 Paddle 中对应的 OpMaker 代码路径。（给出 Github 链接更好）

## Test Cases Checklist

### 张量维度

- [x] 1D 张量
- [x] 2D 张量
- [x] 3D 张量
- [x] 4D 张量

#### special shape

挑选 2D/3D/4D 张量中的一个，测试下面的特殊情况。

- [x] 其中一个维度为 1
- [x] 其中一个维度小于 1024
- [ ] 其中一个维度大于 1024
- [x] 向量的所有维度都是 1

### 张量数据类型

- [ ] int32
- [ ] int64
- [ ] float16
- [x] float32
- [x] float64

### 广播

- [ ] 这个算子是否支持广播？
- [ ] 广播的测试样例

### 算子属性

算子属性的测试用例。

- [x] 属性：属性类型-可取值
    - [x] `uniform_random: min`
    - [x] `uniform_random: max`
    - [x] `uniform_random & gaussian_random: seed`
    - [x] `gaussian_random: mean`
    - [x] `gaussian_random: std`
- [x] 使用 OpTestHelper 测试上述属性的笛卡尔积组合

### 备注

- Paddle的随机数算子使用了`thrust`库实现，其`offset`从`GPUContext`中获取，目前暂时无法严格对齐