### PR TITLE
Fix reduce cast schedule bug

### DIFF
--- a/python/tests/fusion/test_reduce_cast.py
+++ b/python/tests/fusion/test_reduce_cast.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 CINN Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from fusion_test import FusionTest
+
+
+class TestGroup1(FusionTest):
+    def init_input_data(self):
+        self.feed_data = {}
+
+    def build_program(self, builder, target):
+        x = builder.fill_constant(
+            dtype="float32", shape=[4, 5, 20, 20], value=1.00000000)
+        y = builder.cast(
+            builder.reduce_sum(x, dim=[2], keep_dim=False), "float16")
+
+        feed_list = []
+        fetch_list = [y]
+
+        return feed_list, fetch_list
+
+    def test_check_results(self):
+        self.check_fusion_outputs(group_size=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes a bug in the reduce+elementwise subgraph schedule.
In the case of non final dimension reduction, in order to make a loop bound to the cuda axis a multiple of 32, padding was performed on it. Since the shape of the tensor remains unchanged, an If condition was used inside the loop to limit the number of threads executing calculations. When aligning the loop of the elementwise Op following the reduce loop, this situation was not taken into account, resulting in an error in the if condition of the elementwise calculation block. This PR uses a two-stage split to align the loop, and currently only supports loops with only one dimension for padding and only one if condition.

