### PR TITLE
Schedule error

### DIFF
--- a/cinn/ir/CMakeLists.txt
+++ b/cinn/ir/CMakeLists.txt
@@ -7,6 +7,7 @@ gather_srcs(cinnapi_src SRCS
     ir_base.cc
     ir_schedule.cc
     ir_schedule_util.cc
+    ir_schedule_error.cc
     ir_visitor.cc
     ir_printer.cc
     ir_mutator.cc

--- a/cinn/ir/ir_schedule.h
+++ b/cinn/ir/ir_schedule.h
@@ -22,6 +22,7 @@
 #include "cinn/ir/ir.h"
 #include "cinn/ir/ir_base.h"
 #include "cinn/ir/ir_mutator.h"
+#include "cinn/ir/ir_schedule_error.h"
 #include "cinn/ir/schedule_desc.h"
 #include "cinn/ir/tensor.h"
 #include "cinn/utils/random_engine.h"
@@ -67,7 +68,8 @@ class IRSchedule {
   IRSchedule();
   explicit IRSchedule(const ModuleExpr& modexpr,
                       utils::LinearRandomEngine::StateType rand_seed = -1,
-                      bool debug_flag                                = false);
+                      bool debug_flag                                = false,
+                      ScheduleErrorMessageLevel err_msg_level        = ScheduleErrorMessageLevel::kBlank);
   IRSchedule(ir::ModuleExpr&& mod_expr, ScheduleDesc&& trace, utils::LinearRandomEngine::StateType rand_seed = -1);
   IRSchedule(const IRSchedule& other);
   IRSchedule& operator=(const IRSchedule& src);

--- a/cinn/ir/ir_schedule_error.cc
+++ b/cinn/ir/ir_schedule_error.cc
@@ -17,11 +17,11 @@
 namespace cinn {
 namespace ir {
 
-std::string IRScheduleErrorHandler::FormatErrorMessage(const std::string &primitive) {
+std::string IRScheduleErrorHandler::FormatErrorMessage(const std::string &primitive) const {
   std::ostringstream os;
   std::string err_msg = DetailedErrorMessage();
 
-  os << "[IRScheduleError] An error occurred in the schedue primitive <" << primitive << ">. " << std::endl;
+  os << "[IRScheduleError] An error occurred in the scheduel primitive <" << primitive << ">. " << std::endl;
   os << "Error info: " << err_msg;
   return os.str();
 }

--- a/cinn/ir/ir_schedule_error.cc
+++ b/cinn/ir/ir_schedule_error.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cinn/ir/ir_schedule_error.h"
+
+namespace cinn {
+namespace ir {
+
+std::string IRScheduleErrorHandler::FormatErrorMessage(const std::string &primitive) {
+  std::ostringstream os;
+  std::string err_msg = DetailedErrorMessage();
+
+  os << "[IRScheduleError] An error occurred in the schedue primitive <" << primitive << ">. " << std::endl;
+  os << "Error info: " << err_msg;
+  return os.str();
+}
+
+}  // namespace ir
+}  // namespace cinn

--- a/cinn/ir/ir_schedule_error.h
+++ b/cinn/ir/ir_schedule_error.h
@@ -36,7 +36,7 @@ enum class ScheduleErrorMessageLevel : int32_t {
 };
 
 /**
- * This handler is to deal with the errors happens in in the current Scheduling.
+ * This handler is dealing with the errors happen in in the current Scheduling.
  */
 class IRScheduleErrorHandler : public std::runtime_error {
  public:
@@ -50,17 +50,17 @@ class IRScheduleErrorHandler : public std::runtime_error {
   /**
    * \brief Returns a detailed error message corresponding to the kDetailed error level.
    */
-  std::string FormatErrorMessage(const std::string &primitive);
-
-  /**
-   * \brief Returns a detailed error message corresponding to the kDetailed error level.
-   */
-  virtual std::string DetailedErrorMessage() const = 0;
+  std::string FormatErrorMessage(const std::string &primitive) const;
 
   /**
    * \brief Returns a short error message corresponding to the kGeneral error level.
    */
   virtual std::string GeneralErrorMessage() const = 0;
+
+  /**
+   * \brief Returns a detailed error message corresponding to the kDetailed error level.
+   */
+  virtual std::string DetailedErrorMessage() const = 0;
 };
 
 }  // namespace ir

--- a/cinn/ir/ir_schedule_error.h
+++ b/cinn/ir/ir_schedule_error.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace cinn {
+namespace ir {
+
+/**
+ *  \brief Indicates the level of printing error message in the current Schedule
+ */
+enum class ScheduleErrorMessageLevel : int32_t {
+  /** \brief No error message*/
+  kBlank = 0,
+  /** \brief  Print an error message in short mode*/
+  kGenearl = 1,
+  /** \brief Print an error message in detailed mode*/
+  kDetailed = 2,
+};
+
+/**
+ * This handler is to deal with the errors happens in in the current Scheduling.
+ */
+class IRScheduleErrorHandler : public std::runtime_error {
+ public:
+  IRScheduleErrorHandler() : std::runtime_error("") {}
+  /**
+   * \brief constructor
+   * \param s the error message
+   */
+  explicit IRScheduleErrorHandler(const std::string &s) : std::runtime_error(s) {}
+
+  /**
+   * \brief Returns a detailed error message corresponding to the kDetailed error level.
+   */
+  std::string FormatErrorMessage(const std::string &primitive);
+
+  /**
+   * \brief Returns a detailed error message corresponding to the kDetailed error level.
+   */
+  virtual std::string DetailedErrorMessage() const = 0;
+
+  /**
+   * \brief Returns a short error message corresponding to the kGeneral error level.
+   */
+  virtual std::string GeneralErrorMessage() const = 0;
+};
+
+}  // namespace ir
+}  // namespace cinn


### PR DESCRIPTION
**新增`Schedule`报错处理机制**

- 新增异常处理数据结构。不同`schedule primitive`通过继承基类`IRScheduleErrorHandler`，完成不同的报错信息打印
- 分层级打印报错信息。通过向`ScheduleImpl`中新增`ScheduleErrorMessageLevel`，决定后续出现错误时的报错打印层级
- 使用宏简化代码
- 该PR以`Split`为例，展示如何在代码中使用新的报错处理机制
- 后续对于报错信息的打印格式，还需要继续优化，与Paddle主框架保持一致