### PR TITLE
add paddle proto VarType::Type::RAW map to CINN Unk

### DIFF
--- a/cinn/common/type.cc
+++ b/cinn/common/type.cc
@@ -422,6 +422,7 @@ int Type::bytes() const {
 
 Type Str2Type(const std::string &type) {
   static std::unordered_map<std::string, Type> str2type_map = {
+      {"unk", Type()},
       {"void", Void()},
       {"bool", Bool()},
       {"unsigned char", UI8()},

--- a/cinn/frontend/op_mappers/common_utils.h
+++ b/cinn/frontend/op_mappers/common_utils.h
@@ -159,6 +159,10 @@ inline std::string GetPaddleDtype(const paddle::cpp::OpDesc& op_desc,
   }
   auto dtype_pd   = static_cast<paddle::cpp::VarDescAPI::Type>(dtype_id);
   auto dtype_cinn = CppVarType2CommonType(dtype_pd);
+  if (dtype_cinn.is_unk()) {
+    return "";
+  }
+
   return common::Type2Str(dtype_cinn);
 }
 

--- a/cinn/frontend/var_type_utils.h
+++ b/cinn/frontend/var_type_utils.h
@@ -30,38 +30,38 @@ inline common::Type CppVarType2CommonType(paddle::cpp::VarDescAPI::Type type) {
     return common::c_type();                  \
     break;
 
-  static std::vector<std::string> var_type_names_ = {"BOOL",
-                                                     "INT16",
-                                                     "INT32",
-                                                     "INT64",
-                                                     "FP16",
-                                                     "FP32",
-                                                     "FP64",
-                                                     "LOD_TENSOR",
-                                                     "SELECTED_ROWS",
-                                                     "FEED_MINIBATCH",
-                                                     "FETCH_LIST",
-                                                     "STEP_SCOPES",
-                                                     "LOD_RANK_TABLE",
-                                                     "LOD_TENSOR_ARRAY",
-                                                     "PLACE_LIST",
-                                                     "READER",
+  static std::vector<std::string> var_type_names_ = {"BOOL",              // 0
+                                                     "INT16",             // 1
+                                                     "INT32",             // 2
+                                                     "INT64",             // 3
+                                                     "FP16",              // 4
+                                                     "FP32",              // 5
+                                                     "FP64",              // 6
+                                                     "LOD_TENSOR",        // 7
+                                                     "SELECTED_ROWS",     // 8
+                                                     "FEED_MINIBATCH",    // 9
+                                                     "FETCH_LIST",        // 10
+                                                     "STEP_SCOPES",       // 11
+                                                     "LOD_RANK_TABLE",    // 12
+                                                     "LOD_TENSOR_ARRAY",  // 13
+                                                     "PLACE_LIST",        // 14
+                                                     "READER",            // 15
                                                      "",
-                                                     "RAW",
-                                                     "TUPLE",
-                                                     "SIZE_T",
-                                                     "UINT8",
-                                                     "INT8",
-                                                     "BF16",
-                                                     "COMPLEX64",
-                                                     "COMPLEX128",
-                                                     "STRING",
-                                                     "STRINGS",
-                                                     "VOCAB",
-                                                     "FEED_LIST",
-                                                     "PSTRING",
-                                                     "SPARSE_COO",
-                                                     "SPARSE_CSR"};
+                                                     "RAW",          // 17
+                                                     "TUPLE",        // 18
+                                                     "SIZE_T",       // 19
+                                                     "UINT8",        // 20
+                                                     "INT8",         // 21
+                                                     "BF16",         // 22
+                                                     "COMPLEX64",    // 23
+                                                     "COMPLEX128",   // 24
+                                                     "STRING",       // 25
+                                                     "STRINGS",      // 26
+                                                     "VOCAB",        // 27
+                                                     "FEED_LIST",    // 28
+                                                     "PSTRING",      // 29
+                                                     "SPARSE_COO",   // 30
+                                                     "SPARSE_CSR"};  // 31
   CHECK_LT(static_cast<int>(type), var_type_names_.size()) << "Unknown VarDesc type: " << static_cast<int>(type);
 
   switch (type) {
@@ -77,11 +77,15 @@ inline common::Type CppVarType2CommonType(paddle::cpp::VarDescAPI::Type type) {
     SET_TYPE_CASE_ITEM(UINT8, UI8)
     SET_TYPE_CASE_ITEM(INT8, I8)
     SET_TYPE_CASE_ITEM(STRING, String)
+    // The paddle's phi::DataType::UNDEFINED is mapped into ProtoDataType::RAW,
+    // so here need convert back to unkown type.
+    SET_TYPE_CASE_ITEM(RAW, Type)
     default:
-      LOG(FATAL) << "Unknown VarDesc type: " << var_type_names_[static_cast<int>(type)];
+      LOG(FATAL) << "Unknown VarDesc type: " << var_type_names_[static_cast<int>(type)] << "(" << static_cast<int>(type)
+                 << ")";
   }
 #undef SET_DATA_TYPE_CASE_ITEM
-  return common::Void();
+  return common::Type();
 }
 
 inline OpMapperContext::FeedInfo GetFeedInfoFromDesc(const paddle::cpp::VarDesc& desc) {

--- a/python/tests/op_mappers/op_mapper_test.py
+++ b/python/tests/op_mappers/op_mapper_test.py
@@ -399,6 +399,7 @@ class OpMapperTest(OpTest):
             paddle.int64: "int64",
             paddle.uint8: "uint8",
             paddle.bool: "bool",
+            paddle.fluid.core.VarDesc.VarType.RAW: "unk",
         }
         assert dtype in switch_map, str(dtype) + " not support in CINN"
         return switch_map[dtype]
@@ -415,6 +416,8 @@ class OpMapperTest(OpTest):
             "int64": paddle.int64,
             "uint8": paddle.uint8,
             "bool": paddle.bool,
+            # The paddle's phi::DataType::UNDEFINED is mapped into ProtoDataType::RAW,
+            "unk": paddle.fluid.core.VarDesc.VarType.RAW,
         }
         assert dtype in switch_map, dtype + " not support in CINN"
         return switch_map[dtype]

--- a/python/tests/op_mappers/test_reduce_op.py
+++ b/python/tests/op_mappers/test_reduce_op.py
@@ -128,5 +128,14 @@ class TestReduceOutType(TestReduceOp):
         }
 
 
+class TestReduceUnkOutType(TestReduceOp):
+    def set_op_attrs(self):
+        return {
+            "dim": self.dim,
+            "keep_dim": self.keepdim,
+            "out_dtype": self.nptype2paddledtype("unk")
+        }
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Paddle侧[`phi::DataType::UNDEFINED`](https://github.com/PaddlePaddle/Paddle/blob/0942f77e3c855feacbd49737f38170e3b6161261/paddle/phi/core/utils/data_type.h#L204)是映射到了proto中的`VarDesc::Type::RAW`，而reduce算子的`out_dtype`参数默认值正是`phi::DataType::UNDEFINED`，因此CINN中也需要对此做适配处理。