### PR TITLE
Logical op full dtype support

### DIFF
--- a/cinn/hlir/op/elementwise.cc
+++ b/cinn/hlir/op/elementwise.cc
@@ -858,6 +858,10 @@ std::vector<Type> InferDtypeForArange(const std::vector<Type> &inputs_type, cons
   return {common::Str2Type(absl::get<std::string>(attrs.at("dtype")))};
 }
 
+std::vector<Type> InferDtypeForLogicalNot(const std::vector<Type> &inputs_type, const framework::AttrMapType &attrs) {
+  return {common::Bool()};
+}
+
 }  // namespace op
 }  // namespace hlir
 }  // namespace cinn
@@ -901,7 +905,6 @@ CINN_REGISTER_HELPER(elementwise_ops) {
 
   CINN_REGISTER_UNARY(negative, Negative)
   CINN_REGISTER_UNARY(identity, Identity)
-  CINN_REGISTER_UNARY(logical_not, LogicalNot)
   CINN_REGISTER_UNARY(sign, Sign)
   CINN_REGISTER_UNARY(abs, Abs)
   CINN_REGISTER_UNARY(rsqrt, Rsqrt)
@@ -1051,6 +1054,17 @@ CINN_REGISTER_HELPER(elementwise_ops) {
       .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForElementwise))
       .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForElementwise))
       .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElementWise);
+
+  CINN_REGISTER_OP(logical_not)
+      .describe("Logical not function")
+      .set_num_inputs(1)
+      .set_num_outputs(1)
+      .set_attr<cinn::hlir::framework::StrategyFunction>("CINNStrategy", cinn::hlir::op::StrategyForLogicalNot)
+      .set_attr("infershape", MakeOpFunction(cinn::hlir::op::InferShapeForElementwise))
+      .set_attr("inferdtype", MakeOpFunction(cinn::hlir::op::InferDtypeForLogicalNot))
+      .set_attr("inferlayout", MakeOpFunction(cinn::hlir::op::InferLayoutForElementwise))
+      .set_attr<cinn::hlir::framework::OpPatternKind>("OpPattern", cinn::hlir::framework::OpPatternKind::kElementWise)
+      .set_support_level(4);
 
   return true;
 }

--- a/cinn/hlir/pe/broadcast.cc
+++ b/cinn/hlir/pe/broadcast.cc
@@ -256,9 +256,11 @@ HLIR_IMP_BC_PE(Minimum, return ir::Min::Make(a, b););
 HLIR_IMP_BC_PE(LeftShift, return a << b;);
 HLIR_IMP_BC_PE(RightShift, return a >> b;);
 HLIR_IMP_BC_PE(LogicalRightShift, return lang::LogicalRightShift(a, b););
-HLIR_IMP_BC_PE(LogicalAnd, return a && b;);
-HLIR_IMP_BC_PE(LogicalOr, return a || b;);
-HLIR_IMP_BC_PE(LogicalXOr, return (a || b) && !(a && b););
+HLIR_IMP_BC_PE(LogicalAnd, return ir::Cast::Make(Bool(), a) && ir::Cast::Make(Bool(), b););
+HLIR_IMP_BC_PE(LogicalOr, return ir::Cast::Make(Bool(), a) || ir::Cast::Make(Bool(), b););
+HLIR_IMP_BC_PE(LogicalXOr,
+               return (ir::Cast::Make(Bool(), a) || ir::Cast::Make(Bool(), b)) &&
+                      !(ir::Cast::Make(Bool(), a) && ir::Cast::Make(Bool(), b)););
 HLIR_IMP_BC_PE(BitwiseAnd, return a & b;);
 HLIR_IMP_BC_PE(BitwiseOr, return a | b;);
 HLIR_IMP_BC_PE(BitwiseXor, return a ^ b;);


### PR DESCRIPTION
1. 如题，为`logical and/or/xor/not`添加全类型数据支持，已对齐Paddle
2. 关联的单测PR有：#1396、#1397、#1398